### PR TITLE
Parser: Support args with "reserved word" names

### DIFF
--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -41,6 +41,7 @@ StringValue         = "{StringCharacter}*"
 % Boolean Value
 BooleanValue        = true|false
 
+
 % Reserved words
 ReservedWord        = query|mutation|fragment|on|implements|interface|union|scalar|enum|input|extend|null
 

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -102,7 +102,20 @@ Alias -> Name ':' : '$1'.
 Arguments -> '(' ArgumentList ')' : '$2'.
 ArgumentList -> Argument : ['$1'].
 ArgumentList -> Argument ArgumentList : ['$1'|'$2'].
-Argument -> Name ':' Value : build_ast_node('Argument', #{name => extract_binary('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'name' ':' Value : build_ast_node('Argument', #{name => extract_binary('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'query' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'mutation' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'fragment' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'type' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'implements' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'union' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'scalar' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'enum' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'input' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'extend' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'null' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'on' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
+Argument -> 'interface' ':' Value : build_ast_node('Argument', #{name => extract_keyword('$1'), value => '$3'}, #{'start_line' => extract_line('$1')}).
 
 Directives -> Directive : ['$1'].
 Directives -> Directive Directives : ['$1'|'$2'].

--- a/test/lib/absinthe/parser_test.exs
+++ b/test/lib/absinthe/parser_test.exs
@@ -1,0 +1,25 @@
+defmodule Absinthe.ParserTest do
+  use ExSpec, async: true
+
+  it "parses a simple query" do
+    assert {:ok, _} = Absinthe.parse("{ user(id: 2) { name } }")
+  end
+
+  it "fails gracefully" do
+    assert {:error, _} = Absinthe.parse("{ user(id: 2 { name } }")
+  end
+
+  @reserved ~w(query mutation fragment on implements interface union scalar enum input extend null)
+  it "can parse queries with arguments that are 'reserved words'" do
+    @reserved
+    |> Enum.each(fn
+      arg ->
+        assert {:ok, _} = Absinthe.parse("""
+          mutation CreateThing($blah: Int!) {
+            createThing(#{arg}: $blah) { clientThingId }
+          }
+          """)
+    end)
+  end
+
+end


### PR DESCRIPTION
Argument names are unambiguously argument names, and there's nothing in
the GraphQL specification that would disallow, eg, `input` as an
argument name.

Resolves #62.