### PR TITLE
Fix Absinthe.Type.valid_input?/2 catch-all

### DIFF
--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -204,7 +204,7 @@ defmodule Absinthe.Type do
       :error -> false
     end
   end
-  def valid_input?(_) do
+  def valid_input?(_, _) do
     true
   end
 


### PR DESCRIPTION
Had the incorrect arity.

Supports continued work on #62.