### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://secure.travis-ci.org/absinthe-graphql/absinthe.svg?branch=master
 "Build Status")](https://travis-ci.org/absinthe-graphql/absinthe)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/absinthe-graphql/absinthe.svg)](https://beta.hexfaktor.org/github/absinthe-graphql/absinthe)
 
 Goals:
 


### PR DESCRIPTION
Hi there,

I saw your post on my site elixirstatus.com about Absinthe and wondered if you would like to help me test a new proejct of mine: [HexFaktor](http://beta.hexfaktor.org). 

It is a service to monitor your Hex dependencies and I wanted to propose the new deps badge to be added to this project.

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/absinthe-graphql/absinthe.svg)](https://beta.hexfaktor.org/github/absinthe-graphql/absinthe)

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

I basically want to invite you to join the beta to test-drive this, as I really believe that we can create a great service for the community with this.

All that said, don't feel any "obligation" to accept the PR if you don't like it. You can't hurt my feelings by voicing your honest opinion about this idea/project. Let me know what you think!