### PR TITLE
Macro extensibility

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -111,9 +111,9 @@ defmodule Absinthe.Schema do
   alias Absinthe.Language
   alias __MODULE__
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts \\ []) do
     quote do
-      use Absinthe.Schema.Notation
+      use Absinthe.Schema.Notation, unquote(opts)
       import unquote(__MODULE__), only: :macros
       import_types Absinthe.Type.BuiltIns
       @after_compile unquote(__MODULE__)

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1119,6 +1119,9 @@ defmodule Absinthe.Schema.Notation do
   @doc false
   # Ensure the provided operation can be recorded in the current environment,
   # in the current scope context
+  def recordable!(env, usage) do
+    recordable!(env, usage, Keyword.get(@placement, usage, []))
+  end
   def recordable!(env, usage, kw_rules, opts \\ []) do
     do_recordable!(env, usage, Enum.into(List.wrap(kw_rules), %{}), opts)
   end
@@ -1154,6 +1157,13 @@ defmodule Absinthe.Schema.Notation do
   end
   defp do_recordable!(env, _, rules, _) when map_size(rules) == 0 do
     env
+  end
+
+  @doc false
+  # Get the placement information for a macro
+  @spec placement(atom) :: Keyword.t
+  def placement(usage) do
+    Keyword.get(@placement, usage, [])
   end
 
   # The error message when a macro can only be used within a certain set of

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -10,9 +10,10 @@ defmodule Absinthe.Schema.Notation do
   alias Absinthe.Type
   alias Absinthe.Schema.Notation.Scope
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts \\ []) do
+    import_opts = opts |> Keyword.put(:only, :macros)
     quote do
-      import unquote(__MODULE__), only: :macros
+      import unquote(__MODULE__), unquote(import_opts)
       Module.register_attribute __MODULE__, :absinthe_definitions, accumulate: true
       Module.register_attribute(__MODULE__, :absinthe_descriptions, accumulate: true)
       @before_compile unquote(__MODULE__).Writer

--- a/lib/absinthe/schema/notation/writer.ex
+++ b/lib/absinthe/schema/notation/writer.ex
@@ -129,13 +129,9 @@ defmodule Absinthe.Schema.Notation.Writer do
   end
 
   defp update_description(definition, descriptions) do
-    if definition.attrs[:description] do
-      definition
-    else
-      case Map.get(descriptions, definition.identifier) do
-        nil -> definition
-        desc -> Map.update!(definition, :attrs, &Keyword.put(&1, :description, desc))
-      end
+    case Map.get(descriptions, definition.identifier) do
+      nil -> definition
+      desc -> Map.update!(definition, :attrs, &Keyword.put(&1, :description, desc))
     end
   end
 


### PR DESCRIPTION
Additional changes to support [Absinthe.Relay](https://github.com/absinthe-graphql/absinthe_relay)'s extension of notation macros -- and later extension by other external packages.