### PR TITLE
Allows for List of Lists (of Lists of... Whatever)

### DIFF
--- a/lib/absinthe/execution/resolution/list.ex
+++ b/lib/absinthe/execution/resolution/list.ex
@@ -2,6 +2,10 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.List do
 
   alias Absinthe.Execution.Resolution
 
+  def resolve(%{of_type: %{of_type: _} = wrapped_type}, execution) do
+    # That's a list of list, we unwrap and pass it while keeping the selection_set
+    do_resolve(wrapped_type, wrapped_type, execution)
+  end
   def resolve(%{of_type: wrapped_type}, %{resolution: %{ast_node: %{selection_set: nil}}} = execution) do
     # There's no selection set, do inner resolution on the wrapped type
     do_resolve(wrapped_type, wrapped_type, execution)
@@ -15,7 +19,7 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.List do
     {values_to_return, execution_to_return} = Enum.reduce(target, {[], execution}, fn
 
       (value_to_resolve, {values_before, current_execution}) ->
-        this_resolution = %Resolution{type: wrapped_type, target: value_to_resolve}
+        this_resolution = %Resolution{type: wrapped_type, target: value_to_resolve, ast_node: execution.resolution.ast_node}
 
         {:ok, result, next_execution} = Resolution.resolve(inner_to_resolve,
           %{current_execution | resolution: this_resolution}

--- a/test/lib/absinthe/execution/list_test.exs
+++ b/test/lib/absinthe/execution/list_test.exs
@@ -31,6 +31,23 @@ defmodule Absinthe.Execution.ListTest.Schema do
       resolve fn _, _ -> {:ok, [[1, 2, 3], [4, 5, 6]]} end
     end
 
+    field :big_nesting_of_numbers, list_of(list_of(list_of(list_of(:integer)))) do
+      resolve fn _, _ ->
+        list = [[
+          [
+            [1, 2, 3], [4, 5, 6]
+          ],
+          [
+            [7, 8, 9]
+          ],
+          [
+            [10, 11, 12]
+          ]
+        ]]
+        {:ok, list}
+      end
+    end
+
     field :list_of_list_of_books, list_of(list_of(:book)) do
       resolve fn _, _ ->
         books = [[
@@ -102,6 +119,27 @@ defmodule Absinthe.Execution.ListTest do
   """
   it "should resolve list of list of numbers" do
     assert {:ok, %{data: %{"listOfListOfNumbers" => [[1,2,3],[4,5,6]]}}} ==
+      Absinthe.run(@query, __MODULE__.Schema)
+  end
+
+  @query """
+  {
+    bigNestingOfNumbers
+  }
+  """
+  it "should resolve list of lists of... numbers with a depth of 4" do
+    list = [[
+      [
+        [1, 2, 3], [4, 5, 6]
+      ],
+      [
+        [7, 8, 9]
+      ],
+      [
+        [10, 11, 12]
+      ]
+    ]]
+    assert {:ok, %{data: %{"bigNestingOfNumbers" => list}}} ==
       Absinthe.run(@query, __MODULE__.Schema)
   end
 

--- a/test/lib/absinthe/execution/list_test.exs
+++ b/test/lib/absinthe/execution/list_test.exs
@@ -5,6 +5,10 @@ defmodule Absinthe.Execution.ListTest.Schema do
     field :categories, list_of(:string)
   end
 
+  object :book do
+    field :name, :string
+  end
+
   query do
     field :numbers, list_of(:integer), resolve: fn _, _ -> {:ok, [1,2,3]} end
     field :categories, list_of(:string) do
@@ -19,6 +23,34 @@ defmodule Absinthe.Execution.ListTest.Schema do
           %{categories: ["foo", "bar"]},
           %{categories: ["baz", "buz"]},
         ]
+        {:ok, items}
+      end
+    end
+
+    field :list_of_list_of_numbers, list_of(list_of(:integer)) do
+      resolve fn _, _ -> {:ok, [[1, 2, 3], [4, 5, 6]]} end
+    end
+
+    field :list_of_list_of_books, list_of(list_of(:book)) do
+      resolve fn _, _ ->
+        books = [[
+          %{name: "foo"},
+          %{name: "bar"},
+        ], [
+          %{name: "baz"},
+        ]]
+        {:ok, books}
+      end
+    end
+
+    field :list_of_list_of_items, list_of(list_of(:item)) do
+      resolve fn _, _ ->
+        items = [[
+          %{categories: ["foo", "bar"]},
+          %{categories: ["baz", "buz"]},
+        ], [
+          %{categories: ["blip", "blop"]},
+        ]]
         {:ok, items}
       end
     end
@@ -63,5 +95,50 @@ defmodule Absinthe.Execution.ListTest do
       Absinthe.run(@query, __MODULE__.Schema)
   end
 
+  @query """
+  {
+    listOfListOfNumbers
+  }
+  """
+  it "should resolve list of list of numbers" do
+    assert {:ok, %{data: %{"listOfListOfNumbers" => [[1,2,3],[4,5,6]]}}} ==
+      Absinthe.run(@query, __MODULE__.Schema)
+  end
+
+  @query """
+  {
+    listOfListOfBooks {
+      name
+    }
+  }
+  """
+  it "should resolve list of list of books" do
+    books = [[
+      %{"name" => "foo"},
+      %{"name" => "bar"},
+    ], [
+      %{"name" => "baz"},
+    ]]
+    assert {:ok, %{data: %{"listOfListOfBooks" => books}}} ==
+      Absinthe.run(@query, __MODULE__.Schema)
+  end
+
+  @query """
+  {
+    listOfListOfItems {
+      categories
+    }
+  }
+  """
+  it "should resolve list of list of items" do
+    items = [[
+      %{"categories" => ["foo", "bar"]},
+      %{"categories" => ["baz", "buz"]},
+    ], [
+      %{"categories" => ["blip", "blop"]},
+    ]]
+    assert {:ok, %{data: %{"listOfListOfItems" => items}}} ==
+      Absinthe.run(@query, __MODULE__.Schema)
+  end
 
 end


### PR DESCRIPTION
This allows the use of List of Lists, like:

```
query do:
    field :list_of_list_of_numbers, list_of(list_of(:integer)) do
      resolve fn _, _ -> {:ok, [[1, 2, 3], [4, 5, 6]]} end
    end
end
```

That example uses scalars but it's also working for list of lists of objects, as you can see in the specs.

I'm new to Elixir and Absinthe, so I hope I'm not breaking anything (especially by keeping the `ast_node` in the new `Resolution`).
I added some specs and the whole suite still passes.