### PR TITLE
Compile-time extensibility support for Field and Object

### DIFF
--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -77,6 +77,10 @@ defmodule Absinthe.Adapter do
         %{node |
           selection_set: load_ast_node(node.selection_set)}
       end
+      defp load_ast_node(%Language.InlineFragment{} = node) do
+        %{node |
+          selection_set: load_ast_node(node.selection_set)}
+      end
       defp load_ast_node(%Language.SelectionSet{} = node) do
         %{node |
           selections: node.selections |> Enum.map(&load_ast_node/1)}

--- a/lib/absinthe/execution/resolution/field.ex
+++ b/lib/absinthe/execution/resolution/field.ex
@@ -20,11 +20,10 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
             nil
         end
         |> result(ast_node, field, execution)
-
-      %{resolve: resolver} ->
+      %{resolve: _} ->
         case Execution.Arguments.build(ast_node, field.args, execution) do
           {:ok, args, exe} ->
-            resolver.(args, environment(field, ast_node, execution))
+            Type.Field.resolve(field, args, field_info(field, ast_node, execution))
             |> process_raw_result(ast_node, field, exe)
           {:error, missing, invalid, exe} ->
             exe
@@ -65,8 +64,8 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
 
   # Build a `Absinthe.Execution.Field` struct containing the resolution environment
   # of the field
-  @spec environment(Type.Field.t, Language.t, Execution.t) :: Execution.Field.t
-  defp environment(field, ast_node, execution) do
+  @spec field_info(Type.Field.t, Language.t, Execution.t) :: Execution.Field.t
+  defp field_info(field, ast_node, execution) do
     %Execution.Field{
       adapter: execution.adapter,
       ast_node: ast_node,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -545,6 +545,29 @@ defmodule Absinthe.Schema.Notation do
     :ok
   end
 
+  @placement {:private, [under: [:field]]}
+  @doc false
+  defmacro private(owner, key, value) do
+    __CALLER__
+    |> recordable!(:private, @placement[:private])
+    |> record_private!(owner, key, value)
+  end
+
+  @doc false
+  # Record a private value
+  def record_private!(env, owner, key, value) do
+    new_private = Scope.current(env.module).attrs
+    |> Keyword.put_new(:__private__, [])
+    |> update_in([Macro.expand(owner, env)], fn
+      nil ->
+        [{key, value}]
+      existing ->
+        Keyword.put(existing, key, value)
+    end)
+    Scope.put_attribute(env.module, :__private__, new_private)
+    :ok
+  end
+
   @placement {:parse, [under: [:scalar]]}
   @doc """
   Defines a parse function for a `scalar` type

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -150,15 +150,9 @@ defmodule Absinthe.Type.Field do
     system_fn.(args, field_info, designer_fn)
   end
 
-  # Get any `:resolve` function registered in the `:__private__` key
-  # (more than one should not be set)
+  # Get the registered resolve helper, if any
   defp system_resolve(private) do
-    private
-    |> Keyword.values
-    |> Enum.find_value(fn
-      settings ->
-        settings[:resolve]
-    end)
+    get_in(private, [Absinthe, :resolve])
   end
 
   defimpl Absinthe.Validation.RequiredInput do

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -90,9 +90,10 @@ defmodule Absinthe.Type.Field do
                default_value: any,
                args: %{(binary | atom) => Absinthe.Type.Argument.t} | nil,
                resolve: resolver_t | nil,
+               __private__: Keyword.t,
                __reference__: Type.Reference.t}
 
-  defstruct name: nil, description: nil, type: nil, deprecation: nil, args: %{}, resolve: nil, default_value: nil, __reference__: nil
+  defstruct name: nil, description: nil, type: nil, deprecation: nil, args: %{}, resolve: nil, default_value: nil, __private__: [], __reference__: nil
 
   @doc """
   Build an AST of the field map for inclusion in other types
@@ -133,6 +134,31 @@ defmodule Absinthe.Type.Field do
       false ->
         Keyword.put(arg_attrs, :__reference__, default_reference)
     end
+  end
+
+  def resolve(%{resolve: designer_resolve, __private__: private}, args, field_info) do
+    do_resolve(system_resolve(private), designer_resolve, args, field_info)
+  end
+
+  # No system resolver, so just invoke the schema designer's resolver
+  defp do_resolve(nil, designer_fn, args, field_info) do
+    designer_fn.(args, field_info)
+  end
+  # If a system resolver is set, we resolve by passing it the schema designer
+  # resolver; it's responsible for returning the result.
+  defp do_resolve(system_fn, designer_fn, args, field_info) do
+    system_fn.(args, field_info, designer_fn)
+  end
+
+  # Get any `:resolve` function registered in the `:__private__` key
+  # (more than one should not be set)
+  defp system_resolve(private) do
+    private
+    |> Keyword.values
+    |> Enum.find_value(fn
+      settings ->
+        settings[:resolve]
+    end)
   end
 
   defimpl Absinthe.Validation.RequiredInput do

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -82,10 +82,10 @@ defmodule Absinthe.Type.Object do
   * `:interfaces` - A list of interfaces that this type guarantees to implement. See `Absinthe.Type.Interface`.
   * `:is_type_of` - A function used to identify whether a resolved object belongs to this defined type. For use with `:interfaces` entry and `Absinthe.Type.Interface`.
 
-  The `:__reference__` key is for internal use.
+  The `:__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{name: binary, description: binary, fields: map, interfaces: [Absinthe.Type.Interface.t], is_type_of: ((any) -> boolean), __reference__: Type.Reference.t}
-  defstruct name: nil, description: nil, fields: nil, interfaces: [], is_type_of: nil, __reference__: nil
+  @type t :: %{name: binary, description: binary, fields: map, interfaces: [Absinthe.Type.Interface.t], is_type_of: ((any) -> boolean), __private__: Keyword.t, __reference__: Type.Reference.t}
+  defstruct name: nil, description: nil, fields: nil, interfaces: [], is_type_of: nil, __private__: [], __reference__: nil
 
   def build(%{attrs: attrs}) do
     fields = Type.Field.build(attrs[:fields] || [])

--- a/test/lib/absinthe/adapters/language_conventions_test.exs
+++ b/test/lib/absinthe/adapters/language_conventions_test.exs
@@ -192,6 +192,36 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
     assert {:ok, %{data: %{"fieldTrip" => %{"name" => "Museum"}}, errors: [%{message: "Field `badField': Not present in schema", locations: [%{line: 4, column: 0}]}]}} == run(query)
   end
 
+  it "transforms a simple query document" do
+    doc = transform """
+    {
+      person {
+        firstName
+      }
+    }
+    """
+    assert %{definitions: [%{selection_set: %{selections: [%{selection_set: %{selections: [%{name: "first_name"}]}}]}}]} = doc
+  end
+
+  it "transforms a query document with an inline fragment" do
+    doc = transform """
+    {
+      person {
+       ... on Foo {
+         firstName
+       }
+      }
+    }
+    """
+    assert %{definitions: [%{selection_set: %{selections: [%{selection_set: %{selections: [%{selection_set: %{selections: [%{name: "first_name"}]}}]}}]}}]} = doc
+  end
+
+  defp transform(query) do
+    {:ok, doc} = Absinthe.parse(query)
+    doc
+    |> Absinthe.Adapter.LanguageConventions.load_document
+  end
+
   defp run(query_document) do
     run(query_document, %{})
   end


### PR DESCRIPTION
- Add a namespaced `__private__` key for both `Type.Field` and `Type.Object` for extensibility
- Support resolution wrapping: Passing any field resolver defined by the schema designer to a extension-defined resolver registered at the field's `[:__private__, Absinthe, :resolve]` (this allows extensions to handle pre-processing arguments passed to a resolver and post-processing any result). Later we may turn this into a more middleware like stack.
- Support a new placement rule for `Notation` macros -- `:lookup_private`, which can be used by extensions to ensure a macro defining an ancestor scope has set a certain value.
- Fix Adapter issues relating to InlineFragment traversal