### PR TITLE
Refactor selection set logic to handle fragment merges

### DIFF
--- a/lib/absinthe/execution/directives.ex
+++ b/lib/absinthe/execution/directives.ex
@@ -29,8 +29,8 @@ defmodule Absinthe.Execution.Directives do
     end)
     |> reduce_results
   end
-  def check(_, _) do
-    :ok
+  def check(execution, _) do
+    {:ok, execution}
   end
 
   @precedence [:include, :skip]

--- a/lib/absinthe/execution/resolution/selection_set.ex
+++ b/lib/absinthe/execution/resolution/selection_set.ex
@@ -10,82 +10,47 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.SelectionSet do
                 Execution.t) :: {:ok, map} | {:error, any}
   def resolve(%{selections: selections}, %{resolution: %{type: type, target: target}, strategy: :serial} = execution) do
     parent_type = Schema.lookup_type(execution.schema, type)
-    {result, execution_to_return} = selections
-    |> Enum.reduce(%{}, fn
-      selection, acc ->
-        case flatten(selection, execution) do
-          %{} = result ->
-            Map.merge(acc, %{parent_type => result}, fn
-              _, val1, val2 ->
-                Map.merge(val1, val2)
-            end)
-          {concrete_parent_type, result} ->
-            Map.merge(acc, %{concrete_parent_type => result}, fn
-              _, val1, val2 ->
-                Map.merge(val1, val2)
-            end)
+    {flattened, exe} = flatten(selections, parent_type, execution)
+    {result, execution_to_return} = Enum.reduce(flattened, {%{}, exe}, fn
+      {field_parent_type, {name, ast_node}}, {values, field_exe} ->
+        field_resolution = %Resolution{parent_type: field_parent_type, target: target}
+        case resolve_field(ast_node, %{field_exe | resolution: field_resolution}) do
+          {:ok, value, changed_execution} ->
+            {values |> Map.put(name, value), changed_execution}
+          {:skip, changed_execution} ->
+            {values, changed_execution}
         end
-    end)
-    |> Enum.reduce({%{}, execution}, fn ({field_parent_type, fields}, type_acc) ->
-      Enum.reduce(fields, type_acc, fn
-        {name, ast_node}, {acc, exe}  ->
-          field_resolution = %Resolution{parent_type: field_parent_type, target: target}
-          case resolve_field(ast_node, %{exe | resolution: field_resolution}) do
-            {:ok, value, changed_execution} ->
-              {acc |> Map.put(name, value), changed_execution}
-            {:skip, changed_execution} ->
-              {acc, changed_execution}
-          end
-      end)
     end)
     {:ok, result, execution_to_return}
   end
 
-  @spec flatten(Language.t, Execution.t) :: %{binary => Language.t}
-  defp flatten(%Language.Field{alias: alias, name: name} = ast_node, _execution) do
+  defp flatten(items, type, execution) when is_list(items) do
+    Enum.flat_map_reduce(items, execution, &flatten(&1, type, &2))
+  end
+  defp flatten(%Language.Field{alias: alias, name: name} = ast_node, type, execution) do
     alias_or_name = alias || name
-    %{alias_or_name => ast_node}
+    {[{type, {alias_or_name, ast_node}}], execution}
   end
-
-  defp flatten(%Language.FragmentSpread{} = ast_node, execution) do
+  defp flatten(%Language.FragmentSpread{} = ast_node, default_type, execution) do
     case Absinthe.Execution.Directives.check(execution, ast_node) do
-      {:skip, _} ->
-        %{}
+      {:skip, exe} ->
+        {[], exe}
       {flag, exe} when flag in [:ok, :include] ->
-        exe.fragments[ast_node.name]
-        |> flatten_fragment(execution)
+        type = type_for_fragment(ast_node, execution) || default_type
+        flatten(exe.fragments[ast_node.name], type, execution)
     end
   end
-  defp flatten(%Language.InlineFragment{} = ast_node, execution) do
+  defp flatten(%{__struct__: str} = ast_node, type, execution) when str in [Language.InlineFragment, Language.Fragment] do
     case Absinthe.Execution.Directives.check(execution, ast_node) do
       {:skip, _} ->
-        %{}
+        {[], execution}
       {flag, _exe} when flag in [:ok, :include] ->
-        flatten_fragment(ast_node, execution)
+        flatten(ast_node.selection_set.selections, type, execution)
     end
   end
-
   # For missing fragments
-  defp flatten(nil = _ast_node, _execution) do
-    %{}
-  end
-
-  defp flatten_fragment(fragment, execution) do
-    case type_for_fragment(fragment, execution) do
-      nil ->
-        %{}
-      type ->
-        {type, do_flatten_fragment(fragment, execution)}
-    end
-  end
-  defp do_flatten_fragment(fragment, execution) do
-    fragment.selection_set.selections
-    |> Enum.reduce(%{}, fn (selection, acc) ->
-      flatten(selection, execution)
-      |> Enum.reduce(acc, fn ({_name, selection}, acc_for_selection) ->
-        merge_into_result(acc_for_selection, selection, execution)
-      end)
-    end)
+  defp flatten(nil, _, execution) do
+    {[], execution}
   end
 
   @spec type_for_fragment(Language.FragmentSpread.t | Language.InlineFragment.t, Execution.t) :: Type.t | nil
@@ -108,29 +73,8 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.SelectionSet do
         end
     end
   end
-
-  @spec merge_into_result(map, Language.t, Execution.t) :: map
-  defp merge_into_result(acc, %{alias: alias} = selection, execution) when not is_nil(alias) do
-    acc
-    |> do_merge_into_result(%{alias => selection}, execution)
-  end
-  defp merge_into_result(acc, %{name: name} = selection, execution) do
-    acc
-    |> do_merge_into_result(%{name => selection}, execution)
-  end
-
-  defp do_merge_into_result(acc, change, execution) do
-    acc
-    |> Map.merge(change, fn (_name, field1, field2) ->
-      merge_fields(field1, field2, execution)
-    end)
-  end
-
-  @spec merge_fields(Language.t, Language.t, Execution.t) :: Language.t
-  defp merge_fields(_field1, field2, %{schema: _schema}) do
-    # TODO: Merge fields into a new Language.Field.t if the field_type is Object.t
-    # field_type = schema |> Schema.field(resolution.type, field2.name).type |> Type.unwrap
-    field2
+  defp type_for_fragment(_, _) do
+    nil
   end
 
   defp resolve_field(ast_node, execution) do

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -100,6 +100,15 @@ defmodule Absinthe.Type.Interface do
     true
   end
 
+  @doc false
+  @spec member?(t, Type.t) :: boolean
+  def member?(%{__reference__: %{identifier: ident}}, %{interfaces: ifaces}) do
+    ident in ifaces
+  end
+  def member?(_, _) do
+    false
+  end
+
   @spec implements?(Type.Interface.t, Type.Object.t) :: boolean
   def implements?(interface, type) do
     # Convert the submap into a list of key-value pairs where each key

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -39,7 +39,7 @@ defmodule Absinthe.Type.Union do
 
   @type t :: %{name: binary,
                description: binary,
-               types: [Absinthe.Type.t],
+               types: [Type.identifier_t],
                resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
                __reference__: Type.Reference.t}
 
@@ -50,9 +50,12 @@ defmodule Absinthe.Type.Union do
   end
 
   @doc false
-  def member?(%{types: types}, type) do
-    types
-    |> Enum.member?(type)
+  @spec member?(t, Type.t) :: boolean
+  def member?(%{types: types}, %{__reference__: %{identifier: ident}}) do
+    ident in types
+  end
+  def member?(_, _) do
+    false
   end
 
   @doc false

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -175,4 +175,36 @@ defmodule Absinthe.SchemaTest do
 
   end
 
+  defmodule FragmentSpreadSchema do
+    use Absinthe.Schema
+
+    @viewer %{id: "ABCD", name: "Bruce"}
+
+    query do
+      field :viewer, :viewer do
+        resolve fn _, _ -> {:ok, @viewer} end
+      end
+    end
+
+    object :viewer do
+      field :id, :id
+      field :name, :string
+    end
+
+  end
+
+  describe "multiple fragment spreads" do
+
+    @query """
+    query Viewer{viewer{id,...F1}}
+    fragment F0 on Viewer{name,id}
+    fragment F1 on Viewer{id,...F0}
+    """
+
+    it "builds the correct result" do
+      assert {:ok, %{data: %{"viewer" => %{"id" => "ABCD", "name" => "Bruce"}}}} == Absinthe.run(@query, FragmentSpreadSchema)
+    end
+
+  end
+
 end

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -201,6 +201,7 @@ defmodule Absinthe.SchemaTest do
     fragment F1 on Viewer{id,...F0}
     """
 
+    @tag :fragment1
     it "builds the correct result" do
       assert {:ok, %{data: %{"viewer" => %{"id" => "ABCD", "name" => "Bruce"}}}} == Absinthe.run(@query, FragmentSpreadSchema)
     end


### PR DESCRIPTION
I encountered an error when trying to run the following query, generated by Relay:

```graphql
query Viewer{viewer{id,...F1}}
fragment F0 on Viewer{name,id}
fragment F1 on Viewer{id,...F0}
```

This ran afoul of the complicated selection set flattening and merge logic -- which had grown organically to support complex types like unions and interfaces.

This refactors that logic, handling cases like these and at least making things marginally easier to read.
