### PR TITLE
Support parsing and executing a "subscription" root type

### DIFF
--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -43,7 +43,7 @@ BooleanValue        = true|false
 
 
 % Reserved words
-ReservedWord        = query|mutation|fragment|on|implements|interface|union|scalar|enum|input|extend|null
+ReservedWord        = query|mutation|subscription|fragment|on|implements|interface|union|scalar|enum|input|extend|null
 
 Rules.
 

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -16,7 +16,7 @@ Nonterminals
 
 Terminals
   '{' '}' '(' ')' '[' ']' '!' ':' '@' '$' '=' '|' '...'
-  'query' 'mutation' 'fragment' 'on' 'null'
+  'query' 'mutation' 'subscription' 'fragment' 'on' 'null'
   'type' 'implements' 'interface' 'union' 'scalar' 'enum' 'input' 'extend'
   name int_value float_value string_value boolean_value.
 
@@ -33,6 +33,7 @@ Definition -> TypeDefinition : '$1'.
 
 OperationType -> 'query' : extract_atom('$1').
 OperationType -> 'mutation' : extract_atom('$1').
+OperationType -> 'subscription' : extract_atom('$1').
 
 OperationDefinition -> SelectionSet : build_ast_node('OperationDefinition', #{'operation' => 'query', 'selection_set' => '$1'}, #{'start_line' => extract_child_line('$1')}).
 OperationDefinition -> OperationType Name SelectionSet : build_ast_node('OperationDefinition', #{'operation' => '$1', 'name' => extract_binary('$2'), 'selection_set' => '$3'}, #{'start_line' => extract_line('$2')}).
@@ -114,6 +115,7 @@ Directive -> '@' Name Arguments : build_ast_node('Directive', #{name => extract_
 NameWithoutOn -> 'name' : '$1'.
 NameWithoutOn -> 'query' : extract_binary('$1').
 NameWithoutOn -> 'mutation' : extract_binary('$1').
+NameWithoutOn -> 'subscription' : extract_binary('$1').
 NameWithoutOn -> 'fragment' : extract_binary('$1').
 NameWithoutOn -> 'type' : extract_binary('$1').
 NameWithoutOn -> 'implements' : extract_binary('$1').

--- a/test/lib/absinthe/execution/subscription_test.exs
+++ b/test/lib/absinthe/execution/subscription_test.exs
@@ -1,0 +1,31 @@
+defmodule Absinthe.Execution.SubscriptionTest do
+  use ExSpec, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    subscription do
+      field :thing, :string do
+        arg :client_id, non_null(:id)
+        resolve fn
+          %{client_id: id}, _ ->
+            {:ok, "subscribed-#{id}"}
+        end
+      end
+    end
+
+  end
+
+  describe "subscriptions" do
+
+    @query """
+    subscription SubscribeToThing($clientID: ID!) {
+      thing(clientId: $clientId)
+    }
+    """
+    it "can be executed" do
+      assert {:ok, %{data: %{"thing" => "subscribed-abc"}}} == Absinthe.run(@query, Schema, variables: %{"clientId" => "abc"})
+    end
+  end
+
+end

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -144,6 +144,10 @@ defmodule Absinthe.SchemaTest do
       field :name, :string
     end
 
+    subscription name: "SubscriptionRootTypeThing" do
+      field :name, :string
+    end
+
   end
 
 
@@ -157,12 +161,21 @@ defmodule Absinthe.SchemaTest do
       assert "MyRootMutation" == Schema.lookup_type(RootsSchema, :mutation).name
     end
 
+    it "supports subscriptions" do
+      assert "SubscriptionRootTypeThing" == Schema.lookup_type(RootsSchema, :subscription).name
+    end
+
+
   end
 
   describe "fields" do
 
-    it "have the correct structure" do
+    it "have the correct structure in query" do
       assert %Type.Field{name: "name"} = Schema.lookup_type(RootsSchema, :query).fields.name
+    end
+
+    it "have the correct structure in subscription" do
+      assert %Type.Field{name: "name"} = Schema.lookup_type(RootsSchema, :subscription).fields.name
     end
 
   end


### PR DESCRIPTION
Resolves #78 

Note this adds the root type (makes it parseable, executable, etc), but does not extend the API in other ways a full subscription implementation might warrant -- it's too early to do that; since subscriptions aren't in the latest Working Draft release no implementation guidelines have been set. (Notably, for instance, there are no `start` or `stop` extensions as have been recommended, eg, [here](https://kadira.io/blog/graphql/subscriptions-in-graphql).

BUT, you can do whatever you'd like in a resolve function. We'll keep this narrow extension in place until we get clearer guidelines from a specification release.

