### PR TITLE
Keep track of items recorded in the notation scope

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -177,6 +177,7 @@ defmodule Absinthe.Schema.Notation do
   # Record an implemented interface in the current scope
   def record_interface!(env, identifier) do
     Scope.put_attribute(env.module, :interfaces, identifier, accumulate: true)
+    Scope.recorded!(env.module, :attr, :interface)
     :ok
   end
 
@@ -257,6 +258,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a type resolver in the current scope
   def record_resolve_type!(env, func_ast) do
     Scope.put_attribute(env.module, :resolve_type, func_ast)
+    Scope.recorded!(env.module, :attr, :resolve_type)
     :ok
   end
 
@@ -399,6 +401,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a resolver in the current scope
   def record_resolve!(env, func_ast) do
     Scope.put_attribute(env.module, :resolve, func_ast)
+    Scope.recorded!(env.module, :attr, :resolve)
     :ok
   end
 
@@ -420,6 +423,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a type checker in the current scope
   def record_is_type_of!(env, func_ast) do
     Scope.put_attribute(env.module, :is_type_of, func_ast)
+    Scope.recorded!(env.module, :attr, :is_type_of)
     :ok
   end
 
@@ -542,6 +546,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a serialize function in the current scope
   def record_serialize!(env, func_ast) do
     Scope.put_attribute(env.module, :serialize, func_ast)
+    Scope.recorded!(env.module, :attr, :serialize)
     :ok
   end
 
@@ -562,6 +567,7 @@ defmodule Absinthe.Schema.Notation do
     |> update_in([:__private__, owner], &List.wrap(&1))
     |> put_in([:__private__, owner, key], value)
     Scope.put_attribute(env.module, :__private__, new_attrs[:__private__])
+    :ok
   end
 
   @placement {:parse, [under: [:scalar]]}
@@ -588,6 +594,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a parse function in the current scope
   def record_parse!(env, func_ast) do
     Scope.put_attribute(env.module, :parse, func_ast)
+    Scope.recorded!(env.module, :attr, :parse)
     :ok
   end
 
@@ -664,6 +671,8 @@ defmodule Absinthe.Schema.Notation do
           value,
           accumulate: true
         )
+        Scope.recorded!(env.module, :attr, :on)
+
     end)
     :ok
   end
@@ -686,6 +695,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a directive instruction function in the current scope
   def record_instruction!(env, func_ast) do
     Scope.put_attribute(env.module, :instruction, func_ast)
+    Scope.recorded!(env.module, :attr, :instruction)
     :ok
   end
 
@@ -779,6 +789,7 @@ defmodule Absinthe.Schema.Notation do
   # Record a list of member types for a union in the current scope
   def record_types!(env, types) do
     Scope.put_attribute(env.module, :types, List.wrap(types))
+    Scope.recorded!(env.module, :attr, :types)
     :ok
   end
 
@@ -847,6 +858,7 @@ defmodule Absinthe.Schema.Notation do
     |> Keyword.delete(:as)
     |> add_description(env)
     Scope.put_attribute(env.module, :values, {identifier, attrs}, accumulate: true)
+    Scope.recorded!(env.module, :attr, :value)
     :ok
   end
 
@@ -878,6 +890,7 @@ defmodule Absinthe.Schema.Notation do
   def record_description!(env, text_block) do
     text = reformat_description(text_block)
     Scope.put_attribute(env.module, :description, text)
+    Scope.recorded!(env.module, :attr, :description)
     :ok
   end
 
@@ -982,6 +995,7 @@ defmodule Absinthe.Schema.Notation do
     block |> expand(env)
 
     close_scope(kind, env, identifier)
+    Scope.recorded!(env.module, kind, identifier)
   end
 
   defp expand(ast, env) do

--- a/lib/absinthe/schema/notation/scope.ex
+++ b/lib/absinthe/schema/notation/scope.ex
@@ -4,7 +4,7 @@ defmodule Absinthe.Schema.Notation.Scope do
 
   @stack :absinthe_notation_scopes
 
-  defstruct name: nil, attrs: []
+  defstruct name: nil, recordings: [], attrs: []
 
   use Absinthe.Type.Fetch
 
@@ -30,6 +30,59 @@ defmodule Absinthe.Schema.Notation.Scope do
   def current(mod) do
     {c, _} = split(mod)
     c
+  end
+
+  def recorded!(mod, kind, identifier) do
+    update_current(mod, fn
+      %{recordings: recs} = scope ->
+        %{scope | recordings: [{kind, identifier} | recs]}
+      nil ->
+        # Outside any scopes, ignore
+        nil
+    end)
+  end
+
+  @doc """
+  Check if a certain operation has been recorded in the current scope.
+
+  ## Examples
+
+  See if an input object with the identifier `:input` has been defined from
+  this scope:
+
+  ```
+  recorded?(mod, :input_object, :input)
+  ```
+
+  See if the `:description` attribute has been
+
+  ```
+  recorded?(mod, :attr, :description)
+  ```
+  """
+  @spec recorded?(atom, atom, atom) :: boolean
+  def recorded?(mod, kind, identifier) do
+    scope = current(mod)
+    case kind do
+      :attr ->
+        # Supports attributes passed directly to the macro that
+        # created the scope, usually (?) short-circuits the need to
+        # check the scope recordings.
+        scope.attrs[identifier] || recording_marked?(scope, kind, identifier)
+      _ ->
+        recording_marked?(scope, kind, identifier)
+    end
+  end
+
+  # Check the list of recordings for `recorded?/3`
+  defp recording_marked?(scope, kind, identifier) do
+    scope.recordings
+    |> Enum.find(fn
+      {^kind, ^identifier} ->
+        true
+      _ ->
+        false
+    end)
   end
 
   def put_attribute(mod, key, value, opts \\ [accumulate: false]) do


### PR DESCRIPTION
This PR adds a facility to the schema notation scope that's used to track basic metadata of items recorded into the scope -- and a facility to check whether something was recorded.

These can be used in concert in extensions to the notation to, eg, apply defaults if necessary.