### PR TITLE
Custom default resolvers

### DIFF
--- a/lib/absinthe/execution/resolution/field.ex
+++ b/lib/absinthe/execution/resolution/field.ex
@@ -9,21 +9,9 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
 
   @spec resolve(Absinthe.Language.Field.t,
                 Absinthe.Execution.t) :: {:ok, map} | {:error, any}
-  def resolve(%{name: name} = ast_node, %{strategy: :serial, resolution: %{parent_type: parent_type, target: target}} = execution) do
+  def resolve(%{name: name} = ast_node, %{strategy: :serial, resolution: %{parent_type: parent_type}} = execution) do
     field = find_field(ast_node, execution)
     case field do
-      %{resolve: nil} ->
-        case target do
-          %{} ->
-            try do
-              target |> Map.get(name |> String.to_existing_atom)
-            rescue
-              ArgumentError -> nil
-            end
-          _ ->
-            nil
-        end
-        |> result(ast_node, field, execution)
       %{resolve: _} ->
         case Execution.Arguments.build(ast_node, field.args, execution) do
           {:ok, args, exe} ->
@@ -35,7 +23,6 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
             |> skip_as(:invalid, invalid, name, ast_node)
             |> Flag.as(:skip)
         end
-
       nil ->
         if Introspection.type?(parent_type) do
           {:skip, execution}

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -125,14 +125,10 @@ defmodule Absinthe.Schema do
 
   ```
   default_resolve fn
-    _, %{source: source, definition: %{name: name}} ->
-      case source do
-        # Only from sources that are maps
-        %{} ->
-          {:ok, Map.get(source, String.upcase(name))}
-        _ ->
-          {:ok, nil}
-      end
+    _, %{source: source, definition: %{name: name}} when is_map(source) ->
+      {:ok, Map.get(source, String.upcase(name))}
+    _, _ ->
+      {:ok, nil}
   end
   ```
 

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -100,6 +100,42 @@ defmodule Absinthe.Schema do
 
   end
   ```
+
+  ## Default Resolver
+
+  By default, if a `resolve` function is not provided for a field, Absinthe
+  will attempt to extract the value of the field by calling
+  `Absinthe.Type.Field.default_resolve/2`, which uses `Map.get/2` to get a value
+  using the (atom) name of the field.
+
+  You can change this behavior by setting your own default resolve function in
+  your schema. For example, given we have a fields with a definitions like this:
+
+  ```
+  field :name, :string
+  ```
+
+  And we're trying to extract values from a horrible backend API that gives us
+  maps with uppercase (!) string keys:
+
+  ```
+  %{"NAME" => "A name"}
+  ```
+
+  Here's how we could set our custom resolver to expect those keys:
+
+  ```
+  default_resolve fn
+    _, %{source: source, definition: %{name: name}} ->
+      case source do
+        # Only from sources that are maps
+        %{} ->
+          {:ok, Map.get(source, String.upcase(name))}
+        _ ->
+          {:ok, nil}
+      end
+  end
+  ```
   """
 
   @typedoc """
@@ -183,6 +219,14 @@ defmodule Absinthe.Schema do
   """
   defmacro subscription([do: block]) do
     Absinthe.Schema.Notation.scope(__CALLER__, :object, :subscription, [name: @default_subscription_name], block)
+  end
+
+  @doc """
+  Defines a custom default resolve function for the schema.
+  """
+  defmacro default_resolve(func) do
+    Module.put_attribute(__CALLER__.module, :absinthe_default_resolve, func)
+    :ok
   end
 
   # Lookup a directive that in used by/available to a schema

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -104,12 +104,11 @@ defmodule Absinthe.Schema do
   ## Default Resolver
 
   By default, if a `resolve` function is not provided for a field, Absinthe
-  will attempt to extract the value of the field by calling
-  `Absinthe.Type.Field.default_resolve/2`, which uses `Map.get/2` to get a value
-  using the (atom) name of the field.
+  will attempt to extract the value of the field using `Map.get/2` with the
+  (atom) name of the field.
 
-  You can change this behavior by setting your own default resolve function in
-  your schema. For example, given we have a fields with a definitions like this:
+  You can change this behavior by setting your own custom default resolve
+  function in your schema. For example, given we have a field, `name`:
 
   ```
   field :name, :string
@@ -136,6 +135,9 @@ defmodule Absinthe.Schema do
       end
   end
   ```
+
+  Note this will now act as the default resolver for all fields in our schema
+  without their own `resolve` function.
   """
 
   @typedoc """
@@ -225,7 +227,7 @@ defmodule Absinthe.Schema do
   Defines a custom default resolve function for the schema.
   """
   defmacro default_resolve(func) do
-    Module.put_attribute(__CALLER__.module, :absinthe_default_resolve, func)
+    Module.put_attribute(__CALLER__.module, :absinthe_custom_default_resolve, func)
     :ok
   end
 

--- a/lib/absinthe/schema/notation/writer.ex
+++ b/lib/absinthe/schema/notation/writer.ex
@@ -10,6 +10,8 @@ defmodule Absinthe.Schema.Notation.Writer do
     implementors  = Macro.escape info.implementors
     directive_map = Macro.escape info.directive_map
 
+    default_resolve = Module.get_attribute(env.module, :absinthe_default_resolve)
+
     [
       quote do
         def __absinthe_types__, do: unquote(type_map)
@@ -29,6 +31,9 @@ defmodule Absinthe.Schema.Notation.Writer do
         def __absinthe_errors__, do: unquote(errors)
         def __absinthe_interface_implementors__, do: unquote(implementors)
         def __absinthe_exports__, do: unquote(exports)
+        def __absinthe_default_resolve__ do
+          unquote(default_resolve) || &Absinthe.Type.Field.default_resolve/2
+        end
       end
     ]
   end

--- a/lib/absinthe/schema/notation/writer.ex
+++ b/lib/absinthe/schema/notation/writer.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Schema.Notation.Writer do
     implementors  = Macro.escape info.implementors
     directive_map = Macro.escape info.directive_map
 
-    default_resolve = Module.get_attribute(env.module, :absinthe_default_resolve)
+    default_resolve_func = Module.get_attribute(env.module, :absinthe_custom_default_resolve)
 
     [
       quote do
@@ -31,11 +31,20 @@ defmodule Absinthe.Schema.Notation.Writer do
         def __absinthe_errors__, do: unquote(errors)
         def __absinthe_interface_implementors__, do: unquote(implementors)
         def __absinthe_exports__, do: unquote(exports)
-        def __absinthe_default_resolve__ do
-          unquote(default_resolve) || &Absinthe.Type.Field.default_resolve/2
-        end
-      end
+      end,
+      custom_default_resolve(default_resolve_func)
     ]
+  end
+
+  defp custom_default_resolve(nil) do
+    quote do
+      def __absinthe_custom_default_resolve__, do: nil
+    end
+  end
+  defp custom_default_resolve(func) do
+    quote do
+      def __absinthe_custom_default_resolve__, do: unquote(func)
+    end
   end
 
   defp type_functions(definition) do

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -137,7 +137,7 @@ defmodule Absinthe.Type.Field do
   end
 
   def resolve(%{resolve: nil} = field, args, %{schema: schema} = field_info) do
-    %{field | resolve: schema.__absinthe_default_resolve__}
+    %{field | resolve: schema.__absinthe_custom_default_resolve__}
     |> resolve(args, field_info)
   end
   def resolve(%{resolve: designer_resolve, __private__: private}, args, field_info) do
@@ -157,20 +157,6 @@ defmodule Absinthe.Type.Field do
   # Get the registered resolve helper, if any
   defp system_resolve(private) do
     get_in(private, [Absinthe, :resolve])
-  end
-
-  @doc """
-  The default resolver, extracting values from source objects by atom names.
-
-  Override in your schema with `Absinthe.Schema.default_resolve/1`.
-  """
-  def default_resolve(_, %{source: source, definition: %{name: name}}) do
-    case source do
-      %{} = target ->
-        {:ok, Map.get(target, name |> String.to_existing_atom)}
-      _ ->
-        {:ok, nil}
-    end
   end
 
   defimpl Absinthe.Validation.RequiredInput do

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -136,6 +136,10 @@ defmodule Absinthe.Type.Field do
     end
   end
 
+  def resolve(%{resolve: nil} = field, args, %{schema: schema} = field_info) do
+    %{field | resolve: schema.__absinthe_default_resolve__}
+    |> resolve(args, field_info)
+  end
   def resolve(%{resolve: designer_resolve, __private__: private}, args, field_info) do
     do_resolve(system_resolve(private), designer_resolve, args, field_info)
   end
@@ -153,6 +157,20 @@ defmodule Absinthe.Type.Field do
   # Get the registered resolve helper, if any
   defp system_resolve(private) do
     get_in(private, [Absinthe, :resolve])
+  end
+
+  @doc """
+  The default resolver, extracting values from source objects by atom names.
+
+  Override in your schema with `Absinthe.Schema.default_resolve/1`.
+  """
+  def default_resolve(_, %{source: source, definition: %{name: name}}) do
+    case source do
+      %{} = target ->
+        {:ok, Map.get(target, name |> String.to_existing_atom)}
+      _ ->
+        {:ok, nil}
+    end
   end
 
   defimpl Absinthe.Validation.RequiredInput do

--- a/test/lib/absinthe/execution/default_resolver_test.exs
+++ b/test/lib/absinthe/execution/default_resolver_test.exs
@@ -1,0 +1,51 @@
+defmodule Absinthe.Execution.DefaultResolverTest do
+  use ExSpec, async: true
+
+  @root %{:foo => "baz", "bar" => "quux"}
+  @query "{ foo bar }"
+
+  describe "without a custom default resolver defined" do
+
+    defmodule NormalSchema do
+      use Absinthe.Schema
+
+      query do
+        field :foo, :string
+        field :bar, :string
+      end
+
+    end
+
+    it "should resolve using atoms" do
+      assert {:ok, %{data: %{"foo" => "baz", "bar" => nil}}} == Absinthe.run(@query, NormalSchema, root_value: @root)
+    end
+
+  end
+
+  describe "with a custom default resolver defined" do
+
+    defmodule CustomSchema do
+      use Absinthe.Schema
+
+      query do
+        field :foo, :string
+        field :bar, :string
+      end
+
+      default_resolve fn
+        _, %{source: source, definition: %{name: name}} ->
+          {
+            :ok,
+            Map.get(source, name) || Map.get(source, String.to_existing_atom(name))
+          }
+      end
+
+    end
+
+    it "should resolve using as defined" do
+      assert {:ok, %{data: %{"foo" => "baz", "bar" => "quux"}}} == Absinthe.run(@query, CustomSchema, root_value: @root)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Resolves #77.

Adds a macro, `default_resolve`, than can be set in a schema to override the built-in default resolve function.

Eg, to support string [instead of atom] keyed maps:

```elixir
default_resolve fn
  _, %{source: source, definition: %{name: name}} ->
    case source do
      %{} ->
        {:ok, Map.get(source, name)}
       _ ->
        {:ok, nil}
    end
end
```

@benwilson512 Would appreciate a sanity and performance pass. I've tried to limit the overhead, but it's likely you'll find some improvements with some benchmarking.

