### PR TITLE
Mutation and Subscription Operation Definitions without names

### DIFF
--- a/lib/absinthe/execution/input.ex
+++ b/lib/absinthe/execution/input.ex
@@ -4,7 +4,6 @@ defmodule Absinthe.Execution.Input do
   # Common functionality for Arguments and Variables
 
   alias Absinthe.Execution
-  alias Absinthe.Type
   alias __MODULE__.Meta
 
   def process(input_type, meta, execution) do

--- a/lib/absinthe/execution/variables.ex
+++ b/lib/absinthe/execution/variables.ex
@@ -58,7 +58,7 @@ defmodule Absinthe.Execution.Variables do
     end
   end
 
-  defp put_variable(execution, name, %{value: nil}) do
+  defp put_variable(execution, _, %{value: nil}) do
     execution
   end
   defp put_variable(execution, name, variable) do

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -36,6 +36,7 @@ OperationType -> 'mutation' : extract_atom('$1').
 OperationType -> 'subscription' : extract_atom('$1').
 
 OperationDefinition -> SelectionSet : build_ast_node('OperationDefinition', #{'operation' => 'query', 'selection_set' => '$1'}, #{'start_line' => extract_child_line('$1')}).
+OperationDefinition -> OperationType SelectionSet : build_ast_node('OperationDefinition', #{'operation' => '$1', 'selection_set' => '$2'}, #{'start_line' => extract_line('$2')}).
 OperationDefinition -> OperationType Name SelectionSet : build_ast_node('OperationDefinition', #{'operation' => '$1', 'name' => extract_binary('$2'), 'selection_set' => '$3'}, #{'start_line' => extract_line('$2')}).
 OperationDefinition -> OperationType Name VariableDefinitions SelectionSet : build_ast_node('OperationDefinition', #{'operation' => '$1', 'name' => extract_binary('$2'), 'variable_definitions' => '$3', 'selection_set' => '$4'}, #{'start_line' => extract_line('$1')}).
 OperationDefinition -> OperationType Name Directives SelectionSet : build_ast_node('OperationDefinition', #{'operation' => '$1', 'name' => extract_binary('$2'), 'directives' => '$3', 'selection_set' => '$4'}, #{'start_line' => extract_line('$1')}).

--- a/test/lib/absinthe/parser_test.exs
+++ b/test/lib/absinthe/parser_test.exs
@@ -22,4 +22,20 @@ defmodule Absinthe.ParserTest do
     end)
   end
 
+  @query """
+  mutation {
+    likeStory(storyID: 12345) {
+      story {
+        likeCount
+      }
+    }
+  }
+  subscription {
+    viewer { likes }
+  }
+  """
+  it "can parse mutations and subscriptions without names" do
+    assert {:ok, _} = Absinthe.parse(@query)
+  end
+
 end


### PR DESCRIPTION
The parser choked on unnamed mutation and subscription definitions, eg, from the spec:

```
mutation {
  likeStory(storyID: 12345) {
    story {
      likeCount
    }
  }
}
```

Now fixed.