### PR TITLE
IDL Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.1.3
+
+(NOT YET RELEASED)
+
+Mix Tasks:
+
+- `absinthe.schema.json` now requires schema to be given as an `--schema`
+  option, but supports the `:absinthe` `:schema` application configuration
+  value.
+- `absinthe.schema.graphql` task added.
+
 ## v1.1.2
 
 Bugfixes:

--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -212,7 +212,7 @@ defmodule Absinthe.Adapter do
         nil
       end
       def adapt(other, _) do
-        Logger.warn "Could not adapt #{inspect other}"
+        Logger.warn "Absinthe: #{__MODULE__} could not adapt #{inspect other}"
         other
       end
 

--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -57,6 +57,8 @@ defmodule Absinthe.Adapter do
 
   defmacro __using__(_) do
     quote do
+      require Logger
+
       @behaviour unquote(__MODULE__)
 
       alias Absinthe.Execution
@@ -96,80 +98,129 @@ defmodule Absinthe.Adapter do
         map_var(rest, [item | acc])
       end
 
-      defp load_variable_definitions(%{variable: variable} = node) do
-        %{ node |
-          variable: Map.update!(variable, :name, &to_internal_name(&1, :variable))
-        }
-      end
+      def load_document(node), do: adapt(node, :load)
+      def dump_document(node), do: adapt(node, :dump)
 
-      def load_document(%{definitions: definitions} = node) do
-        %{node |
-          definitions: definitions |> Enum.map(&load_ast_node/1),
-        }
-      end
+      @ignore_nodes [
+        Language.EnumTypeDefinition,
+        Language.UnionTypeDefinition,
+        Language.ScalarTypeDefinition,
+        Language.StringValue,
+        Language.BooleanValue,
+        Language.IntValue,
+        Language.FloatValue,
+        Language.EnumValue
+      ]
 
       # Rename a AST node and traverse children
-      defp load_ast_node(%Language.Directive{} = node) do
+      def adapt(%Language.Document{definitions: definitions} = node, adaptation) do
+        %{
+          node |
+          definitions: definitions |> Enum.map(&adapt(&1, adaptation)),
+         }
+      end
+      def adapt(%Language.VariableDefinition{variable: variable} = node, adaptation) do
+        %{
+          node |
+          variable: Map.update!(variable, :name, &do_adapt(&1, :variable, adaptation))
+         }
+      end
+      def adapt(%Language.Directive{} = node, adaptation) do
         %{node |
-          arguments: Enum.map(node.arguments, &load_ast_node/1)
+          arguments: Enum.map(node.arguments, &adapt(&1, adaptation))
         }
       end
-      defp load_ast_node(%Language.Variable{} = node) do
-        %{node | name: to_internal_name(node.name, :variable)}
+      def adapt(%Language.Variable{} = node, adaptation) do
+        %{node | name: do_adapt(node.name, :variable, adaptation)}
       end
-      defp load_ast_node(%Language.OperationDefinition{} = node) do
+      def adapt(%Language.OperationDefinition{} = node, adaptation) do
         %{node |
-          name: node.name |> to_internal_name(:operation),
-          selection_set: load_ast_node(node.selection_set),
-          variable_definitions: node.variable_definitions |> Enum.map(&load_variable_definitions/1)
+          name: node.name |> do_adapt(:operation, adaptation),
+          selection_set: adapt(node.selection_set, adaptation),
+          variable_definitions: node.variable_definitions |> Enum.map(&adapt(&1, adaptation))
         }
       end
-      defp load_ast_node(%Language.Fragment{} = node) do
+      def adapt(%Language.ObjectDefinition{} = node, adaptation) do
         %{node |
-          directives: node.directives |> Enum.map(&load_ast_node/1),
-          selection_set: load_ast_node(node.selection_set),
+          fields: Enum.map(node.fields, &adapt(&1, adaptation))
+         }
+      end
+      def adapt(%Language.InputObjectDefinition{} = node, adaptation) do
+        %{node |
+          fields: Enum.map(node.fields, &adapt(&1, adaptation))
+         }
+      end
+      def adapt(%Language.Fragment{} = node, adaptation) do
+        %{node |
+          directives: node.directives |> Enum.map(&adapt(&1, adaptation)),
+          selection_set: adapt(node.selection_set, adaptation),
         }
       end
-      defp load_ast_node(%Language.InlineFragment{} = node) do
+      def adapt(%Language.InlineFragment{} = node, adaptation) do
         %{node |
-          directives: node.directives |> Enum.map(&load_ast_node/1),
-          selection_set: load_ast_node(node.selection_set)}
+          directives: node.directives |> Enum.map(&adapt(&1, adaptation)),
+          selection_set: adapt(node.selection_set, adaptation)}
       end
-      defp load_ast_node(%Language.FragmentSpread{} = node) do
+      def adapt(%Language.FragmentSpread{} = node, adaptation) do
         %{node |
-          directives: node.directives |> Enum.map(&load_ast_node/1)}
+          directives: node.directives |> Enum.map(&adapt(&1, adaptation))}
       end
-      defp load_ast_node(%Language.SelectionSet{} = node) do
+      def adapt(%Language.SelectionSet{} = node, adaptation) do
         %{node |
-          selections: node.selections |> Enum.map(&load_ast_node/1)}
+          selections: node.selections |> Enum.map(&adapt(&1, adaptation))}
       end
-      defp load_ast_node(%Language.Field{} = node) do
+      def adapt(%Language.Field{} = node, adaptation) do
         %{node |
-          name: node.name |> to_internal_name(:field),
-          selection_set: load_ast_node(node.selection_set),
-          arguments: node.arguments |> Enum.map(&load_ast_node/1),
-          directives: node.directives |> Enum.map(&load_ast_node/1),
+          name: node.name |> do_adapt(:field, adaptation),
+          selection_set: adapt(node.selection_set, adaptation),
+          arguments: node.arguments |> Enum.map(&adapt(&1, adaptation)),
+          directives: node.directives |> Enum.map(&adapt(&1, adaptation)),
         }
       end
-      defp load_ast_node(%Language.ObjectValue{} = node) do
+      def adapt(%Language.FieldDefinition{} = node, adaptation) do
         %{node |
-          fields: node.fields |> Enum.map(&load_ast_node/1)}
+          name: node.name |> do_adapt(:field, adaptation),
+          arguments: node.arguments |> Enum.map(&adapt(&1, adaptation)),
+         }
       end
-      defp load_ast_node(%Language.ObjectField{} = node) do
+      def adapt(%Language.InputValueDefinition{} = node, adaptation) do
         %{node |
-          name: node.name |> to_internal_name(:field),
-          value: load_ast_node(node.value)}
+          name: node.name |> do_adapt(:field, adaptation),
+         }
       end
-      defp load_ast_node(%Language.Argument{} = node) do
+      def adapt(%Language.ObjectValue{} = node, adaptation) do
         %{node |
-          name: node.name |> to_internal_name(:argument),
-          value: load_ast_node(node.value)}
+          fields: node.fields |> Enum.map(&adapt(&1, adaptation))}
       end
-      defp load_ast_node(%Language.ListValue{} = node) do
-        %{node | values: Enum.map(node.values, &load_ast_node/1)}
+      def adapt(%Language.ObjectField{} = node, adaptation) do
+        %{node |
+          name: node.name |> do_adapt(:field, adaptation),
+          value: adapt(node.value, adaptation)}
       end
-      defp load_ast_node(other) do
+      def adapt(%Language.Argument{} = node, adaptation) do
+        %{node |
+          name: node.name |> do_adapt(:argument, adaptation),
+          value: adapt(node.value, adaptation)}
+      end
+      def adapt(%Language.ListValue{} = node, adaptation) do
+        %{node | values: Enum.map(node.values, &adapt(&1, adaptation))}
+      end
+      def adapt(%{__struct__: str} = node, _) when str in @ignore_nodes do
+        node
+      end
+      def adapt(nil, _) do
+        nil
+      end
+      def adapt(other, _) do
+        Logger.warn "Could not adapt #{inspect other}"
         other
+      end
+
+      defp do_adapt(value, role, :load) do
+        to_internal_name(value, role)
+      end
+      defp do_adapt(value, role, :dump) do
+        to_external_name(value, role)
       end
 
       def dump_results(%{data: data} = results) do
@@ -227,6 +278,8 @@ defmodule Absinthe.Adapter do
       end
 
       defoverridable [load_document: 1,
+                      dump_document: 1,
+                      adapt: 2,
                       dump_results: 1,
                       format_error: 2,
                       format_error: 1,
@@ -249,6 +302,22 @@ defmodule Absinthe.Adapter do
   ```
   """
   @callback load_document(Absinthe.Language.Document.t) :: Absinthe.Language.Document.t
+
+
+  @doc """
+  Convert an AST node to/from a representation.
+
+  Called by `load_document/1`.
+
+  ## Examples
+
+  ```
+  def adapt(%{definitions: definitions} = document, :load) do
+    %{document | definitions: definitions |> Enum.map(&your_custom_loader/1)}
+  end
+  ```
+  """
+  @callback adapt(Absinthe.Language.t, :load | :dump) :: Absinthe.Language.t
 
   @doc """
   Convert the canonical (internal) results to the output (external)

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -1,9 +1,11 @@
 defmodule Absinthe.Language.IDL do
   @moduledoc false
 
-  alias Absinthe.Schema
-  alias Absinthe.Language
-  alias Absinthe.Type
+  alias Absinthe.{Schema, Language, Type, Adapter}
+
+  defp adapt(name, role) do
+    Adapter.LanguageConventions.to_external_name(name, role)
+  end
 
   @spec to_idl_ast(atom) :: Language.Document.t
   def to_idl_ast(schema) do
@@ -51,7 +53,7 @@ defmodule Absinthe.Language.IDL do
   end
   def to_idl_ast(%Type.Argument{} = node, schema) do
     %Language.InputValueDefinition{
-      name: node.name,
+      name: node.name |> adapt(:argument),
       type: to_idl_ast(node.type, schema)
     }
   end
@@ -72,14 +74,14 @@ defmodule Absinthe.Language.IDL do
   @spec to_idl_ast(Type.t, Type.t, Schema.t) :: Language.t
   defp to_idl_ast(%Type.InputObject{}, %Type.Field{} = node, schema) do
     %Language.InputValueDefinition{
-      name: node.name,
+      name: node.name |> adapt(:field),
       default_value: to_idl_default_value_ast(Schema.lookup_type(schema, node.type, unwrap: false), node.default_value, schema),
       type: to_idl_ast(node.type, schema)
     }
   end
   defp to_idl_ast(%{__struct__: str}, %Type.Field{} = node, schema) when str in [Type.Object, Type.Interface] do
     %Language.FieldDefinition{
-      name: node.name,
+      name: node.name |> adapt(:field),
       arguments: Enum.map(Map.values(node.args), &to_idl_ast(&1, schema)),
       type: to_idl_ast(node.type, schema)
     }

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -31,6 +31,12 @@ defmodule Absinthe.Language.IDL do
       fields: Enum.map(Map.values(node.fields), &to_idl_ast(node, &1, schema))
     }
   end
+  def to_idl_ast(%Type.Enum{} = node, schema) do
+    %Language.EnumTypeDefinition{
+      name: node.name,
+      values: Enum.map(Map.values(node.values), &Map.get(&1, :name))
+    }
+  end
   def to_idl_ast(%Type.Argument{} = node, schema) do
     %Language.InputValueDefinition{
       name: node.name,
@@ -136,8 +142,16 @@ defmodule Absinthe.Language.IDL do
       node.name,
       ": ",
       to_idl_iodata(node.type),
-      default_idl_iodata(node.default_value),
-      "\n"
+      default_idl_iodata(node.default_value)
+    ]
+  end
+  def to_idl_iodata(%Language.EnumTypeDefinition{} = node) do
+    [
+      "enum ",
+      node.name,
+      " {\n",
+      indented(2, node.values),
+      "}\n"
     ]
   end
   def to_idl_iodata(%Language.NamedType{} = node) do
@@ -155,6 +169,9 @@ defmodule Absinthe.Language.IDL do
       to_idl_iodata(node.type),
       "]"
     ]
+  end
+  def to_idl_iodata(value) when is_binary(value) do
+    value
   end
 
   defp implements_iodata([]) do
@@ -204,7 +221,7 @@ defmodule Absinthe.Language.IDL do
   end
 
   defp arguments_idl_iodata([]) do
-    ""
+    []
   end
   defp arguments_idl_iodata(arguments) do
     [

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -1,4 +1,5 @@
 defmodule Absinthe.Language.IDL do
+  @moduledoc false
 
   alias Absinthe.Schema
   alias Absinthe.Language
@@ -152,7 +153,6 @@ defmodule Absinthe.Language.IDL do
       arguments_idl_iodata(node.arguments),
       ": ",
       to_idl_iodata(node.type),
-      "\n"
     ]
   end
   def to_idl_iodata(%Language.InputValueDefinition{} = node) do
@@ -160,7 +160,7 @@ defmodule Absinthe.Language.IDL do
       node.name,
       ": ",
       to_idl_iodata(node.type),
-      default_idl_iodata(node.default_value)
+      default_idl_iodata(node.default_value),
     ]
   end
   def to_idl_iodata(%Language.EnumTypeDefinition{} = node) do
@@ -278,11 +278,11 @@ defmodule Absinthe.Language.IDL do
     ]
   end
 
-  defp indented(amount, collection) do
+  defp indented(amount, collection, opts \\ []) do
     indent = 1..amount |> Enum.map(fn _ -> " " end)
     Enum.map(collection, fn
       member ->
-        [indent, to_idl_iodata(member)]
+        [indent, to_idl_iodata(member), "\n"]
     end)
   end
 

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -1,0 +1,109 @@
+defmodule Absinthe.Language.IDL do
+
+  alias Absinthe.Schema
+  alias Absinthe.Language
+  alias Absinthe.Type
+
+  @spec to_idl_ast(atom) :: Language.Document.t
+  def to_idl_ast(schema) do
+    %Language.Document{
+      definitions: Enum.map(Enum.reject(Absinthe.Schema.types(schema), &Absinthe.Type.built_in?/1), &to_idl_ast(&1, schema))
+    }
+  end
+
+  @spec to_idl_ast(Absinthe.Type.t, Absinthe.Schema.t) :: Language.t
+  def to_idl_ast(%Type.Object{} = node, schema) do
+    %Language.ObjectDefinition{
+      name: node.name,
+      fields: Enum.map(Map.values(node.fields), &to_idl_ast(&1, schema))
+    }
+  end
+  def to_idl_ast(%Type.Field{} = node, schema) do
+    %Language.FieldDefinition{
+      name: node.name,
+      arguments: Enum.map(Map.values(node.args), &to_idl_ast(&1, schema)),
+      type: to_idl_ast(node.type, schema)
+    }
+  end
+  def to_idl_ast(%Type.Argument{} = node, schema) do
+    %Language.InputValueDefinition{
+      name: node.name,
+      type: to_idl_ast(node.type, schema)
+    }
+  end
+  def to_idl_ast(%Type.List{of_type: type} = node, schema) do
+    %Language.ListType{
+      type: to_idl_ast(type, schema)
+    }
+  end
+  def to_idl_ast(%Type.NonNull{of_type: type} = node, schema) do
+    %Language.NonNullType{
+      type: to_idl_ast(type, schema)
+    }
+  end
+  def to_idl_ast(node, schema) when is_atom(node) do
+    %Language.NamedType{name: schema.__absinthe_type__(node).name}
+  end
+
+  @spec to_idl_iodata(Language.t) :: iodata
+  def to_idl_iodata(%Language.Document{} = doc) do
+    doc.definitions
+    |> Enum.map(&to_idl_iodata/1)
+  end
+  def to_idl_iodata(%Language.ObjectDefinition{} = node) do
+    [
+      "type ",
+      node.name,
+      " {\n",
+      indented(2, node.fields),
+      "}\n"
+    ]
+  end
+  def to_idl_iodata(%Language.FieldDefinition{} = node) do
+    [
+      node.name,
+      arguments_idl_iodata(node.arguments),
+      ": ",
+      to_idl_iodata(node.type),
+      "\n"
+    ]
+  end
+  def to_idl_iodata(%Language.NamedType{} = node) do
+    node.name
+  end
+  def to_idl_iodata(%Language.NonNullType{} = node) do
+    [
+      to_idl_iodata(node.type),
+      "!"
+    ]
+  end
+  def to_idl_iodata(%Language.ListType{} = node) do
+    [
+      "[",
+      to_idl_iodata(node.type),
+      "]"
+    ]
+  end
+
+
+
+  defp arguments_idl_iodata([]) do
+    ""
+  end
+  defp arguments_idl_iodata(arguments) do
+    [
+      "(",
+      Enum.intersperse(Enum.map(arguments, &to_idl_iodata/1), ", "),
+      ")"
+    ]
+  end
+
+  defp indented(amount, collection) do
+    indent = 1..amount |> Enum.map(fn _ -> " " end)
+    Enum.map(collection, fn
+      member ->
+        [indent, to_idl_iodata(member)]
+    end)
+  end
+
+end

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -37,10 +37,15 @@ defmodule Absinthe.Language.IDL do
       values: Enum.map(Map.values(node.values), &Map.get(&1, :name))
     }
   end
-  def to_idl_ast(%Absinthe.Type.Union{} = node, schema) do
+  def to_idl_ast(%Type.Union{} = node, schema) do
     %Language.UnionTypeDefinition{
       name: node.name,
       types: Enum.map(node.types, &to_idl_named_type_ast(&1, schema))
+    }
+  end
+  def to_idl_ast(%Type.Scalar{} = node, _schema) do
+    %Language.ScalarTypeDefinition{
+      name: node.name
     }
   end
   def to_idl_ast(%Type.Argument{} = node, schema) do
@@ -174,6 +179,12 @@ defmodule Absinthe.Language.IDL do
       " = ",
       Enum.map(node.types, &Map.get(&1, :name))
       |> Enum.join(" | ")
+    ]
+  end
+  def to_idl_iodata(%Language.ScalarTypeDefinition{} = node) do
+    [
+      "scalar ",
+      node.name
     ]
   end
   def to_idl_iodata(%Language.NamedType{} = node) do

--- a/lib/absinthe/language/idl.ex
+++ b/lib/absinthe/language/idl.ex
@@ -3,10 +3,6 @@ defmodule Absinthe.Language.IDL do
 
   alias Absinthe.{Schema, Language, Type, Adapter}
 
-  defp adapt(name, role) do
-    Adapter.LanguageConventions.to_external_name(name, role)
-  end
-
   @spec to_idl_ast(atom) :: Language.Document.t
   def to_idl_ast(schema) do
     %Language.Document{
@@ -53,7 +49,7 @@ defmodule Absinthe.Language.IDL do
   end
   def to_idl_ast(%Type.Argument{} = node, schema) do
     %Language.InputValueDefinition{
-      name: node.name |> adapt(:argument),
+      name: node.name,
       type: to_idl_ast(node.type, schema)
     }
   end
@@ -74,14 +70,14 @@ defmodule Absinthe.Language.IDL do
   @spec to_idl_ast(Type.t, Type.t, Schema.t) :: Language.t
   defp to_idl_ast(%Type.InputObject{}, %Type.Field{} = node, schema) do
     %Language.InputValueDefinition{
-      name: node.name |> adapt(:field),
+      name: node.name,
       default_value: to_idl_default_value_ast(Schema.lookup_type(schema, node.type, unwrap: false), node.default_value, schema),
       type: to_idl_ast(node.type, schema)
     }
   end
   defp to_idl_ast(%{__struct__: str}, %Type.Field{} = node, schema) when str in [Type.Object, Type.Interface] do
     %Language.FieldDefinition{
-      name: node.name |> adapt(:field),
+      name: node.name,
       arguments: Enum.map(Map.values(node.args), &to_idl_ast(&1, schema)),
       type: to_idl_ast(node.type, schema)
     }

--- a/lib/mix/tasks/absinthe.schema.graphql.ex
+++ b/lib/mix/tasks/absinthe.schema.graphql.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.Absinthe.Schema.Graphql do
+  require Logger
+  use Mix.Task
+  import Mix.Generator
+
+  @shortdoc "Generate a schema.graphql file for an Absinthe schema"
+
+  @moduledoc """
+  Generate a schema.graphql file
+
+  ## Usage
+
+      absinthe.schema.graphql Schema.Module.Name [FILENAME]
+
+  ## Examples
+
+      $ mix absinthe.schema.graphql MySchema
+      $ mix absinthe.schema.graphql MySchema ../path/to/schema.graphql
+
+  """
+
+  def run(argv) do
+    Mix.Task.run("app.start", [])
+
+    {opts, [schema_name|rest], _} = OptionParser.parse(argv)
+
+    filename = rest |> List.first || "schema.graphql"
+    schema = [schema_name] |> Module.safe_concat
+
+    content = schema
+    |> Absinthe.Language.IDL.to_idl_ast
+    |> Absinthe.Language.IDL.to_idl_iodata
+
+    create_directory(Path.dirname(filename))
+    create_file(filename, content, force: true)
+  end
+
+end

--- a/lib/mix/tasks/absinthe.schema.graphql.ex
+++ b/lib/mix/tasks/absinthe.schema.graphql.ex
@@ -3,37 +3,39 @@ defmodule Mix.Tasks.Absinthe.Schema.Graphql do
   use Mix.Task
   import Mix.Generator
 
-  @shortdoc "Generate a schema.graphql file for an Absinthe schema"
+  @shortdoc "Generate a schema.graphql (IDL) file for an Absinthe schema"
 
   @default_filename "./schema.graphql"
   @default_adapter Absinthe.Adapter.LanguageConventions
+  @default_adapter_name "Absinthe.Adapter.LanguageConventions"
 
   @moduledoc """
   Generate a schema.graphql file
 
   ## Usage
 
-      absinthe.schema.graphql Schema.Module.Name [FILENAME]
+      absinthe.schema.graphql [OPTIONS] [FILENAME]
 
   ## Options
 
-    --adapter Sets the adapter. Default: #{@default_adapter}
+      --schema The schema. Default: As configured for `:absinthe` `:schema`
+      --adapter Sets the adapter. Default: #{@default_adapter_name}
 
   ## Examples
 
   Write to default path `#{@default_filename}` using the `:schema` configured for
   the `:absinthe` application, adapting it using the default
-  `#{@default_adapter}` adapter:
+  `#{@default_adapter_name}` adapter:
 
       $ mix absinthe.schema.graphql
 
   Write to default path `#{@default_filename}` using the `MySchema` schema, adapting
-  it using the default `#{@default_adapter}` adapter:
+  it using the default `#{@default_adapter_name}` adapter:
 
       $ mix absinthe.schema.graphql --schema MySchema
 
   Write to path `/path/to/schema.graphql` using the `MySchema` schema, adapting
-  it using the default `#{@default_adapter}` adapter:
+  it using the default `#{@default_adapter_name}` adapter:
 
       $ mix absinthe.schema.graphql --schema MySchema /path/to/schema.graphql
 

--- a/lib/mix/tasks/absinthe.schema.graphql.ex
+++ b/lib/mix/tasks/absinthe.schema.graphql.ex
@@ -12,10 +12,15 @@ defmodule Mix.Tasks.Absinthe.Schema.Graphql do
 
       absinthe.schema.graphql Schema.Module.Name [FILENAME]
 
+  ## Options
+
+    --adapter Sets the adapter. Default: Absinthe.Adapter.LanguageConventions
+
   ## Examples
 
       $ mix absinthe.schema.graphql MySchema
       $ mix absinthe.schema.graphql MySchema ../path/to/schema.graphql
+      $ mix absinthe.schema.graphql MySchema --adapter Absinthe.Adapter.Passthrough
 
   """
 
@@ -25,14 +30,22 @@ defmodule Mix.Tasks.Absinthe.Schema.Graphql do
     {opts, [schema_name|rest], _} = OptionParser.parse(argv)
 
     filename = rest |> List.first || "schema.graphql"
+    adapter = find_adapter(opts)
     schema = [schema_name] |> Module.safe_concat
 
     content = schema
     |> Absinthe.Language.IDL.to_idl_ast
+    |> adapter.dump_document
     |> Absinthe.Language.IDL.to_idl_iodata
+
+    IO.puts "OK"
 
     create_directory(Path.dirname(filename))
     create_file(filename, content, force: true)
+  end
+
+  defp find_adapter(opts) do
+    Keyword.get(opts, :adapter, Absinthe.Adapter.LanguageConventions)
   end
 
 end

--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -43,7 +43,7 @@ BooleanValue        = true|false
 
 
 % Reserved words
-ReservedWord        = query|mutation|subscription|fragment|on|implements|interface|union|scalar|enum|input|extend|null
+ReservedWord        = query|mutation|subscription|fragment|on|implements|interface|union|scalar|enum|input|extend|type|null
 
 Rules.
 

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -209,6 +209,7 @@ InputObjectDefinition -> 'input' Name '{' InputValueDefinitionList '}' :
 TypeExtensionDefinition -> 'extend' ObjectDefinition :
   build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, #{'start_line' => extract_line('$1')}).
 
+
 Erlang code.
 
 extract_atom({Value, _Line}) -> Value.

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -1,0 +1,56 @@
+defmodule Absinthe.Language.IDLtest do
+  use ExSpec, async: true
+
+  describe "object types" do
+
+    @idl """
+    type Article {
+      author: User
+    }
+    type User {
+      articles: [Article]
+    }
+    """
+
+    defmodule ObjectSchema do
+      use Absinthe.Schema
+
+      object :article do
+        field :author, :user
+      end
+
+      object :user do
+        field :articles, list_of(:article)
+      end
+
+    end
+
+    it "are parsed from IDL" do
+      assert {:ok, _} = Absinthe.parse(@idl)
+    end
+
+    it "can be converted to IDL AST" do
+      assert %Absinthe.Language.ObjectDefinition{} = Absinthe.Language.IDL.to_idl_ast(ObjectSchema.__absinthe_type__(:article), ObjectSchema)
+    end
+
+    it "can be converted to IDL iodata" do
+      equiv_idl = """
+      type Article {
+        author: User
+      }
+      """
+      {:ok, equiv_idl_ast_doc} = Absinthe.parse(equiv_idl)
+      equiv_idl_ast = equiv_idl_ast_doc.definitions |> List.first
+      equiv_idl_iodata = Absinthe.Language.IDL.to_idl_iodata(equiv_idl_ast)
+
+      idl_ast = ObjectSchema.__absinthe_type__(:article) |> Absinthe.Language.IDL.to_idl_ast(ObjectSchema)
+      idl_iodata = Absinthe.Language.IDL.to_idl_iodata(idl_ast)
+      assert idl_iodata == equiv_idl_iodata
+    end
+    it "can be converted to IDL iodata as a schema" do
+      assert Absinthe.Language.IDL.to_idl_iodata(ObjectSchema |> Absinthe.Language.IDL.to_idl_ast)
+    end
+
+  end
+
+end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -99,6 +99,20 @@ defmodule Absinthe.Language.IDLtest do
       assert %Absinthe.Language.InputObjectDefinition{} = Absinthe.Language.IDL.to_idl_ast(InputObjectSchema.__absinthe_type__(:input_article), InputObjectSchema)
     end
 
+    # Note: This only tests that input object defaults parsed in from IDL
+    # are successfully emitted back, not that they can be set in Absinthe schema notation
+    it "can be provided as defaults" do
+      idl = """
+      type QueryRoot {
+        createThing(input: InputThing = {name: "Boo"}): Thing
+      }
+      """
+      {:ok, idl_ast_doc} = Absinthe.parse(idl)
+      idl_ast = idl_ast_doc.definitions |> List.first
+      idl_iodata = Absinthe.Language.IDL.to_idl_iodata(idl_ast)
+      assert idl == IO.iodata_to_binary(idl_iodata)
+    end
+
     it "can be converted to IDL iodata" do
       equiv_idl = """
       input InputArticle {

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -53,4 +53,56 @@ defmodule Absinthe.Language.IDLtest do
 
   end
 
+  describe "input object types" do
+
+    @idl """
+    input InputArticle {
+      author: User
+    }
+    input InputUser {
+      articles: [Article]
+    }
+    """
+
+    defmodule InputObjectSchema do
+      use Absinthe.Schema
+
+      input_object :input_article do
+        field :author, :input_user
+      end
+
+      input_object :input_user do
+        field :articles, list_of(:input_article)
+      end
+
+    end
+
+    it "are parsed from IDL" do
+      assert {:ok, _} = Absinthe.parse(@idl)
+    end
+
+    it "can be converted to IDL AST" do
+      assert %Absinthe.Language.InputObjectDefinition{} = Absinthe.Language.IDL.to_idl_ast(InputObjectSchema.__absinthe_type__(:input_article), InputObjectSchema)
+    end
+
+    it "can be converted to IDL iodata" do
+      equiv_idl = """
+      input InputArticle {
+        author: InputUser
+      }
+      """
+      {:ok, equiv_idl_ast_doc} = Absinthe.parse(equiv_idl)
+      equiv_idl_ast = equiv_idl_ast_doc.definitions |> List.first
+      equiv_idl_iodata = Absinthe.Language.IDL.to_idl_iodata(equiv_idl_ast)
+
+      idl_ast = InputObjectSchema.__absinthe_type__(:input_article) |> Absinthe.Language.IDL.to_idl_ast(InputObjectSchema)
+      idl_iodata = Absinthe.Language.IDL.to_idl_iodata(idl_ast)
+      assert idl_iodata == equiv_idl_iodata
+    end
+    it "can be converted to IDL iodata as a schema" do
+      assert Absinthe.Language.IDL.to_idl_iodata(InputObjectSchema |> Absinthe.Language.IDL.to_idl_ast)
+    end
+
+  end
+
 end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -291,4 +291,44 @@ defmodule Absinthe.Language.IDLtest do
 
   end
 
+  describe "scalars" do
+
+    @idl """
+    scalar Time
+
+    """
+
+    defmodule ScalarSchema do
+      use Absinthe.Schema
+
+      scalar :time do
+        parse fn _ -> {:ok, :stub} end
+        serialize fn _ -> "stub" end
+      end
+
+    end
+
+    it "are parsed from IDL" do
+      assert {:ok, _} = Absinthe.parse(@idl)
+    end
+
+    it "can be converted to IDL AST" do
+      assert %Absinthe.Language.ScalarTypeDefinition{} = Absinthe.Language.IDL.to_idl_ast(ScalarSchema.__absinthe_type__(:time), ScalarSchema)
+    end
+
+    it "can be converted to IDL iodata" do
+      {:ok, equiv_idl_ast_doc} = Absinthe.parse(@idl)
+      equiv_idl_ast = equiv_idl_ast_doc.definitions |> List.first
+      equiv_idl_iodata = Absinthe.Language.IDL.to_idl_iodata(equiv_idl_ast)
+
+      idl_ast = ScalarSchema.__absinthe_type__(:time) |> Absinthe.Language.IDL.to_idl_ast(ScalarSchema)
+      idl_iodata = Absinthe.Language.IDL.to_idl_iodata(idl_ast)
+      assert idl_iodata == equiv_idl_iodata
+    end
+    it "can be converted to IDL iodata as a schema" do
+      assert Absinthe.Language.IDL.to_idl_iodata(ScalarSchema |> Absinthe.Language.IDL.to_idl_ast)
+    end
+
+  end
+
 end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -1,10 +1,13 @@
 defmodule Absinthe.Language.IDLtest do
   use ExSpec, async: true
 
-  describe "object types" do
+  describe "object and interface types" do
 
     @idl """
-    type Article {
+    interface Authored {
+      author: User
+    }
+    type Article implements Authored {
       author: User
     }
     type User {
@@ -15,8 +18,17 @@ defmodule Absinthe.Language.IDLtest do
     defmodule ObjectSchema do
       use Absinthe.Schema
 
+      interface :authored do
+        field :author, :user
+        resolve_type fn
+          _, _ ->
+            {:ok, :article}
+        end
+      end
+
       object :article do
         field :author, :user
+        interface :authored
       end
 
       object :user do
@@ -35,7 +47,7 @@ defmodule Absinthe.Language.IDLtest do
 
     it "can be converted to IDL iodata" do
       equiv_idl = """
-      type Article {
+      type Article implements Authored {
         author: User
       }
       """
@@ -109,5 +121,7 @@ defmodule Absinthe.Language.IDLtest do
     end
 
   end
+
+
 
 end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -241,12 +241,6 @@ defmodule Absinthe.Language.IDLtest do
     defmodule UnionSchema do
       use Absinthe.Schema
 
-      query do
-        field :do_search, :search_result do
-          arg :search_term, :string
-        end
-      end
-
       object :person do
         field :name, :string
         field :age, :integer
@@ -293,10 +287,6 @@ defmodule Absinthe.Language.IDLtest do
     end
     it "can be converted to IDL iodata as a schema" do
       assert Absinthe.Language.IDL.to_idl_iodata(UnionSchema |> Absinthe.Language.IDL.to_idl_ast)
-    end
-
-    it "adapts field and argument names" do
-      assert %Absinthe.Language.ObjectDefinition{fields: [%{name: "doSearch", arguments: [%{name: "searchTerm"}]}]} = Absinthe.Language.IDL.to_idl_ast(UnionSchema.__absinthe_type__(:query), UnionSchema)
     end
 
   end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -69,6 +69,8 @@ defmodule Absinthe.Language.IDLtest do
 
       input_object :input_article do
         field :author, :input_user
+        field :publish, :boolean, default_value: true
+        field :tags, list_of(:string), default_value: ~w(a b c)
       end
 
       input_object :input_user do
@@ -89,6 +91,8 @@ defmodule Absinthe.Language.IDLtest do
       equiv_idl = """
       input InputArticle {
         author: InputUser
+        publish: Boolean = true
+        tags: [String] = ["a", "b", "c"]
       }
       """
       {:ok, equiv_idl_ast_doc} = Absinthe.parse(equiv_idl)
@@ -96,6 +100,7 @@ defmodule Absinthe.Language.IDLtest do
       equiv_idl_iodata = Absinthe.Language.IDL.to_idl_iodata(equiv_idl_ast)
 
       idl_ast = InputObjectSchema.__absinthe_type__(:input_article) |> Absinthe.Language.IDL.to_idl_ast(InputObjectSchema)
+
       idl_iodata = Absinthe.Language.IDL.to_idl_iodata(idl_ast)
       assert idl_iodata == equiv_idl_iodata
     end

--- a/test/lib/absinthe/language/idl_test.exs
+++ b/test/lib/absinthe/language/idl_test.exs
@@ -241,6 +241,12 @@ defmodule Absinthe.Language.IDLtest do
     defmodule UnionSchema do
       use Absinthe.Schema
 
+      query do
+        field :do_search, :search_result do
+          arg :search_term, :string
+        end
+      end
+
       object :person do
         field :name, :string
         field :age, :integer
@@ -287,6 +293,10 @@ defmodule Absinthe.Language.IDLtest do
     end
     it "can be converted to IDL iodata as a schema" do
       assert Absinthe.Language.IDL.to_idl_iodata(UnionSchema |> Absinthe.Language.IDL.to_idl_ast)
+    end
+
+    it "adapts field and argument names" do
+      assert %Absinthe.Language.ObjectDefinition{fields: [%{name: "doSearch", arguments: [%{name: "searchTerm"}]}]} = Absinthe.Language.IDL.to_idl_ast(UnionSchema.__absinthe_type__(:query), UnionSchema)
     end
 
   end


### PR DESCRIPTION
This is builds the foundation for conversions between schema types and their AST representations (eg, GraphQL IDL AST) -- and the eventual output of the raw IDL to the filesystem (eg, as `schema.graphql` is done for Relay in the JavaScript implementation).

There are follow-on plans in the opposite direction (IDL -> Schema, at least via static generation) that will be built later on top of these features.

## Progress 

Progress per type/concern, showing stats of (schema type -> IDL AST -> IDL iodata):

- [x] Object type
  - [x] Basic generation
  - [x] Fields
    - [x] Basic generation
    - [x] Arguments
      - [x] Basic
      - [x] NonNull
      - [x] List
  - [x] Declared interfaces (eg, _implements_)
- [x] Input Object type
  - [x] Basic 
  - [x] Defaults
    - [x] Scalars
    - [x] Lists
    - [x] Enum values
    - [x] Objects
- [x] Enum type
- [x] Union type