### PR TITLE
Prevent Utils.camelize from stripping leading underscores

### DIFF
--- a/lib/absinthe/utils.ex
+++ b/lib/absinthe/utils.ex
@@ -16,6 +16,8 @@ defmodule Absinthe.Utils do
   "__FooBar"
   iex> camelize("__foo")
   "__Foo"
+  iex> camelize("_foo")
+  "_Foo"
   ```
 
   With a lowercase first letter:
@@ -28,12 +30,15 @@ defmodule Absinthe.Utils do
   "__fooBar"
   iex> camelize("__foo", lower: true)
   "__foo"
+  iex> camelize("_foo", lower: true)
+  "_foo"
+
   ```
   """
   @spec camelize(binary, Keyword.t) :: binary
   def camelize(word, opts \\ [])
-  def camelize("__" <> word, opts) do
-    "__" <> camelize(word, opts)
+  def camelize("_" <> word, opts) do
+    "_" <> camelize(word, opts)
   end
   def camelize(word, opts) do
     case opts |> Enum.into(%{}) do

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -309,6 +309,17 @@ defmodule AbsintheTest do
 
   end
 
+  describe "an alias with an underscore" do
+
+    @query """
+    { _thing123:thing(id: "foo") { name } }
+    """
+    it "is returned intact" do
+      assert {:ok, %{data: %{"_thing123" => %{"name" => "Foo"}}}} == run(@query)
+    end
+
+  end
+
   defp run(query, options \\ []) do
     query
     |> Absinthe.run(Things, options)


### PR DESCRIPTION
This prevents the stripping of leading underscores from during document adaptation.

Came to light due to Relay's habit of using single underscore prefixed aliases.

`_foo123` now gets properly returned as `_foo123` vs `foo123`.