### PR TITLE
Fix bug where Union resolve_type was missing an alias

### DIFF
--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -35,7 +35,7 @@ defmodule Absinthe.Type.Union do
 
   use Absinthe.Introspection.Kind
 
-  alias Absinthe.Type
+  alias Absinthe.{Schema, Type}
 
   @type t :: %{name: binary,
                description: binary,


### PR DESCRIPTION
It was using `Schema.lookup_type` without the required alias in place.