### PR TITLE
Allow source lookup from documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Absinthe.Mixfile do
      files: ["lib", "src", "priv", "mix.exs", "README*"],
      maintainers: ["Bruce Williams", "Ben Wilson"],
      licenses: ["BSD"],
-     links: %{github: "https://github.com/CargoSense/absinthe"}]
+     links: %{github: "https://github.com/absinthe-graphql/absinthe"}]
   end
 
   # Specifies which paths to compile per environment.

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Absinthe.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package,
+     source_url: "https://github.com/absinthe-graphql/absinthe",
      docs: [source_ref: "v#{@version}", main: "Absinthe"],
      deps: deps
     ]


### PR DESCRIPTION
This adds the source_url setting to the project's mix.exs.

While testing locally, I realized there is no tag for the latest release. This will generate broken links from hex, so I think it's a good idea to create a release for the 1.1.3.