### PR TITLE
Fix merging of fragments with abstract type conditions

### DIFF
--- a/lib/absinthe/execution/resolution/selection_set.ex
+++ b/lib/absinthe/execution/resolution/selection_set.ex
@@ -91,7 +91,7 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.SelectionSet do
       %{__struct__: type_name} when type_name in [Type.Union, Type.Interface] ->
         resolved = Execution.concrete_type(this_type, target, execution)
         if condition_type do
-          if Type.equal?(resolved, condition_type), do: resolved
+          if Type.equal?(this_type, condition_type) || Type.equal?(resolved, condition_type), do: resolved
         else
           resolved
         end

--- a/test/lib/absinthe/execution/fragment_spread_test.exs
+++ b/test/lib/absinthe/execution/fragment_spread_test.exs
@@ -1,0 +1,25 @@
+defmodule Absinthe.Execution.FragmentSpreadTest do
+  use ExSpec, async: true
+
+  @query """
+  query AbstractFragmentSpread {
+    firstSearchResult {
+      ...F0
+    }
+  }
+
+  fragment F0 on SearchResult {
+    ...F1
+    __typename
+  }
+
+  fragment F1 on Person {
+    age
+  }
+  """
+
+  it "spreads fragments with abstract target" do
+    assert {:ok, %{data: %{"firstSearchResult" => %{"__typename" => "Person", "age" => 35}}}} == Absinthe.run(@query, ContactSchema)
+  end
+
+end


### PR DESCRIPTION
This fixes a bug where a fragment with an abstract type condition (eg, Union or Interface) isn't correctly applied.

For example, with schema:

```elixir
query do
  field :first_search_result, :search_result do
    # ...
  end
end

union :search_result do
  types: [:business, :person]
end

object :business do
  # ...
  field :employee_count, :integer
end

object :person do
  # ...
  field :age, :integer
end
```

The following query would return `{}` for `firstSearchResult`, as application of fragment `F0` didn't pass an equality check that dependent on _only_ checking the concrete type of the current source object (eg, the person or business):

```
  query AbstractFragmentSpread {
    firstSearchResult {
      ...F0
    }
  }

  fragment F0 on SearchResult {
    ...F1
    __typename
  }

  fragment F1 on Person {
    age
  }
```