### PR TITLE
More reserved word support

### DIFF
--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -11,7 +11,7 @@ Nonterminals
   OperationType Name NameWithoutOn VariableDefinitions VariableDefinition Directives Directive
   Field Alias Arguments ArgumentList Argument
   FragmentSpread FragmentName InlineFragment
-  VariableDefinitionList Variable DefaultValue Identifier
+  VariableDefinitionList Variable DefaultValue NameWithoutOn
   Type TypeCondition NamedTypeList NamedType ListType NonNullType
   Value EnumValue ListValue Values ObjectValue ObjectFields ObjectField.
 
@@ -113,6 +113,8 @@ Directives -> Directive : ['$1'].
 Directives -> Directive Directives : ['$1'|'$2'].
 Directive -> '@' NameWithoutOn : build_ast_node('Directive', #{name => extract_binary('$2')}, #{'start_line' => extract_line('$1')}).
 Directive -> '@' NameWithoutOn Arguments : build_ast_node('Directive', #{name => extract_binary('$2'), 'arguments' => '$3'}, #{'start_line' => extract_line('$1')}).
+Directive -> '@' 'on' : build_ast_node('Directive', #{name => extract_binary('$2')}, #{'start_line' => extract_line('$1')}).
+Directive -> '@' 'on' Arguments : build_ast_node('Directive', #{name => extract_binary('$2'), 'arguments' => '$3'}, #{'start_line' => extract_line('$1')}).
 
 NameWithoutOn -> 'name' : '$1'.
 NameWithoutOn -> 'query' : extract_binary('$1').

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -11,7 +11,7 @@ Nonterminals
   OperationType Name NameWithoutOn VariableDefinitions VariableDefinition Directives Directive
   Field Alias Arguments ArgumentList Argument
   FragmentSpread FragmentName InlineFragment
-  VariableDefinitionList Variable DefaultValue
+  VariableDefinitionList Variable DefaultValue Identifier
   Type TypeCondition NamedTypeList NamedType ListType NonNullType
   Value EnumValue ListValue Values ObjectValue ObjectFields ObjectField.
 
@@ -111,10 +111,8 @@ Argument -> 'on' ':' Value : build_ast_node('Argument', #{name => extract_binary
 
 Directives -> Directive : ['$1'].
 Directives -> Directive Directives : ['$1'|'$2'].
-Directive -> '@' Name : build_ast_node('Directive', #{name => extract_binary('$2')}, #{'start_line' => extract_line('$1')}).
-Directive -> '@' Name Arguments : build_ast_node('Directive', #{name => extract_binary('$2'), 'arguments' => '$3'}, #{'start_line' => extract_line('$1')}).
-Directive -> '@' 'directive' : build_ast_node('Directive', #{name => extract_binary('$2')}, #{'start_line' => extract_line('$1')}).
-Directive -> '@' 'directive' Arguments : build_ast_node('Directive', #{name => extract_binary('$2'), 'arguments' => '$3'}, #{'start_line' => extract_line('$1')}).
+Directive -> '@' NameWithoutOn : build_ast_node('Directive', #{name => extract_binary('$2')}, #{'start_line' => extract_line('$1')}).
+Directive -> '@' NameWithoutOn Arguments : build_ast_node('Directive', #{name => extract_binary('$2'), 'arguments' => '$3'}, #{'start_line' => extract_line('$1')}).
 
 NameWithoutOn -> 'name' : '$1'.
 NameWithoutOn -> 'query' : extract_binary('$1').
@@ -130,6 +128,7 @@ NameWithoutOn -> 'enum' : extract_binary('$1').
 NameWithoutOn -> 'input' : extract_binary('$1').
 NameWithoutOn -> 'extend' : extract_binary('$1').
 NameWithoutOn -> 'null' : extract_binary('$1').
+NameWithoutOn -> 'directive' : extract_binary('$1').
 
 Name -> NameWithoutOn : '$1'.
 Name -> 'on' : extract_binary('$1').

--- a/test/lib/absinthe/parser_test.exs
+++ b/test/lib/absinthe/parser_test.exs
@@ -49,5 +49,18 @@ defmodule Absinthe.ParserTest do
     assert {:ok, _} = Absinthe.parse(@query)
   end
 
+  @query """
+  query Something($enum: String!) {
+    doSomething(directive: "thing") {
+      id
+    }
+    doSomething(directive: "thing") @schema(object: $enum) {
+      id
+    }
+  }
+  """
+  it "can parse identifiers in different contexts" do
+    assert {:ok, _} = Absinthe.parse(@query)
+  end
 
 end

--- a/test/lib/absinthe/parser_test.exs
+++ b/test/lib/absinthe/parser_test.exs
@@ -63,4 +63,18 @@ defmodule Absinthe.ParserTest do
     assert {:ok, _} = Absinthe.parse(@query)
   end
 
+  @query """
+  query Something($on: String!) {
+    on(on: "thing") {
+      id
+    }
+    doSomething(on: "thing") @on(on: $on) {
+      id
+    }
+  }
+  """
+  it "can parse 'on' in different contexts" do
+    assert {:ok, _} = Absinthe.parse(@query)
+  end
+
 end


### PR DESCRIPTION
In a number of contexts, reserved words from the lexer need to be handled manually in the parser to support their ability to be used elsewhere (eg, `directive` as the name for an argument). This branch fixes a number of cases brought up by tests imported from graphql-js, which tends to use these words (and helps shake out bugs).

Note: The parser could use another look at some point by someone to help cleanup terminals; I'm unhappy about the `NameWithoutOn` rule specifically that's used to support these -- it seems like a simpler approach is probably possible, and may generate a faster/simpler parser.