### PR TITLE
Include root `subscriptionType` in built-in introspection query

### DIFF
--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -26,6 +26,13 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
           {:ok, Absinthe.Schema.lookup_type(schema, :mutation)}
       end
 
+    field :subscription_type,
+      type: :__type,
+      resolve: fn
+        _, %{schema: schema} ->
+          {:ok, Absinthe.Schema.lookup_type(schema, :subscription)}
+      end
+
     field :directives,
       type: list_of(:__directive),
       resolve: fn

--- a/test/lib/absinthe/introspection_test.exs
+++ b/test/lib/absinthe/introspection_test.exs
@@ -40,7 +40,7 @@ defmodule Absinthe.IntrospectionTest do
         ContactSchema
       )
       names = types |> Enum.map(&(&1["name"])) |> Enum.sort
-      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType __Schema __Directive __DirectiveLocation __EnumValue __Field __InputValue __Type) |> Enum.sort
+      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType RootSubscriptionType __Schema __Directive __DirectiveLocation __EnumValue __Field __InputValue __Type) |> Enum.sort
       assert expected == names
     end
 
@@ -52,6 +52,11 @@ defmodule Absinthe.IntrospectionTest do
     it "can use __schema to get the mutation type" do
       result = "{ __schema { mutationType { name kind } } }" |> Absinthe.run(ContactSchema)
       assert_result {:ok, %{data: %{"__schema" => %{"mutationType" => %{"name" => "RootMutationType", "kind" => "OBJECT"}}}}}, result
+    end
+
+    it "can use __schema to get the subscription type" do
+      result = "{ __schema { subscriptionType { name kind } } }" |> Absinthe.run(ContactSchema)
+      assert_result {:ok, %{data: %{"__schema" => %{"subscriptionType" => %{"name" => "RootSubscriptionType", "kind" => "OBJECT"}}}}}, result
     end
 
     it "can use __schema to get the directives" do

--- a/test/support/contact_schema.ex
+++ b/test/support/contact_schema.ex
@@ -63,6 +63,9 @@ defmodule ContactSchema do
 
   end
 
+  subscription do
+  end
+
   input_object :profile_input do
     description "The basic details for a person"
 


### PR DESCRIPTION
The built-in introspection query is used by the mix tasks to generate `schema.(graphql|json)` files, and it should match up with the reference introspection query at https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js

fixes #140