### PR TITLE
Convert Blueprint flags to a map

### DIFF
--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint do
     schema: nil,
     adapter: nil,
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -23,7 +23,7 @@ defmodule Absinthe.Blueprint do
     adapter: nil | Absinthe.Adapter.t,
     # Added by phases
     errors: [Blueprint.Phase.Error.t],
-    flags: [atom]
+    flags: Blueprint.flags_t
   }
 
   @type node_t ::
@@ -36,7 +36,9 @@ defmodule Absinthe.Blueprint do
 
   @type use_t ::
       Blueprint.Document.Fragment.Named.Use.t
-    | Blueprint.Input.Variable.Use.t 
+    | Blueprint.Input.Variable.Use.t
+
+  @type flags_t :: %{atom => module}
 
   defdelegate prewalk(blueprint, fun), to: Absinthe.Blueprint.Transform
   defdelegate prewalk(blueprint, acc, fun), to: Absinthe.Blueprint.Transform
@@ -61,6 +63,22 @@ defmodule Absinthe.Blueprint do
   @spec fragment(t, String.t) :: nil | Blueprint.Document.Fragment.Named.t
   def fragment(blueprint, name) do
     Enum.find(blueprint.fragments, &(&1.name == name))
+  end
+
+  @doc """
+  Add a flag to a node.
+  """
+  @spec put_flag(node_t, atom, module) :: node_t
+  def put_flag(node, flag, mod) do
+    update_in(node.flags, &Map.put(&1, flag, mod))
+  end
+
+  @doc """
+  Determine whether a flag has been set on a node.
+  """
+  @spec flagged?(node_t, atom) :: boolean
+  def flagged?(node, flag) do
+    Map.has_key?(node.flags, flag)
   end
 
 end

--- a/lib/absinthe/blueprint/directive.ex
+++ b/lib/absinthe/blueprint/directive.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Directive do
     source_location: nil,
     # Added by phases
     schema_node: nil,
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -19,7 +19,7 @@ defmodule Absinthe.Blueprint.Directive do
     arguments: [Blueprint.Input.Argument.t],
     source_location: nil | Blueprint.Document.SourceLocation.t,
     schema_node: nil | Absinthe.Type.Directive.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/document/field.ex
+++ b/lib/absinthe/blueprint/document/field.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Document.Field do
     arguments: [],
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
     source_location: nil,
     type_conditions: [],
@@ -23,7 +23,7 @@ defmodule Absinthe.Blueprint.Document.Field do
     selections: [Blueprint.Document.selection_t],
     arguments: [Blueprint.Input.Argument.t],
     directives: [Blueprint.Directive.t],
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Phase.Error.t],
     fields: [Blueprint.Document.Field.t],
     source_location: nil | Blueprint.Document.SourceLocation.t,

--- a/lib/absinthe/blueprint/document/fragment/inline.ex
+++ b/lib/absinthe/blueprint/document/fragment/inline.ex
@@ -11,14 +11,14 @@ defmodule Absinthe.Blueprint.Document.Fragment.Inline do
     # Populated by phases
     schema_node: nil,
     fields: [],
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     directives: [Blueprint.Directive.t],
     errors: [Absinthe.Phase.Error.t],
-    flags: [atom],
+    flags: Blueprint.flags_t,
     fields: [Blueprint.Document.Field.t],
     selections: [Blueprint.Document.selection_t],
     schema_node: nil | Absinthe.Type.t,

--- a/lib/absinthe/blueprint/document/fragment/named.ex
+++ b/lib/absinthe/blueprint/document/fragment/named.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Blueprint.Document.Fragment.Named do
     # Populated by phases
     schema_node: nil,
     fields: [],
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -25,7 +25,7 @@ defmodule Absinthe.Blueprint.Document.Fragment.Named do
     selections: [Blueprint.Document.selection_t],
     schema_node: nil | Absinthe.Type.t,
     source_location: nil | Blueprint.Document.SourceLocation.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     type_condition: Blueprint.TypeReference.Name.t,
   }
 

--- a/lib/absinthe/blueprint/document/fragment/spread.ex
+++ b/lib/absinthe/blueprint/document/fragment/spread.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Blueprint.Document.Fragment.Spread do
     directives: [],
     source_location: nil,
     # Populated by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -16,7 +16,7 @@ defmodule Absinthe.Blueprint.Document.Fragment.Spread do
     directives: [Blueprint.Document.Directive.t],
     errors: [Absinthe.Phase.Error.t],
     name: String.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     source_location: nil | Blueprint.Document.SourceLocation.t,
   }
 

--- a/lib/absinthe/blueprint/document/operation.ex
+++ b/lib/absinthe/blueprint/document/operation.ex
@@ -14,7 +14,7 @@ defmodule Absinthe.Blueprint.Document.Operation do
     fragment_uses: [],
     source_location: nil,
     # Populated by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     provided_values: %{},
     fields: [],
@@ -33,7 +33,7 @@ defmodule Absinthe.Blueprint.Document.Operation do
     source_location: nil | Blueprint.Document.SourceLocation.t,
     schema_node: nil | Absinthe.Type.Object.t,
     provided_values: %{String.t => nil | Blueprint.Input.t},
-    flags: [atom],
+    flags: Blueprint.flags_t,
     fields: [Blueprint.Document.Field.t],
     errors: [Absinthe.Phase.Error.t],
   }

--- a/lib/absinthe/blueprint/document/variable_definition.ex
+++ b/lib/absinthe/blueprint/document/variable_definition.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Blueprint.Document.VariableDefinition do
     default_value: nil,
     source_location: nil,
     # Added by phases
-    flags: [],
+    flags: %{},
     provided_value: nil,
     errors: [],
     schema_type: nil,
@@ -22,7 +22,7 @@ defmodule Absinthe.Blueprint.Document.VariableDefinition do
     source_location: nil | Blueprint.Document.SourceLocation.t,
     provided_value: nil | Blueprint.Input.t,
     errors: [Absinthe.Phase.Error.t],
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_type: Type.t,
   }
 

--- a/lib/absinthe/blueprint/input/argument.ex
+++ b/lib/absinthe/blueprint/input/argument.ex
@@ -11,7 +11,7 @@ defmodule Absinthe.Blueprint.Input.Argument do
     schema_node: nil,
     normalized_value: nil, # Value after having variable values inlined
     data_value: nil, # Value converted to native elixir value
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -22,7 +22,7 @@ defmodule Absinthe.Blueprint.Input.Argument do
     schema_node: nil | Absinthe.Type.Argument.t,
     normalized_value: Blueprint.Input.t,
     data_value: any,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/input/boolean.ex
+++ b/lib/absinthe/blueprint/input/boolean.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.Boolean do
     :value,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     value: true | false,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_node: nil | Absinthe.Type.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Phase.Error.t],

--- a/lib/absinthe/blueprint/input/enum.ex
+++ b/lib/absinthe/blueprint/input/enum.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.Enum do
     :value,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     value: String.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_node: nil | Absinthe.Type.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Phase.Error.t],

--- a/lib/absinthe/blueprint/input/field.ex
+++ b/lib/absinthe/blueprint/input/field.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Blueprint.Input.Field do
     :name,
     :value,
     # Added by phases
-    flags: [],
+    flags: %{},
     source_location: nil,
     schema_node: nil,
     errors: [],
@@ -16,7 +16,7 @@ defmodule Absinthe.Blueprint.Input.Field do
   @type t :: %__MODULE__{
     name: String.t,
     value: Blueprint.Input.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_node: nil | Type.Field.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Absinthe.Phase.Error.t],

--- a/lib/absinthe/blueprint/input/float.ex
+++ b/lib/absinthe/blueprint/input/float.ex
@@ -5,14 +5,14 @@ defmodule Absinthe.Blueprint.Input.Float do
     :value,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     value: float,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     source_location: Blueprint.Document.SourceLocation.t,
     schema_node: nil | Absinthe.Type.t,
     errors: [Absinthe.Phase.Error.t],

--- a/lib/absinthe/blueprint/input/integer.ex
+++ b/lib/absinthe/blueprint/input/integer.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.Integer do
     :value,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     value: integer,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     source_location: Blueprint.Document.SourceLocation.t,
     schema_node: nil | Absinthe.Type.t,
     errors: [Phase.Error.t],

--- a/lib/absinthe/blueprint/input/list.ex
+++ b/lib/absinthe/blueprint/input/list.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.List do
     :values,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     values: [Blueprint.Input.t],
-    flags: [],
+    flags: Blueprint.flags_t,
     schema_node: nil | Absinthe.Type.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Phase.Error.t],

--- a/lib/absinthe/blueprint/input/object.ex
+++ b/lib/absinthe/blueprint/input/object.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.Object do
     :source_location,
     fields: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     fields: [Blueprint.Input.Field.t],
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_node: nil | Absinthe.Type.InputObject.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Absinthe.Phase.Error.t],

--- a/lib/absinthe/blueprint/input/string.ex
+++ b/lib/absinthe/blueprint/input/string.ex
@@ -7,14 +7,14 @@ defmodule Absinthe.Blueprint.Input.String do
     :value,
     :source_location,
     # Added by phases
-    flags: [],
+    flags: %{},
     schema_node: nil,
     errors: [],
   ]
 
   @type t :: %__MODULE__{
     value: String.t,
-    flags: [atom],
+    flags: Blueprint.flags_t,
     schema_node: nil | Absinthe.Type.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Phase.Error.t],

--- a/lib/absinthe/blueprint/input/variable.ex
+++ b/lib/absinthe/blueprint/input/variable.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Blueprint.Input.Variable do
     :name,
     source_location: nil,
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -16,7 +16,7 @@ defmodule Absinthe.Blueprint.Input.Variable do
     name: String.t,
     source_location: nil | Blueprint.Document.SourceLocation.t,
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/enum_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_type_definition.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
     values: [],
     directives: [],
     # Added by phases,
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
     values: [String.t],
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/enum_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_value_definition.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Blueprint.Schema.EnumValueDefinition do
     directives: [],
     source_location: nil,
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -19,7 +19,7 @@ defmodule Absinthe.Blueprint.Schema.EnumValueDefinition do
     directives: [Blueprint.Directive.t],
     source_location: nil | Blueprint.Document.SourceLocation.t,
     # Added by phases
-    flags: [],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/field_definition.ex
+++ b/lib/absinthe/blueprint/schema/field_definition.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Schema.FieldDefinition do
     arguments: [],
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -21,7 +21,7 @@ defmodule Absinthe.Blueprint.Schema.FieldDefinition do
     type: Blueprint.TypeReference.t,
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t]
   }
 

--- a/lib/absinthe/blueprint/schema/input_object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/input_object_type_definition.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Schema.InputObjectTypeDefinition do
     fields: [],
     directives: [],
     # Added by phases,
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -20,7 +20,7 @@ defmodule Absinthe.Blueprint.Schema.InputObjectTypeDefinition do
     fields: [Blueprint.Schema.InputValueDefinition.t],
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/input_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/input_value_definition.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Blueprint.Schema.InputValueDefinition do
     default_value: nil,
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -25,7 +25,7 @@ defmodule Absinthe.Blueprint.Schema.InputValueDefinition do
     # The struct module of the parent
     placement: :argument_definition | :input_field_definition,
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/interface_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/interface_type_definition.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
     fields: [],
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
     fields: [Blueprint.Schema.FieldDefinition.t],
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/object_type_definition.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
     fields: [],
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -21,7 +21,7 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
     interfaces: [String.t],
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/scalar_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/scalar_type_definition.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
     description: nil,
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
     description: nil | String.t,
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/schema_definition.ex
+++ b/lib/absinthe/blueprint/schema/schema_definition.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Blueprint.Schema.SchemaDefinition do
     fields: [],
     directives: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -16,7 +16,7 @@ defmodule Absinthe.Blueprint.Schema.SchemaDefinition do
     fields: [Blueprint.Schema.FieldDefinition.t],
     directives: [Blueprint.Directive.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/blueprint/schema/union_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/union_type_definition.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
     directives: [],
     types: [],
     # Added by phases
-    flags: [],
+    flags: %{},
     errors: [],
   ]
 
@@ -19,7 +19,7 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
     directives: [Blueprint.Directive.t],
     types: [Blueprint.TypeReference.Name.t],
     # Added by phases
-    flags: [atom],
+    flags: Blueprint.flags_t,
     errors: [Absinthe.Phase.Error.t],
   }
 

--- a/lib/absinthe/phase.ex
+++ b/lib/absinthe/phase.ex
@@ -12,6 +12,40 @@ defmodule Absinthe.Phase do
       def run(input), do: {:ok, input}
 
       defoverridable run: 1
+
+      @spec flag_invalid(Blueprint.node_t) :: Blueprint.node_t
+      def flag_invalid(%{flags: _} = node) do
+        Absinthe.Blueprint.put_flag(node, :invalid, __MODULE__)
+      end
+
+      @spec flag_invalid(Blueprint.node_t, atom) :: Blueprint.node_t
+      def flag_invalid(%{flags: _} = node, flag) do
+        flagging = %{:invalid => __MODULE__, flag => __MODULE__}
+        update_in(node.flags, &Map.merge(&1, flagging))
+      end
+
+      def put_flag(%{flags: _} = node, flag) do
+        Absinthe.Blueprint.put_flag(node, flag, __MODULE__)
+      end
+
+      @spec put_error(Blueprint.node_t, Phase.Error.t) :: Blueprint.node_t
+      def put_error(%{errors: _} = node, error) do
+        update_in(node.errors, &[error | &1])
+      end
+
+      def any_invalid?(nodes) do
+        Enum.any?(nodes, &match?(%{flags: %{invalid: _}}, &1))
+      end
+
+      def inherit_invalid(%{flags: _} = node, children, add_flag) do
+        case any_invalid?(children) do
+          true ->
+            flag_invalid(node, add_flag)
+          false ->
+            node
+        end
+      end
+
     end
   end
 

--- a/lib/absinthe/phase/document/arguments/data.ex
+++ b/lib/absinthe/phase/document/arguments/data.ex
@@ -23,6 +23,7 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
   """
 
   alias Absinthe.{Blueprint, Type}
+  use Absinthe.Phase
 
   def run(input) do
     result = Blueprint.prewalk(input, &(handle_node(&1, input.adapter)))
@@ -92,9 +93,9 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
               name: schema_field.name |> adapter.to_external_name(:field),
               value: nil,
               schema_node: schema_field,
-              source_location: node.source_location,
-              flags: [:invalid, :missing]
+              source_location: node.source_location
             }
+            |> flag_invalid(:missing)
           ]
         end
       _ ->
@@ -158,22 +159,6 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
     {:error, node}
   end
 
-  @spec any_invalid?([Blueprint.Input.t]) :: boolean
-  defp any_invalid?(inputs) do
-    Enum.any?(inputs, &(Enum.member?(&1.flags, :invalid)))
-  end
-
-  defp flag_invalid(node, flag) do
-    %{node | flags: [flag | with_invalid(node.flags)]}
-  end
-  defp with_invalid(flags) do
-    if Enum.member?(flags, :invalid) do
-      flags
-    else
-      [:invalid | flags]
-    end
-  end
-
   @spec unwrap_non_null(Type.NonNull.t | Type.t) :: Type.t
   defp unwrap_non_null(%Type.NonNull{of_type: type}) do
     type
@@ -195,9 +180,9 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
               literal_value: nil,
               data_value: nil,
               schema_node: schema_argument,
-              source_location: node.source_location,
-              flags: [:invalid, :missing]
+              source_location: node.source_location
             }
+            |> flag_invalid(:missing)
           ]
         end
       _ ->

--- a/lib/absinthe/phase/document/flatten.ex
+++ b/lib/absinthe/phase/document/flatten.ex
@@ -92,12 +92,8 @@ defmodule Absinthe.Phase.Document.Flatten do
     fields
   end
 
-  @nope [:invalid, :skip]
-  defp include?(%{flags: flags}) do
-    !Enum.any?(@nope, &(&1 in flags))
-  end
-  defp include?(_) do
-    true
-  end
+  defp include?(%{flags: %{invalid: _}}), do: false
+  defp include?(%{flags: %{skip: _}}), do: false
+  defp include?(_), do: true
 
 end

--- a/lib/absinthe/phase/document/validation/known_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/known_argument_names.ex
@@ -21,16 +21,13 @@ defmodule Absinthe.Phase.Document.Validation.KnownArgumentNames do
     {:ok, result}
   end
 
-
   # Find any arguments that have been marked as invalid due to a missing
   # associated schema node.
   @spec handle_node(Blueprint.node_t) :: Blueprint.node_t
   defp handle_node(%Blueprint.Input.Argument{schema_node: nil} = node) do
-    %{
-      node |
-      flags: [:invalid, :no_schema_node] ++ node.flags,
-      errors: [error(node) | node.errors]
-    }
+    node
+    |> flag_invalid(:no_schema_node)
+    |> put_error(error(node))
   end
   defp handle_node(node) do
     node

--- a/lib/absinthe/phase/document/validation/unique_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_argument_names.ex
@@ -28,7 +28,6 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   defp handle_node(%argument_host{} = node) when argument_host in @argument_hosts do
     arguments = Enum.map(node.arguments, &(process(&1, node.arguments)))
     %{node | arguments: arguments}
-    |> inherit_invalid(arguments, :duplicate_arguments)
   end
   defp handle_node(node) do
     node
@@ -46,11 +45,9 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
     argument
   end
   defp check_duplicates(argument, _multiple) do
-    %{
-      argument |
-      flags: [:invalid, :duplicate_name] ++ argument.flags,
-      errors: [error(argument) | argument.errors]
-    }
+    argument
+    |> flag_invalid(:duplicate_name)
+    |> put_error(error(argument))
   end
 
   # Generate an error for a duplicate argument.
@@ -58,9 +55,17 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   defp error(node) do
     Phase.Error.new(
       __MODULE__,
-      "Duplicate argument name.",
+      error_message,
       node.source_location
     )
+  end
+
+  @doc """
+  Generate the error message.
+  """
+  @spec error_message :: String.t
+  def error_message do
+    "Duplicate argument name."
   end
 
 end

--- a/lib/absinthe/phase/document/validation/unique_input_field_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_input_field_names.ex
@@ -22,7 +22,6 @@ defmodule Absinthe.Phase.Document.Validation.UniqueInputFieldNames do
   defp handle_node(%Blueprint.Input.Object{} = node) do
     fields = Enum.map(node.fields, &(process(&1, node.fields)))
     %{node | fields: fields}
-    |> inherit_invalid(fields, :duplicate_fields)
   end
   defp handle_node(node) do
     node
@@ -40,11 +39,9 @@ defmodule Absinthe.Phase.Document.Validation.UniqueInputFieldNames do
     field
   end
   defp check_duplicates(field, _multiple) do
-    %{
-      field |
-      flags: [:invalid, :duplicate_name] ++ field.flags,
-      errors: [error(field) | field.errors]
-    }
+    field
+    |> flag_invalid(:duplicate_name)
+    |> put_error(error(field))
   end
 
   # Generate an error for an input field

--- a/lib/absinthe/phase/validation.ex
+++ b/lib/absinthe/phase/validation.ex
@@ -12,38 +12,12 @@ defmodule Absinthe.Phase.Validation do
 
     @spec any_invalid?([Blueprint.node_t]) :: boolean
     def any_invalid?(nodes) do
-      nodes
-      |> Enum.any?(&(Enum.member?(&1.flags, :invalid)))
-    end
-
-    @doc """
-    If any of the provided sources are invalid, flag the node as
-    invalid (and any other extra, dictated flags)
-    """
-    @spec inherit_invalid(Blueprint.node_t, [Blueprint.node_t], atom | [atom]) :: Blueprint.node_t
-    @spec inherit_invalid(Blueprint.node_t, [Blueprint.node_t]) :: Blueprint.node_t
-    def inherit_invalid(node, sources, extras \\ []) do
-      if any_invalid?(sources) do
-        %{node | flags: [:invalid] ++ List.wrap(extras) ++ node.flags}
-      else
-        node
-      end
-    end
-
-    @spec put_error(Blueprint.node_t, Phase.Error.t) :: Blueprint.node_t
-    def put_error(%{errors: errors} = node, error) do
-      %{node | errors: [error | errors]}
-    end
-
-    def flag_invalid(node, flag) do
-      %{node | flags: [flag | with_invalid(node.flags)]}
-    end
-    def with_invalid(flags) do
-      if Enum.member?(flags, :invalid) do
-        flags
-      else
-        [:invalid | flags]
-      end
+      Enum.any?(nodes, fn
+        %{flags: %{invalid: _}} ->
+          true
+        _ ->
+          false
+      end)
     end
 
   end

--- a/lib/absinthe/phase/validation/known_directives.ex
+++ b/lib/absinthe/phase/validation/known_directives.ex
@@ -17,7 +17,6 @@ defmodule Absinthe.Phase.Validation.KnownDirectives do
   defp handle_node(%Blueprint.Directive{schema_node: nil} = node) do
     node
     |> put_error(error_unknown(node))
-    |> flag_invalid(:no_schema_node)
   end
   defp handle_node(%Blueprint.Directive{} = node) do
     node
@@ -26,8 +25,8 @@ defmodule Absinthe.Phase.Validation.KnownDirectives do
     node
   end
   defp handle_node(%{directives: _} = node) do
-    node = check_directives(node)
-    inherit_invalid(node, node.directives, :bad_directive)
+    check_directives(node)
+    |> inherit_invalid(node.directives, :bad_directive)
   end
   defp handle_node(node) do
     node

--- a/lib/absinthe/type/built_ins/directives.ex
+++ b/lib/absinthe/type/built_ins/directives.ex
@@ -2,6 +2,7 @@ defmodule Absinthe.Type.BuiltIns.Directives do
   @moduledoc false
 
   use Absinthe.Schema.Notation
+  alias Absinthe.Blueprint
 
   directive :include do
     description """
@@ -14,9 +15,9 @@ defmodule Absinthe.Type.BuiltIns.Directives do
 
     expand fn
       %{if: true}, node ->
-        %{node | flags: [:include | node.flags]}
+        Blueprint.put_flag(node, :include, __MODULE__)
       _, node ->
-        %{node | flags: [:skip | node.flags]}
+        Blueprint.put_flag(node, :skip, __MODULE__)
     end
 
   end
@@ -32,9 +33,9 @@ defmodule Absinthe.Type.BuiltIns.Directives do
 
     expand fn
       %{if: true}, node ->
-        %{node | flags: [:skip | node.flags]}
+        Blueprint.put_flag(node, :skip, __MODULE__)
       _, node ->
-        %{node | flags: [:include | node.flags]}
+        Blueprint.put_flag(node, :include, __MODULE__)
     end
 
   end

--- a/test/lib/absinthe/phase/document/directives_test.exs
+++ b/test/lib/absinthe/phase/document/directives_test.exs
@@ -45,13 +45,13 @@ defmodule Absinthe.Phase.Document.DirectivesTest do
     it "adds a :skip flag" do
       {:ok, result} = input(@query, %{"cats" => false})
       node = named(result, Blueprint.Document.Field, "categories")
-      assert Enum.member?(node.flags, :skip)
+      assert Blueprint.flagged?(node, :skip)
     end
 
     it "adds an :include flag" do
       {:ok, result} = input(@query, %{"cats" => true})
       node = named(result, Blueprint.Document.Field, "categories")
-      assert Enum.member?(node.flags, :include)
+      assert Blueprint.flagged?(node, :include)
     end
 
   end

--- a/test/lib/absinthe/phase/document/validation/unique_argument_names_test.exs
+++ b/test/lib/absinthe/phase/document/validation/unique_argument_names_test.exs
@@ -12,7 +12,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNamesTest do
     List.wrap(values)
     |> Enum.map(fn
       value ->
-        bad_value(Blueprint.Input.Argument, @message, line, literal_value_check(name, value))
+        bad_value(Blueprint.Input.Argument, @rule.error_message, line, literal_value_check(name, value))
     end)
   end
 

--- a/test/support/harness/validation.ex
+++ b/test/support/harness/validation.ex
@@ -25,7 +25,7 @@ defmodule Support.Harness.Validation do
             assert !Enum.empty?(pairs), "No errors were found.\n#{expectation_banner}"
             matched = Enum.any?(pairs, fn
               {%str{} = node, %Phase.Error{phase: @rule, message: ^message} = err} when str == node_kind ->
-                if Enum.member?(node.flags, :invalid) && check_fun.(node) do
+                if check_fun.(node) do
                   if !line do
                     true
                   else


### PR DESCRIPTION
This reworks the `Blueprint.node_t` `:flags` from an `[atom]` to an `%{atom => module}` for better matching (and so we can determine where flags were set).