### PR TITLE
coerce enum literals to string types when its a string type

### DIFF
--- a/lib/absinthe/phase/document/arguments/coercion.ex
+++ b/lib/absinthe/phase/document/arguments/coercion.ex
@@ -21,8 +21,21 @@ defmodule Absinthe.Phase.Document.Arguments.Coercion do
     {:ok, node}
   end
 
-  defp coerce_node(%Blueprint.Input.String{schema_node: %Type.Enum{}} = node) do
-    Map.put(node, :__struct__, Blueprint.Input.Enum)
+  defp coerce_node(%Blueprint.Input.String{schema_node: type} = node) do
+    case Type.unwrap(type) do
+      %Type.Enum{} ->
+        Map.put(node, :__struct__, Blueprint.Input.Enum)
+      _ ->
+        node
+    end
+  end
+  defp coerce_node(%Blueprint.Input.Enum{schema_node: type} = node) do
+    case Type.unwrap(type) do
+      %Type.Scalar{} ->
+        Map.put(node, :__struct__, Blueprint.Input.String)
+      _ ->
+        node
+    end
   end
   defp coerce_node(node), do: node
 

--- a/test/support/id_schema.ex
+++ b/test/support/id_schema.ex
@@ -14,8 +14,9 @@ defmodule Absinthe.IdTestSchema do
       args: [
         id: [type: non_null(:id)]
       ],
-      resolve: fn %{id: item_id}, _ ->
-        {:ok, @items[item_id]}
+      resolve: fn
+        %{id: item_id}, _ ->
+          {:ok, @items[item_id]}
       end
 
   end


### PR DESCRIPTION
This exists to fix https://github.com/absinthe-graphql/absinthe/blob/intermediate-representation/test/lib/absinthe_test.exs#L213

Note that the argument `id: foo` does not have quotes around `foo`. Is this a valid test? This branch does the requisite changes to make it pass but it seems wrong to coerce enum literals in this case.

Thoughts? @bruce 