### PR TITLE
Fix argument tests

### DIFF
--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -125,7 +125,10 @@ defmodule Absinthe.Phase.Schema do
     %{node | schema_node: parent_schema_node}
   end
   defp value_with_schema_node(%Blueprint.Input.Object{} = node, parent_schema_node, schema, adapter) do
-    schema_node = Type.expand(parent_schema_node.type, schema)
+    schema_node = case parent_schema_node do
+      %{type: type} -> Type.expand(type, schema)
+      type -> type
+    end
     fields = Enum.map(node.fields, &input_field_with_schema_node(&1, schema_node, schema, adapter))
     %{node | schema_node: schema_node, fields: fields}
   end

--- a/test/lib/absinthe/execution/arguments_test.exs
+++ b/test/lib/absinthe/execution/arguments_test.exs
@@ -3,8 +3,6 @@ defmodule Absinthe.Execution.ArgumentsTest do
 
   import AssertResult
 
-  alias Absinthe.{Pipeline, Phase}
-
   defmodule Schema do
     use Absinthe.Schema
 


### PR DESCRIPTION
This fixes the last argument test failures. The failures were because if you have a list of input objects, list already handles expanding the parent schema node prior to iterating over children. Thus, the clause which handles input objects can't assume that its parent schema node needs expanding.