### PR TITLE
Enforce validation errors skipping resolution

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -146,10 +146,6 @@ defmodule Absinthe do
     defexception message: "execution failed"
   end
 
-  def parse(input) do
-    Absinthe.Phase.Parse.run(input)
-  end
-
   @type result_selection_t :: %{
     String.t =>
         nil

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -213,7 +213,12 @@ defmodule Absinthe do
   @spec run(binary | Absinthe.Language.Source.t | Absinthe.Language.Document.t, Absinthe.Schema.t, run_opts) :: {:ok, result_t} | {:error, any}
   def run(document, schema, options \\ []) do
     pipeline = Absinthe.Pipeline.for_document(schema, Map.new(options))
-    Absinthe.Pipeline.run(document, pipeline)
+    case Absinthe.Pipeline.run(document, pipeline) do
+      {:ok, result, _phases} ->
+        {:ok, result}
+      other ->
+        other
+    end
   end
 
   @doc """

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Blueprint do
     # Added by phases
     flags: %{},
     errors: [],
-    result: nil
+    result: Blueprint.Document.Result.new
   ]
 
   @type t :: %__MODULE__{
@@ -25,7 +25,7 @@ defmodule Absinthe.Blueprint do
     # Added by phases
     errors: [Blueprint.Phase.Error.t],
     flags: Blueprint.flags_t,
-    result: nil | map
+    result: Blueprint.Document.Result.t
   }
 
   @type node_t ::

--- a/lib/absinthe/blueprint/document/operation.ex
+++ b/lib/absinthe/blueprint/document/operation.ex
@@ -17,7 +17,6 @@ defmodule Absinthe.Blueprint.Document.Operation do
     flags: %{},
     schema_node: nil,
     provided_values: %{},
-    resolution: nil,
     fields: [],
     errors: [],
   ]
@@ -34,7 +33,6 @@ defmodule Absinthe.Blueprint.Document.Operation do
     source_location: nil | Blueprint.Document.SourceLocation.t,
     schema_node: nil | Absinthe.Type.Object.t,
     provided_values: %{String.t => nil | Blueprint.Input.t},
-    resolution: nil | Blueprint.Document.Result.Object.t,
     flags: Blueprint.flags_t,
     fields: [Blueprint.Document.Field.t],
     errors: [Absinthe.Phase.Error.t],

--- a/lib/absinthe/blueprint/document/result.ex
+++ b/lib/absinthe/blueprint/document/result.ex
@@ -1,8 +1,23 @@
 defmodule Absinthe.Blueprint.Document.Result do
 
+  alias Absinthe.Phase
   alias __MODULE__
 
-  @type t ::
+  defstruct [
+    validation: [],
+    resolution: nil
+  ]
+
+  def new do
+    %__MODULE__{}
+  end
+
+  @type t :: %__MODULE__ {
+    validation: [Phase.Error.t],
+    resolution: nil | Result.Object.t
+  }
+
+  @type node_t ::
       Result.Object
     | Result.List
     | Result.Leaf

--- a/lib/absinthe/blueprint/document/result/leaf.ex
+++ b/lib/absinthe/blueprint/document/result/leaf.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Blueprint.Document.Result.Leaf do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    value: Blueprint.Document.Result.t,
+    value: Blueprint.Document.Result.node_t,
     errors: [Phase.Error.t],
     flags: [Blueprint.flag_t],
   }

--- a/lib/absinthe/blueprint/document/result/list.ex
+++ b/lib/absinthe/blueprint/document/result/list.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Blueprint.Document.Result.List do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    values: [Blueprint.Document.Result.t],
+    values: [Blueprint.Document.Result.node_t],
     errors: [Phase.Error.t],
     flags: [Blueprint.flag_t],
   }

--- a/lib/absinthe/blueprint/document/result/object.ex
+++ b/lib/absinthe/blueprint/document/result/object.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Blueprint.Document.Result.Object do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    fields: [Blueprint.Document.Result.t],
+    fields: [Blueprint.Document.Result.node_t],
     errors: [Phase.Error.t],
     flags: [Blueprint.flag_t]
   }

--- a/lib/absinthe/phase.ex
+++ b/lib/absinthe/phase.ex
@@ -1,17 +1,18 @@
 defmodule Absinthe.Phase do
 
   @type t :: module
-  @type result_t :: {:cont | :halt, any}
+  @type result_t ::
+      {:ok, any}
+    | {:jump, any, t}
+    | {:insert, any, t | [t]}
+    | {:replace, any, t | [t]}
+    | {:error, String.t}
 
   alias __MODULE__
 
   defmacro __using__(_) do
     quote do
       @behaviour Phase
-
-      def run(input), do: {:ok, input}
-
-      defoverridable run: 1
 
       @spec flag_invalid(Blueprint.node_t) :: Blueprint.node_t
       def flag_invalid(%{flags: _} = node) do
@@ -49,6 +50,6 @@ defmodule Absinthe.Phase do
     end
   end
 
-  @callback run(any) :: {:ok, any} | {:error, Phase.Error.t}
+  @callback run(any, any) :: result_t
 
 end

--- a/lib/absinthe/phase/blueprint.ex
+++ b/lib/absinthe/phase/blueprint.ex
@@ -3,8 +3,8 @@ defmodule Absinthe.Phase.Blueprint do
 
   alias Absinthe.Blueprint
 
-  @spec run(any) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(any, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     doc = input # The doc is also the input
     {:ok, Blueprint.Draft.convert(input, doc)}
   end

--- a/lib/absinthe/phase/debug.ex
+++ b/lib/absinthe/phase/debug.ex
@@ -3,8 +3,8 @@ defmodule Absinthe.Phase.Debug do
 
   alias Absinthe.Blueprint
 
-  @spec run(any) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(any, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     if System.get_env("DEBUG") do
       IO.inspect(input)
     end

--- a/lib/absinthe/phase/document/arguments/coercion.ex
+++ b/lib/absinthe/phase/document/arguments/coercion.ex
@@ -15,8 +15,8 @@ defmodule Absinthe.Phase.Document.Arguments.Coercion do
   use Absinthe.Phase
   alias Absinthe.{Blueprint, Type}
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     node = Blueprint.prewalk(input, &coerce_node/1)
     {:ok, node}
   end

--- a/lib/absinthe/phase/document/arguments/data.ex
+++ b/lib/absinthe/phase/document/arguments/data.ex
@@ -25,7 +25,7 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
   alias Absinthe.{Blueprint, Type}
   use Absinthe.Phase
 
-  def run(input) do
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &(handle_node(&1, input.adapter)))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/arguments/defaults.ex
+++ b/lib/absinthe/phase/document/arguments/defaults.ex
@@ -15,8 +15,8 @@ defmodule Absinthe.Phase.Document.Arguments.Defaults do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     node = Blueprint.prewalk(input, &populate_node/1)
     {:ok, node}
   end

--- a/lib/absinthe/phase/document/arguments/normalize.ex
+++ b/lib/absinthe/phase/document/arguments/normalize.ex
@@ -15,8 +15,8 @@ defmodule Absinthe.Phase.Document.Arguments.Normalize do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     acc = %{provided_values: %{}}
     {node, _} = Blueprint.prewalk(input, acc, &handle_node/2)
     {:ok, node}

--- a/lib/absinthe/phase/document/cascade_invalid.ex
+++ b/lib/absinthe/phase/document/cascade_invalid.ex
@@ -8,17 +8,17 @@ defmodule Absinthe.Phase.Document.CascadeInvalid do
 
   alias Absinthe.Blueprint
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
-    result = Blueprint.update_current(input, &process(&1, input.schema))
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
+    result = Blueprint.update_current(input, &process/1)
     {:ok, result}
   end
 
-  defp process(operation, schema) do
-    Blueprint.prewalk(operation, &handle_node(&1, schema))
+  defp process(operation) do
+    Blueprint.prewalk(operation, &handle_node/1)
   end
 
-  defp handle_node(%Blueprint.Document.Field{} = node, schema) do
+  defp handle_node(%Blueprint.Document.Field{} = node) do
     node = if any_invalid?(node.arguments) do
       node |> flag_invalid(:bad_arguments)
     else
@@ -31,7 +31,7 @@ defmodule Absinthe.Phase.Document.CascadeInvalid do
     end
     node
   end
-  defp handle_node(node, _) do
+  defp handle_node(node) do
     node
   end
 

--- a/lib/absinthe/phase/document/directives.ex
+++ b/lib/absinthe/phase/document/directives.ex
@@ -8,8 +8,8 @@ defmodule Absinthe.Phase.Document.Directives do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     node = Blueprint.prewalk(input, &handle_node/1)
     {:ok, node}
   end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -13,7 +13,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   use Absinthe.Phase
 
   def run(bp_root, context, root_value) do
-    bp_root = Blueprint.update_current(bp_root, fn
+    result = case Blueprint.current_operation(bp_root) do
+      nil ->
+        bp_root
       op ->
         field = %Resolution.Info{
           adapter: bp_root.adapter,
@@ -23,9 +25,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
           source: root_value,
         }
         resolution = resolve_operation(op, bp_root, field, root_value)
-        %{op | resolution: resolution}
-    end)
-    {:ok, bp_root}
+        put_in(bp_root.result.resolution, resolution)
+    end
+    {:ok, result}
   end
 
   def resolve_operation(operation, bp_root, info, source) do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -5,14 +5,17 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   While this phase starts with a blueprint, it returns an annotated value tree.
   """
 
-  alias Absinthe.{Blueprint, Type}
+  alias Absinthe.{Blueprint, Type, Phase}
 
   alias __MODULE__
 
   alias Absinthe.Phase
   use Absinthe.Phase
 
-  def run(bp_root, context, root_value) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(bp_root, options \\ []) do
+    context = Keyword.get(options, :context, %{})
+    root_value = Keyword.get(options, :root_value, %{})
     result = case Blueprint.current_operation(bp_root) do
       nil ->
         bp_root

--- a/lib/absinthe/phase/document/flatten.ex
+++ b/lib/absinthe/phase/document/flatten.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Flatten do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     fragments = for fragment <- input.fragments do
       process(fragment, input.fragments)
     end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Phase.Document.Result do
       %{validation: errors} ->
         {:validation_failed, errors}
     end
-    {:ok, format_result(result)}
+    format_result(result)
   end
 
   defp format_result(:execution_failed) do

--- a/lib/absinthe/phase/document/uses.ex
+++ b/lib/absinthe/phase/document/uses.ex
@@ -13,8 +13,8 @@ defmodule Absinthe.Phase.Document.Uses do
     variables: [Blueprint.Input.Variable.Use.t]
   }
 
-  @spec run(Blueprint.t) :: {:ok, Blueprint.t}
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, _options \\ []) do
     ops = Enum.map(input.operations, &add_uses(&1, input))
     node = %{input | operations: ops}
     {:ok, node}

--- a/lib/absinthe/phase/document/validation/arguments_of_correct_type.ex
+++ b/lib/absinthe/phase/document/validation/arguments_of_correct_type.ex
@@ -10,8 +10,8 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType do
   @doc """
   Run this validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &(handle_node(&1, input.schema)))
     {:ok, result}
   end
@@ -51,11 +51,10 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType do
   end
   defp collect_child_errors(%Blueprint.Input.Object{} = node, schema) do
     node.fields
-    |> Enum.with_index
     |> Enum.flat_map(fn
-      {%{flags: %{invalid: _}, schema_node: nil} = child, idx} ->
+      %{flags: %{invalid: _}, schema_node: nil} = child ->
         [unknown_field_error_message(child.name)]
-      {%{flags: %{invalid: _}} = child, idx} ->
+      %{flags: %{invalid: _}} = child ->
         child_type_name = Type.value_type(child.schema_node, schema)
         |> Type.name(schema)
         child_inspected_value = Blueprint.Input.inspect(child.value)
@@ -63,7 +62,7 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType do
           value_error_message(child.name, child_type_name, child_inspected_value) |
           collect_child_errors(child.value, schema)
         ]
-      {child, _} ->
+      child ->
         collect_child_errors(child, schema)
     end)
   end

--- a/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
+++ b/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
@@ -10,8 +10,8 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input))
     {:ok, result}
   end
@@ -49,7 +49,6 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
 
   # Generate the error for a field
   @spec error(Blueprint.node_t, String.t, [String.t], [String.t]) :: Phase.Error.t
-  defp error(field_node, parent_type_name, type_suggestions \\ [], field_suggestions \\ [])
   defp error(field_node, parent_type_name, type_suggestions, field_suggestions) do
     Phase.Error.new(
       __MODULE__,
@@ -80,7 +79,7 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
     <> to_quoted_or_list(type_suggestions |> Enum.take(@suggest))
     <> "?"
   end
-  def error_message(field_name, type_name, type_suggestions, field_suggestions) do
+  def error_message(field_name, type_name, type_suggestions, _) do
     error_message(field_name, type_name, type_suggestions)
   end
 

--- a/lib/absinthe/phase/document/validation/known_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/known_argument_names.ex
@@ -15,8 +15,8 @@ defmodule Absinthe.Phase.Document.Validation.KnownArgumentNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.schema))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/known_fragment_names.ex
+++ b/lib/absinthe/phase/document/validation/known_fragment_names.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.KnownFragmentNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/lone_anonymous_operation.ex
+++ b/lib/absinthe/phase/document/validation/lone_anonymous_operation.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.LoneAnonymousOperation do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node/1)
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
+++ b/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
@@ -17,16 +17,13 @@ defmodule Absinthe.Phase.Document.Validation.NoFragmentCycles do
   @spec run(Blueprint.t) :: Phase.result_t
   def run(input) do
     {fragments, error_count} = check(input.fragments)
-    {
-      instruction(error_count),
-      put_in(input.fragments, fragments)
-    }
+    result = put_in(input.fragments, fragments)
+    if error_count > 0 do
+      {:jump, result, Phase.Document.Validation.Result}
+    else
+      {:ok, result}
+    end
   end
-
-  # Determine whether any errors have occurred
-  @spec instruction(integer) :: :ok | :error
-  defp instruction(0), do: :ok
-  defp instruction(_), do: :error
 
   # Check a list of fragments for cycles
   @spec check([Blueprint.Document.Fragment.Named.t]) :: {[Blueprint.Document.Fragment.Named.t], integer}

--- a/lib/absinthe/phase/document/validation/no_undefined_variables.ex
+++ b/lib/absinthe/phase/document/validation/no_undefined_variables.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.NoUndefinedVariables do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.operations))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/no_unused_fragments.ex
+++ b/lib/absinthe/phase/document/validation/no_unused_fragments.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.NoUnusedFragments do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.operations))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/no_unused_variables.ex
+++ b/lib/absinthe/phase/document/validation/no_unused_variables.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.NoUnusedVariables do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.operations))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/provided_non_null_arguments.ex
+++ b/lib/absinthe/phase/document/validation/provided_non_null_arguments.ex
@@ -10,8 +10,8 @@ defmodule Absinthe.Phase.Document.Validation.ProvidedNonNullArguments do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &(handle_node(&1, input.schema)))
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/result.ex
+++ b/lib/absinthe/phase/document/validation/result.ex
@@ -4,18 +4,25 @@ defmodule Absinthe.Phase.Document.Validation.Result do
   Collects validation errors into the result.
   """
 
-  alias Absinthe.{Blueprint, Phase, Type, Schema}
+  alias Absinthe.{Blueprint, Phase}
 
   use Absinthe.Phase
 
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, nil | Phase.t) :: Phase.result_t
+  def run(input, abort_phase) do
     {input, errors} = Blueprint.prewalk(input, [], &handle_node/2)
     result = put_in(input.result.validation, errors)
-    {:ok, result}
+    case {errors, abort_phase} do
+      {[], _} ->
+        {:ok, result}
+      {_, nil} ->
+        {:ok, result}
+      _ ->
+        {:jump, result, abort_phase}
+    end
   end
 
   # Collect the validation errors from nodes

--- a/lib/absinthe/phase/document/validation/result.ex
+++ b/lib/absinthe/phase/document/validation/result.ex
@@ -1,0 +1,30 @@
+defmodule Absinthe.Phase.Document.Validation.Result do
+
+  @moduledoc """
+  Collects validation errors into the result.
+  """
+
+  alias Absinthe.{Blueprint, Phase, Type, Schema}
+
+  use Absinthe.Phase
+
+  @doc """
+  Run the validation.
+  """
+  @spec run(Blueprint.t) :: Phase.result_t
+  def run(input) do
+    {input, errors} = Blueprint.prewalk(input, [], &handle_node/2)
+    result = put_in(input.result.validation, errors)
+    {:ok, result}
+  end
+
+  # Collect the validation errors from nodes
+  @spec handle_node(Blueprint.node_t, [Phase.Error.t]) :: {Blueprint.node_t, [Phase.Error.t]}
+  defp handle_node(%{errors: errs} = node, acc) do
+    {node, acc ++ errs}
+  end
+  defp handle_node(node, acc) do
+    {node, acc}
+  end
+
+end

--- a/lib/absinthe/phase/document/validation/scalar_leafs.ex
+++ b/lib/absinthe/phase/document/validation/scalar_leafs.ex
@@ -3,7 +3,7 @@ defmodule Absinthe.Phase.Document.Validation.ScalarLeafs do # [sic]
   Validates an operation name was provided when needed.
   """
 
-  alias Absinthe.{Blueprint, Phase, Type, Schema}
+  alias Absinthe.{Blueprint, Phase, Type}
 
   use Absinthe.Phase
   use Absinthe.Phase.Validation
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.ScalarLeafs do # [sic]
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.schema))
     {:ok, result}
   end
@@ -50,14 +50,6 @@ defmodule Absinthe.Phase.Document.Validation.ScalarLeafs do # [sic]
     node
     |> flag_invalid(flag)
     |> put_error(error(node, required_subselection_message(node.name, Type.name(type))))
-  end
-
-  @spec named_type(Type.t, Schema.t) :: Type.named_t
-  defp named_type(%Type.Field{} = node, schema) do
-    Schema.lookup_type(schema, node.type)
-  end
-  defp named_type(%{name: _} = node, _) do
-    node
   end
 
   # Generate the error

--- a/lib/absinthe/phase/document/validation/selected_current_operation.ex
+++ b/lib/absinthe/phase/document/validation/selected_current_operation.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     node = if Enum.count(input.operations, &(&1.current)) == 1 do
       input
     else

--- a/lib/absinthe/phase/document/validation/unique_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_argument_names.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node/1)
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/unique_fragment_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_fragment_names.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueFragmentNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     fragments = for fragment <- input.fragments do
       process(fragment, input.fragments)
     end

--- a/lib/absinthe/phase/document/validation/unique_input_field_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_input_field_names.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueInputFieldNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node/1)
     {:ok, result}
   end

--- a/lib/absinthe/phase/document/validation/unique_operation_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_operation_names.ex
@@ -11,8 +11,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueOperationNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     operations = for operation <- input.operations do
       process(operation, input.operations)
     end

--- a/lib/absinthe/phase/document/validation/unique_variable_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_variable_names.ex
@@ -12,8 +12,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueVariableNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     operations = for operation <- input.operations do
       variable_definitions = for variable <- operation.variable_definitions do
         process(variable, operation.variable_definitions)

--- a/lib/absinthe/phase/document/validation/variables_are_input_types.ex
+++ b/lib/absinthe/phase/document/validation/variables_are_input_types.ex
@@ -12,15 +12,15 @@ defmodule Absinthe.Phase.Document.Validation.VariablesAreInputTypes do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.prewalk(input, &handle_node(&1, input.schema))
     {:ok, result}
   end
 
   # Find variable definitions
   @spec handle_node(Blueprint.node_t, Schema.t) :: Blueprint.node_t
-  defp handle_node(%Blueprint.Document.VariableDefinition{schema_node: nil} = node, schema) do
+  defp handle_node(%Blueprint.Document.VariableDefinition{schema_node: nil} = node, _) do
     node
   end
   defp handle_node(%Blueprint.Document.VariableDefinition{} = node, schema) do

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -3,9 +3,18 @@ defmodule Absinthe.Phase.Parse do
 
   alias Absinthe.{Language, Phase}
 
-  @spec run(Language.Source.t) :: {:ok, Language.Document.t} | {:error, Phase.Error.t}
-  def run(input) do
-    parse(input)
+  @spec run(Language.Source.t, nil | Phase.t) :: {:ok, Language.Document.t} | {:error, Phase.Error.t}
+  def run(input, abort_phase \\ nil) do
+    case {parse(input), abort_phase} do
+     {{:error, %{message: msg, locations: [%{line: line}]}}, nil} ->
+       {:error, msg <> ", on line #{line}"}
+     {{:error, %{message: msg}}, nil} ->
+       {:error, msg}
+     {{:error, error}, abort_phase} ->
+       {:jump, error, abort_phase}
+     {other, _} ->
+       other
+    end
   end
 
   @spec tokenize(binary) :: {:ok, [tuple]} | {:error, binary}

--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -10,8 +10,10 @@ defmodule Absinthe.Phase.Schema do
 
   alias Absinthe.{Blueprint, Type, Schema}
 
-  @spec run(Blueprint.t, Absinthe.Schema.t, Absinthe.Adapter.t) :: {:ok, Blueprint.t}
-  def run(input, schema, adapter \\ Absinthe.Adapter.LanguageConventions) do
+  @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
+  def run(input, options \\ []) do
+    schema = Keyword.fetch!(options, :schema)
+    adapter = Keyword.get(options, :adapter, Absinthe.Adapter.LanguageConventions)
     do_run(input, %{schema: schema, adapter: adapter})
   end
 
@@ -29,7 +31,7 @@ defmodule Absinthe.Phase.Schema do
     selections_with_schema = Enum.map(node.selections, &selection_with_schema_node(&1, schema_node, schema, adapter))
     %{node | schema_node: schema_node, selections: selections_with_schema}
   end
-  defp handle_node(%Blueprint.Document.VariableDefinition{type: type_reference} = node, schema, adapter) do
+  defp handle_node(%Blueprint.Document.VariableDefinition{type: type_reference} = node, schema, _) do
     type = type_reference_to_type(type_reference, schema)
     if Type.unwrap(type) do
       %{node | schema_node: type}

--- a/lib/absinthe/phase/validation/known_directives.ex
+++ b/lib/absinthe/phase/validation/known_directives.ex
@@ -8,8 +8,8 @@ defmodule Absinthe.Phase.Validation.KnownDirectives do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.postwalk(input, &handle_node/1)
     {:ok, result}
   end

--- a/lib/absinthe/phase/validation/known_type_names.ex
+++ b/lib/absinthe/phase/validation/known_type_names.ex
@@ -8,8 +8,8 @@ defmodule Absinthe.Phase.Validation.KnownTypeNames do
   @doc """
   Run the validation.
   """
-  @spec run(Blueprint.t) :: Phase.result_t
-  def run(input) do
+  @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
+  def run(input, _options \\ []) do
     result = Blueprint.postwalk(input, &(handle_node(&1, input.schema)))
     {:ok, result}
   end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -47,12 +47,13 @@ defmodule Absinthe.Pipeline do
       Phase.Document.Arguments.Data,
       Phase.Document.Arguments.Defaults,
       Phase.Document.Validation.data_pipeline,
+      Phase.Document.Validation.Result,
       Phase.Document.Directives,
       Phase.Document.CascadeInvalid,
       Phase.Document.Flatten,
       {Phase.Document.Execution.Resolution, [context, root_value]},
       Phase.Debug,
-      Phase.Document.Execution.Data
+      Phase.Document.Result
     ]
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -5,23 +5,16 @@ defmodule Absinthe.Pipeline do
 
   require Logger
 
-  @type input_t :: any
-  @type output_t :: %{errors: [Phase.Error.t]}
+  @type data_t :: any
 
   @type phase_config_t :: Phase.t | {Phase.t, [any]}
 
   @type t :: [phase_config_t | [phase_config_t]]
 
-  @spec run(input_t, t) :: {:ok, output_t} | {:error, String.t}
+  @spec run(data_t, t) :: {:ok, data_t, [Phase.t]} | {:error, String.t, [Phase.t]}
   def run(input, pipeline) do
-    case do_run(input, pipeline) do
-      {:ok, _} = halted_with_user_errors ->
-        halted_with_user_errors
-      {:error, _} = halted_with_developer_errors ->
-        halted_with_developer_errors
-      completed ->
-        {:ok, completed}
-    end
+    List.flatten(pipeline)
+    |> run_phase(input)
   end
 
   @spec for_document(Absinthe.Schema.t) :: t
@@ -84,6 +77,21 @@ defmodule Absinthe.Pipeline do
     end
   end
 
+  @doc """
+  Return the part of a pipeline after (and including) a specific phase.
+  """
+  @spec from(t, atom) :: t
+  def from(pipeline, phase) do
+    result = List.flatten(pipeline)
+    |> Enum.drop_while(&(!match_phase?(phase, &1)))
+    case result do
+      [] ->
+        raise RuntimeError, "Could not find phase #{phase}"
+      _ ->
+        result
+    end
+  end
+
   # Whether a phase configuration is for a given phase
   @spec match_phase?(Phase.t, phase_config_t) :: boolean
   defp match_phase?(phase, phase), do: true
@@ -105,33 +113,27 @@ defmodule Absinthe.Pipeline do
     beginning ++ [additional] ++ (pipeline -- beginning)
   end
 
-  @bad_return "Phase did not return an {:ok, any} | {:error, %{errors: [Phase.Error.t]} | Phase.Error.t | String.t} tuple"
-
-  @spec do_run(input_t, t) :: {:ok, output_t} | {:error, Phase.Error.t}
-  defp do_run(input, pipeline) do
-    List.flatten(pipeline)
-    |> Enum.reduce_while(input, fn config, input ->
-      {phase, args} = phase_invocation(config)
-      case apply(phase, :run, [input | args]) do
-        {:ok, value} ->
-          {:cont, value}
-        {:error, value} when is_binary(value) ->
-          halt_with_error_result(phase, value)
-        {:error, %Phase.Error{} = value} ->
-          halt_with_error_result(phase, value)
-        {:error, %{errors: _} = value} ->
-          halt_with_error_result(phase, value)
-        {:pipeline_error, message} ->
-          {:halt, {:error, message}}
-        _ ->
-          {:halt, {:error, phase_error(phase, @bad_return)}}
-      end
-    end)
+  @spec run_phase(t, data_t, [Phase.t]) :: {:ok, data_t, [Phase.t]} | {:error, String.t, [Phase.t]}
+  defp run_phase(pipeline, input, done \\ [])
+  defp run_phase([], input, done) do
+    {:ok, input, done}
   end
-
-  @spec halt_with_error_result(Phase.t, output_t | Phase.Error.t | [Phase.Error.t]) :: {:halt, {:ok, output_t}}
-  defp halt_with_error_result(phase, error) do
-    {:halt, {:ok, result_with_errors(phase, error)}}
+  defp run_phase([phase_config | todo], input, done) do
+    {phase, args} = phase_invocation(phase_config)
+    case apply(phase, :run, [input | args]) do
+      {:ok, result} ->
+        run_phase(todo, result, [phase | done])
+      {:jump, result, destination_phase} ->
+        run_phase(from(todo, destination_phase), result, [phase | done])
+      {:insert, result, extra_pipeline} ->
+        run_phase(List.wrap(extra_pipeline) ++ todo, result, [phase | done])
+      {:replace, result, final_pipeline} ->
+        run_phase(List.wrap(final_pipeline), result, [phase | done])
+      {:error, message} = err ->
+        {:error, message, [phase | done]}
+      _ ->
+        {:error, "Last phase did not return a valid result tuple.", [phase | done]}
+    end
   end
 
   @spec phase_invocation(phase_config_t) :: {Phase.t, list}
@@ -140,26 +142,6 @@ defmodule Absinthe.Pipeline do
   end
   defp phase_invocation(phase) do
     {phase, []}
-  end
-
-  @spec result_with_errors(Phase.t, output_t | Phase.Error.t | [Phase.Error.t]) :: output_t
-  defp result_with_errors(_, %{errors: _} = result) do
-    result
-  end
-  defp result_with_errors(phase, err) do
-    error = phase_error(phase, err)
-    %{errors: [%{message: error.message}]}
-  end
-
-  @spec phase_error(Phase.t, Phase.Error.t | String.t) :: Phase.Error.t
-  defp phase_error(_, %Phase.Error{} = err) do
-    err
-  end
-  defp phase_error(phase, message) when is_binary(message) do
-    %Phase.Error{
-      message: message,
-      phase: phase,
-    }
   end
 
 end

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -277,7 +277,7 @@ defmodule Absinthe.Schema do
   def concrete_types(schema, %Type.Interface{} = type) do
     implementors(schema, type)
   end
-  def concrete_types(schema, %Type.Object{} = type) do
+  def concrete_types(_, %Type.Object{} = type) do
     [type]
   end
 

--- a/test/lib/absinthe/execution/arguments_test.exs
+++ b/test/lib/absinthe/execution/arguments_test.exs
@@ -109,7 +109,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
       doc = """
       query GetContacts($contacts:[ContactInput]){contacts(contacts:$contacts)}
       """
-      assert_result {:ok, %{data: %{}, errors: [%{message: ~s(In argument "contacts": Expected type "[ContactInput]!", found null.)}]}},
+      assert_result {:ok, %{errors: [%{message: ~s(In argument "contacts": Expected type "[ContactInput]!", found null.)}]}},
         doc |> run(Schema)
     end
 
@@ -193,7 +193,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
       end
 
       it "should return an error with invalid values" do
-        assert_result {:ok, %{data: %{}, errors: [%{message: ~s(Argument "type" has invalid value "bagel".)}]}},
+        assert_result {:ok, %{errors: [%{message: ~s(Argument "type" has invalid value "bagel".)}]}},
           "{ contact(type: \"bagel\") }" |> run(Schema)
       end
 
@@ -207,7 +207,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         doc = """
         { requiredThing }
         """
-        assert_result {:ok, %{data: %{}, errors: [%{message: ~s(In argument "name": Expected type "InputName!", found null.)}]}}, doc |> run(Schema)
+        assert_result {:ok, %{errors: [%{message: ~s(In argument "name": Expected type "InputName!", found null.)}]}}, doc |> run(Schema)
       end
     end
 
@@ -245,7 +245,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         doc = """
         {contacts(contacts: [{email: "a@b.com"}, {foo: "c@d.com"}])}
         """
-        assert_result {:ok, %{data: %{}, errors: [
+        assert_result {:ok, %{errors: [
           %{message: ~s(Argument "contacts" has invalid value [{email: "a@b.com"}, {foo: "c@d.com"}].\nIn element #2: Expected type "ContactInput", found {foo: "c@d.com", email: null}.\nIn field "foo": Unknown field.\nIn field "email": Expected type "String!", found null.)},
         ]}},
           doc |> run(Schema)
@@ -264,7 +264,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         doc = """
         {user(contact: {foo: "buz"})}
         """
-        assert_result {:ok, %{data: %{}, errors: [
+        assert_result {:ok, %{errors: [
           %{message: ~s(Argument "contact" has invalid value {foo: "buz"}.\nIn field "foo": Unknown field.\nIn field "email": Expected type "String!", found null.)},
         ]}},
           doc |> run(Schema)
@@ -274,7 +274,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         doc = """
         {user(contact: {email: "bubba", foo: "buz"})}
         """
-        assert_result {:ok, %{data: %{}, errors: [%{message: "Argument \"contact\" has invalid value {email: \"bubba\", foo: \"buz\"}.\nIn field \"foo\": Unknown field."}]}},
+        assert_result {:ok, %{errors: [%{message: "Argument \"contact\" has invalid value {email: \"bubba\", foo: \"buz\"}.\nIn field \"foo\": Unknown field."}]}},
           doc |> run(Schema)
       end
     end
@@ -300,7 +300,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
       end
 
       it "returns a correct error when passed the wrong type" do
-        assert_result {:ok, %{data: %{}, errors: [%{message: ~s(Argument "flag" has invalid value {foo: 1}.)}]}},
+        assert_result {:ok, %{errors: [%{message: ~s(Argument "flag" has invalid value {foo: 1}.)}]}},
           "{ something(flag: {foo: 1}) }" |> run(Schema)
       end
     end
@@ -310,7 +310,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         assert_result {:ok, %{data: %{"contact" => "Email"}}}, "{ contact(type: Email) }" |> run(Schema)
       end
       it "should return an error with invalid values" do
-        assert_result {:ok, %{data: %{}, errors: [%{message: ~s(Argument "type" has invalid value "bagel".)}]}},
+        assert_result {:ok, %{errors: [%{message: ~s(Argument "type" has invalid value "bagel".)}]}},
           "{ contact(type: \"bagel\") }" |> run(Schema)
       end
     end
@@ -323,7 +323,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
         user(contact: {email: "bubba@joe.com", contactType: 1})
       }
       """
-      assert_result {:ok, %{data: %{}, errors: [%{message: ~s(Argument "contact" has invalid value {email: "bubba@joe.com", contactType: 1}.\nIn field "contactType": Expected type "ContactType", found 1.)}]}}, run(doc, Schema)
+      assert_result {:ok, %{errors: [%{message: ~s(Argument "contact" has invalid value {email: "bubba@joe.com", contactType: 1}.\nIn field "contactType": Expected type "ContactType", found 1.)}]}}, run(doc, Schema)
     end
   end
 

--- a/test/lib/absinthe/language/directive_definition_test.exs
+++ b/test/lib/absinthe/language/directive_definition_test.exs
@@ -19,7 +19,7 @@ defmodule Absinthe.Language.DirectiveDefinitionTest do
   end
 
   defp from_input(text) do
-    {:ok, doc} = Phase.Parse.run(text)
+    {:ok, doc} = Phase.Parse.run(text, nil)
 
     doc
     |> extract_ast_node

--- a/test/lib/absinthe/language/document_test.exs
+++ b/test/lib/absinthe/language/document_test.exs
@@ -1,4 +1,4 @@
-defmodule Absinthe.Languguage.DocumentTest do
+defmodule Absinthe.Language.DocumentTest do
   use Absinthe.Case, async: true
 
   alias Absinthe.Blueprint
@@ -37,7 +37,7 @@ defmodule Absinthe.Languguage.DocumentTest do
     end
 
     describe "given a non-existing operation name" do
-      {:ok, doc} = Absinthe.Phase.Parse.run(@input)
+      {:ok, doc} = Absinthe.Phase.Parse.run(@input, nil)
       result = Document.get_operation(doc, "DoesNotExist")
       assert nil == result
     end
@@ -174,7 +174,7 @@ defmodule Absinthe.Languguage.DocumentTest do
   end
 
   def ir(input) do
-    {:ok, blueprint} = Absinthe.Pipeline.run(input, [Absinthe.Phase.Parse, Absinthe.Phase.Blueprint])
+    {:ok, blueprint, _} = Absinthe.Pipeline.run(input, [Absinthe.Phase.Parse, Absinthe.Phase.Blueprint])
     blueprint
   end
 

--- a/test/lib/absinthe/phase/document/directives_test.exs
+++ b/test/lib/absinthe/phase/document/directives_test.exs
@@ -62,13 +62,13 @@ defmodule Absinthe.Phase.Document.DirectivesTest do
   end
 
   defp blueprint(query, values) do
-    {:ok, blueprint} = Pipeline.run(query, pre_pipeline(values))
+    {:ok, blueprint, _} = Pipeline.run(query, pre_pipeline(values))
     blueprint
   end
 
   # Get the document pipeline up to (but not including) this phase
   defp pre_pipeline(values) do
-    Pipeline.for_document(Schema, variables: values)
+    Pipeline.for_document(Schema, variables: values, abort_to_phase: nil)
     |> Pipeline.before(Phase.Document.Directives)
   end
 

--- a/test/lib/absinthe/phase/document/flatten_test.exs
+++ b/test/lib/absinthe/phase/document/flatten_test.exs
@@ -121,7 +121,7 @@ defmodule Absinthe.Phase.Document.FlattenTest do
     it "has its selections flattened to fields" do
       pre = Pipeline.for_document(ContactSchema)
       |> Pipeline.before(Phase.Document.Flatten)
-      {:ok, blueprint} = Pipeline.run(@introspection_query, pre)
+      {:ok, blueprint, _} = Pipeline.run(@introspection_query, pre)
       {:ok, result} = Phase.Document.Flatten.run(blueprint)
       op = Blueprint.current_operation(result)
       assert Blueprint.find(op, fn
@@ -141,7 +141,7 @@ defmodule Absinthe.Phase.Document.FlattenTest do
   end
 
   defp blueprint(query, variables) do
-    {:ok, blueprint} = Pipeline.run(query, pre_pipeline(variables))
+    {:ok, blueprint, _phases} = Pipeline.run(query, pre_pipeline(variables))
     blueprint
   end
 

--- a/test/lib/absinthe/phase/document/schema_test.exs
+++ b/test/lib/absinthe/phase/document/schema_test.exs
@@ -250,11 +250,11 @@ defmodule Absinthe.Phase.Document.SchemaTest do
 
   defp input(query) do
     blueprint(query)
-    |> Phase.Schema.run(Schema)
+    |> Phase.Schema.run(schema: Schema)
   end
 
   defp blueprint(query) do
-    {:ok, blueprint} = Pipeline.run(query, @pre_pipeline)
+    {:ok, blueprint, _} = Pipeline.run(query, @pre_pipeline)
     blueprint
   end
 

--- a/test/lib/absinthe/phase/document/variables_test.exs
+++ b/test/lib/absinthe/phase/document/variables_test.exs
@@ -48,7 +48,7 @@ defmodule Absinthe.Phase.Document.VariablesTest do
   end
 
   defp blueprint(query) do
-    {:ok, blueprint} = Pipeline.run(query, @pre_pipeline)
+    {:ok, blueprint, _} = Pipeline.run(query, @pre_pipeline)
     blueprint
   end
 

--- a/test/lib/absinthe/pipeline_test.exs
+++ b/test/lib/absinthe/pipeline_test.exs
@@ -13,10 +13,10 @@ defmodule Absinthe.PipelineTest do
     { foo { bar } }
     """
 
-    it 'can create a blueprint' do
+    it "can create a blueprint" do
       pipeline = Pipeline.for_document(Schema)
       |> Pipeline.upto(Phase.Blueprint)
-      assert {:ok, %Blueprint{}} = Pipeline.run(@query, pipeline)
+      assert {:ok, %Blueprint{}, [Phase.Blueprint, Phase.Parse]} = Pipeline.run(@query, pipeline)
     end
 
   end
@@ -30,11 +30,11 @@ defmodule Absinthe.PipelineTest do
     """
 
     it 'can create a blueprint without a prototype schema' do
-      assert {:ok, %Blueprint{}} = Pipeline.run(@query, Pipeline.for_schema(nil))
+      assert {:ok, %Blueprint{}, _} = Pipeline.run(@query, Pipeline.for_schema(nil))
     end
 
     it 'can create a blueprint with a prototype schema' do
-      assert {:ok, %Blueprint{}} = Pipeline.run(@query, Pipeline.for_schema(Schema))
+      assert {:ok, %Blueprint{}, _} = Pipeline.run(@query, Pipeline.for_schema(Schema))
     end
 
   end
@@ -72,8 +72,8 @@ defmodule Absinthe.PipelineTest do
 
   describe ".run with options" do
     it "should work" do
-      assert {:ok, "oof.oof.oof"} == Pipeline.run("foo", [Phase1, {Phase2, %{times: 3}}, {Phase3, %{reverse: false}}])
-      assert {:ok, "foo.foo.foo"} == Pipeline.run("foo", [Phase1, {Phase2, %{times: 3}}, {Phase3, %{reverse: true}}])
+      assert {:ok, "oof.oof.oof", [Phase3, Phase2, Phase1]} == Pipeline.run("foo", [Phase1, {Phase2, %{times: 3}}, {Phase3, %{reverse: false}}])
+      assert {:ok, "foo.foo.foo", [Phase3, Phase2, Phase1]} == Pipeline.run("foo", [Phase1, {Phase2, %{times: 3}}, {Phase3, %{reverse: true}}])
     end
   end
 
@@ -86,7 +86,7 @@ defmodule Absinthe.PipelineTest do
 
   describe ".run with a bad phase result" do
     it "should return a nice error object" do
-      assert {:error, %Phase.Error{phase: BadPhase, message: "Phase did not return an {:ok, any} | {:error, %{errors: [Phase.Error.t]} | Phase.Error.t | String.t} tuple"}} = Pipeline.run("foo", [BadPhase])
+      assert {:error, "Last phase did not return a valid result tuple.", [BadPhase]} == Pipeline.run("foo", [BadPhase])
     end
   end
 

--- a/test/lib/absinthe/pipeline_test.exs
+++ b/test/lib/absinthe/pipeline_test.exs
@@ -41,7 +41,7 @@ defmodule Absinthe.PipelineTest do
 
   defmodule Phase1 do
     use Phase
-    def run(input) do
+    def run(input, _) do
       {:ok, String.reverse(input)}
     end
   end
@@ -79,7 +79,7 @@ defmodule Absinthe.PipelineTest do
 
   defmodule BadPhase do
     use Phase
-    def run(input) do
+    def run(input, _) do
       input
     end
   end

--- a/test/lib/absinthe/type/directive_test.exs
+++ b/test/lib/absinthe/type/directive_test.exs
@@ -38,7 +38,7 @@ defmodule Absinthe.Type.DirectiveTest do
     it "behaves as expected for a field" do
       assert {:ok, %{data: %{"person" => %{"name" => "Bruce"}}}} == Absinthe.run(@query_field, ContactSchema, variables: %{"skipPerson" => false})
       assert {:ok, %{data: %{}}} == Absinthe.run(@query_field, ContactSchema, variables: %{"skipPerson" => true})
-      assert_result {:ok, %{data: %{"person" => %{"name" => "Bruce"}}, errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_field, ContactSchema)
+      assert_result {:ok, %{errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_field, ContactSchema)
     end
 
     @query_fragment """
@@ -55,7 +55,7 @@ defmodule Absinthe.Type.DirectiveTest do
     it "behaves as expected for a fragment" do
       assert_result {:ok, %{data: %{"person" => %{"name" => "Bruce", "age" => 35}}}}, run(@query_fragment, ContactSchema, variables: %{"skipAge" => false})
       assert_result {:ok, %{data: %{"person" => %{"name" => "Bruce"}}}}, run(@query_fragment, ContactSchema, variables: %{"skipAge" => true})
-      assert_result {:ok, %{data: %{"person" => %{"name" => "Bruce", "age" => 35}}, errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_fragment, ContactSchema)
+      assert_result {:ok, %{errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_fragment, ContactSchema)
     end
   end
 
@@ -73,7 +73,7 @@ defmodule Absinthe.Type.DirectiveTest do
     it "behaves as expected for a field" do
       assert_result {:ok, %{data: %{"person" => %{"name" => "Bruce"}}}}, run(@query_field, ContactSchema, variables: %{"includePerson" => true})
       assert_result {:ok, %{data: %{}}}, run(@query_field, ContactSchema, variables: %{"includePerson" => false})
-      assert_result {:ok, %{data: %{}, errors: [%{locations: [%{column: 0, line: 2}], message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_field, ContactSchema)
+      assert_result {:ok, %{errors: [%{locations: [%{column: 0, line: 2}], message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}}, run(@query_field, ContactSchema)
     end
 
     @query_fragment """

--- a/test/lib/absinthe/type/interface_test.exs
+++ b/test/lib/absinthe/type/interface_test.exs
@@ -93,8 +93,7 @@ defmodule Absinthe.Type.InterfaceTest do
         result = """
         { contact { entity { name age } } }
         """ |> Absinthe.run(ContactSchema)
-        assert_result {:ok, %{data: %{"contact" => %{"entity" => %{"name" => "Bruce"}}},
-                              errors: [%{message: ~s(Cannot query field "age" on type "NamedEntity". Did you mean to use an inline fragment on "Person"?)}]}}, result
+        assert_result {:ok, %{errors: [%{message: ~s(Cannot query field "age" on type "NamedEntity". Did you mean to use an inline fragment on "Person"?)}]}}, result
       end
 
       it "can select fields from an implementing type with 'on'" do

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -34,7 +34,7 @@ defmodule AbsintheTest do
       }
     }
     """
-    assert_result {:ok, %{data: %{"thing" => %{"name" => "Foo"}}, errors: [%{message: ~s(Cannot query field "bad" on type "Thing".)}]}}, run(query, Things)
+    assert_result {:ok, %{errors: [%{message: ~s(Cannot query field "bad" on type "Thing".)}]}}, run(query, Things)
   end
 
   it "blows up on bad resolutions" do
@@ -61,8 +61,7 @@ defmodule AbsintheTest do
 
   it "checks for required arguments" do
     query = "{ thing { name } }"
-    assert_result {:ok, %{data: %{},
-                          errors: [%{message: ~s(In argument "id": Expected type "String!", found null.)}]}}, run(query, Things)
+    assert_result {:ok, %{errors: [%{message: ~s(In argument "id": Expected type "String!", found null.)}]}}, run(query, Things)
 
   end
 
@@ -74,7 +73,7 @@ defmodule AbsintheTest do
       }
     }
     """
-    assert_result {:ok, %{data: %{}, errors: [%{message: ~s(Unknown argument "extra" on field "thing" of type "RootQueryType".)}]}}, run(query, Things)
+    assert_result {:ok, %{errors: [%{message: ~s(Unknown argument "extra" on field "thing" of type "RootQueryType".)}]}}, run(query, Things)
   end
 
   it "checks for badly formed arguments" do
@@ -83,8 +82,7 @@ defmodule AbsintheTest do
       number(val: "AAA")
     }
     """
-    assert_result {:ok, %{data: %{},
-                         errors: [%{message: ~s(Argument "val" has invalid value "AAA".)}]}}, run(query, Things)
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "val" has invalid value "AAA".)}]}}, run(query, Things)
   end
 
   it "returns nested objects" do
@@ -148,8 +146,7 @@ defmodule AbsintheTest do
       }
     }
     """
-    assert_result {:ok, %{data: %{},
-                         errors: [%{message: ~s(Argument "thing" has invalid value {value: "BAD"}.\nIn field "value": Expected type "Int", found "BAD".)}]}}, run(query, Things)
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "thing" has invalid value {value: "BAD"}.\nIn field "value": Expected type "Int", found "BAD".)}]}}, run(query, Things)
   end
 
   it "reports variables that are never used" do
@@ -161,7 +158,7 @@ defmodule AbsintheTest do
       }
     """
     result = run(query, Things, variables: %{"thingId" => "bar"})
-    assert_result {:ok, %{data: %{"thing" => %{"name" => "Bar"}}, errors: [%{message: ~s(Variable "other" is never used in operation "GimmeThingByVariable".)}]}}, result
+    assert_result {:ok, %{errors: [%{message: ~s(Variable "other" is never used in operation "GimmeThingByVariable".)}]}}, result
   end
 
   it "reports parser errors from parse" do
@@ -337,11 +334,11 @@ defmodule AbsintheTest do
     end
 
     it "should error when no operation name is supplied" do
-      assert {:ok, %{data: %{}, errors: [%{message: "Must provide a valid operation name if query contains multiple operations."}]}} == run(@multiple_ops_query, Things)
+      assert {:ok, %{errors: [%{message: "Must provide a valid operation name if query contains multiple operations."}]}} == run(@multiple_ops_query, Things)
     end
     it "should error when an invalid operation name is supplied" do
       op_name = "invalid"
-      assert_result {:ok, %{data: %{}, errors: [%{message: "Must provide a valid operation name if query contains multiple operations."}]}}, run(@multiple_ops_query, Things, operation_name: op_name)
+      assert_result {:ok, %{errors: [%{message: "Must provide a valid operation name if query contains multiple operations."}]}}, run(@multiple_ops_query, Things, operation_name: op_name)
     end
   end
 

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -342,4 +342,18 @@ defmodule AbsintheTest do
     end
   end
 
+  it "handles cycles" do
+    cycler = """
+    fragment Foo on Blag {
+      name
+      ...Bar
+    }
+    fragment Bar on Blah {
+      age
+      ...Foo
+    }
+    """
+    assert_result {:ok, %{errors: [%{message: "forms a cycle via: (`Foo' => `Bar' => `Foo')"}]}}, run(cycler, Things)
+  end
+
 end

--- a/test/support/case/run.ex
+++ b/test/support/case/run.ex
@@ -1,8 +1,7 @@
 defmodule Absinthe.Case.Run do
 
   def run(document, schema, options \\ []) do
-    pipeline = Absinthe.Pipeline.for_document(schema, Map.new(options))
-    Absinthe.Pipeline.run(document, pipeline)
+    Absinthe.run(document, schema, options)
   end
 
 end

--- a/test/support/harness/document/phase.ex
+++ b/test/support/harness/document/phase.ex
@@ -14,7 +14,7 @@ defmodule Harness.Document.Phase do
       def run_phase(query, provided_values, additional_args \\ []) do
         pipeline = Pipeline.for_document(unquote(schema), provided_values)
         |> Pipeline.before(unquote(phase))
-        with {:ok, blueprint} <- Pipeline.run(query, pipeline) do
+        with {:ok, blueprint, _} <- Pipeline.run(query, pipeline) do
           apply(unquote(phase), :run, [blueprint | additional_args])
         end
       end


### PR DESCRIPTION
This is to support #158.

- [x] Structural changes to phases (will explain in a comment)
- [x] Support the various permutations of GraphQL result structure 
- [x] If validation fails, skip to final GraphQL result phase