### PR TITLE
v1.1 Fix: return error on list of object queries with no subfields #161

### DIFF
--- a/lib/absinthe/execution/resolution/list.ex
+++ b/lib/absinthe/execution/resolution/list.ex
@@ -1,6 +1,9 @@
 defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.List do
 
   alias Absinthe.Execution.Resolution
+  alias Absinthe.Execution
+  alias Absinthe.Flag
+  alias Absinthe.Utils
 
   def resolve(%{of_type: %{of_type: _} = wrapped_type}, execution) do
     # That's a list of list, we unwrap and pass it while keeping the selection_set
@@ -16,18 +19,30 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.List do
   end
 
   def do_resolve(wrapped_type, inner_to_resolve, %{resolution: %{target: target}} = execution) do
-    {values_to_return, execution_to_return} = Enum.reduce(target, {[], execution}, fn
+    {values_to_return, execution_to_return} = Enum.reduce_while(target, {[], execution}, fn
 
       (value_to_resolve, {values_before, current_execution}) ->
         this_resolution = %Resolution{type: wrapped_type, target: value_to_resolve, ast_node: execution.resolution.ast_node}
 
-        {:ok, result, next_execution} = Resolution.resolve(inner_to_resolve,
+        result = Resolution.resolve(inner_to_resolve,
           %{current_execution | resolution: this_resolution}
         )
 
-        {[result|values_before], next_execution}
+        case result do
+          {:ok, result, next_execution} ->
+            {:cont, {[result|values_before], next_execution}}
+          {:skip, next_execution} ->
+            {:halt, {:skip, next_execution}}
+        end
     end)
-    {:ok, Enum.reverse(values_to_return), execution_to_return}
+    if values_to_return != :skip do
+      {:ok, Enum.reverse(values_to_return), execution_to_return}
+    else
+      ast_node = execution.resolution.ast_node
+      execution
+      |> Execution.put_error(:field, ast_node.name, "of type \"[#{Utils.camelize(to_string(wrapped_type))}]\" must have a selection of subfields. Did you mean \"#{ast_node.name} { ... }\"?", at: ast_node)
+      |> Flag.as(:skip)
+    end
   end
 
 end

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -233,6 +233,16 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"red" => %{"name" => "RED", "value" => 100}, "green" => %{"name" => "GREEN", "value" => 200}, "blue" => %{"name" => "BLUE", "value" => 300}, "puce" => %{"name" => "PUCE", "value" => -100}}, errors: [%{message: "Argument `channel.p' (Channel): Deprecated; it's ugly"}]}}, result
   end
 
+  it "should return an error when not specifying subfields" do
+    query = """
+      {
+        things
+      }
+    """
+    result = run(query)
+    assert_result {:ok, %{errors: [%{message: "Field `things': of type \"[Thing]\" must have a selection of subfields. Did you mean \"things { ... }\"?"}], data: %{}}}, result
+  end
+
   describe "fragments" do
 
     @simple_fragment """

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -116,6 +116,12 @@ defmodule Things do
           {:ok, @db |> Map.get(id)}
       end
 
+    field :things,
+      type: list_of(:thing),
+      resolve: fn
+        _, _ ->
+          {:ok, Map.values(@db)}
+      end
   end
 
   input_object :input_thing do


### PR DESCRIPTION
This fixes the issue brought up in https://github.com/absinthe-graphql/absinthe/issues/161 I copied the error message that v1.2 presents for this particular error.