### PR TITLE
Fix problem with GraphiQL introspection returning a list of types

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -247,7 +247,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   def find_target_type(schema_type, schema) when is_atom(schema_type) do
     schema.__absinthe_type__(schema_type)
   end
+  # For fields
   def find_target_type(%{type: type}, schema) do
+    find_target_type(type, schema)
+  end
+  # For lists and non-nulls
+  def find_target_type(%{of_type: type}, schema) do
     find_target_type(type, schema)
   end
 

--- a/test/lib/absinthe/introspection_test.exs
+++ b/test/lib/absinthe/introspection_test.exs
@@ -381,4 +381,16 @@ defmodule Absinthe.IntrospectionTest do
 
   end
 
+  describe "full introspection" do
+
+    @filename "graphql/introspection.graphql"
+    @query File.read!(Path.join([:code.priv_dir(:absinthe), @filename]))
+
+    it "runs" do
+      result = @query |> run(ContactSchema)
+      assert {:ok, %{data: %{"__schema" => _}}} = result
+    end
+
+  end
+
 end


### PR DESCRIPTION
This also adds a test that ensures the full introspection (which we store in `priv/graphql/introspection.graphql`) can always run.