### PR TITLE
Fixed type resolution of wrapped types

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -54,7 +54,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp resolve_fields(parent, bp_root, info, source) do
     parent_type = case parent.schema_node do
       %Type.Field{} = schema_node ->
-        info.schema.__absinthe_type__(schema_node.type)
+        type = if Type.wrapped?(schema_node.type) do
+          Type.unwrap(schema_node.type)
+        else
+          schema_node.type
+        end
+        info.schema.__absinthe_type__(type)
       other ->
         other
     end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -54,12 +54,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp resolve_fields(parent, bp_root, info, source) do
     parent_type = case parent.schema_node do
       %Type.Field{} = schema_node ->
-        type = if Type.wrapped?(schema_node.type) do
-          Type.unwrap(schema_node.type)
-        else
-          schema_node.type
-        end
-        info.schema.__absinthe_type__(type)
+        schema_node.type
+        |> Type.unwrap
+        |> info.schema.__absinthe_type__
       other ->
         other
     end

--- a/test/lib/absinthe/introspection_test.exs
+++ b/test/lib/absinthe/introspection_test.exs
@@ -28,6 +28,12 @@ defmodule Absinthe.IntrospectionTest do
 
   describe "when querying against a union" do
     it "returns the name of the object type currently being queried" do
+      # Simple type
+      result = "{ firstSearchResult { __typename } }" |> run(ContactSchema)
+      assert_result {:ok, %{data: %{"firstSearchResult" => %{"__typename" => "Person"}}}}, result
+      # Wrapped type
+      result = "{ searchResults { __typename } }" |> run(ContactSchema)
+      assert_result {:ok, %{data: %{"searchResults" => [%{"__typename" => "Person"}, %{"__typename" => "Business"}]}}}, result
     end
   end
 

--- a/test/support/contact_schema.ex
+++ b/test/support/contact_schema.ex
@@ -36,6 +36,13 @@ defmodule ContactSchema do
           {:ok, @bruce}
       end
 
+    field :search_results,
+      type: non_null(list_of(non_null(:search_result))),
+      resolve: fn
+        _, _ ->
+          {:ok, [@bruce, @business]}
+      end
+
     field :profile,
       type: :person,
       args: [name: [type: non_null(:string)]],


### PR DESCRIPTION
Type resolution was failing for wrapped union types, as it was trying to look up `%Absinthe.Type.NonNull{of_type: :foo}` from the `schema.__absinthe_type__` which returned `nil`