### PR TITLE
Fixed Pipeline.without/2

### DIFF
--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -157,7 +157,7 @@ defmodule Absinthe.Pipeline do
   @spec without(t, Phase.t) :: t
   def without(pipeline, phase) do
     pipeline
-    |> Enum.filter(&(match_phase?(phase, &1)))
+    |> Enum.filter(&(not match_phase?(phase, &1)))
   end
 
   @spec insert_before(t, Phase.t, Phase.t) :: t

--- a/test/lib/absinthe/pipeline_test.exs
+++ b/test/lib/absinthe/pipeline_test.exs
@@ -135,4 +135,13 @@ defmodule Absinthe.PipelineTest do
 
   end
 
+  describe ".upto" do
+
+    it "returns the pipeline without specified phase" do
+      assert [A, B, D, {E, []}, F] == Pipeline.without(@pipeline, C)
+      assert [A, B, C, D, F] == Pipeline.without(@pipeline, E)
+    end
+
+  end
+
 end


### PR DESCRIPTION
I assume this is a bug and it now behaves as expected.