### PR TITLE
Metadata utility

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -551,12 +551,22 @@ defmodule Absinthe.Schema.Notation do
     :ok
   end
 
-  @placement {:private, [under: [:field, :object]]}
+  @placement {:private, [under: [:field, :object, :input_object, :enum, :scalar, :interface, :union]]}
   @doc false
   defmacro private(owner, key, value) do
     __CALLER__
     |> recordable!(:private, @placement[:private])
     |> record_private!(owner, key, value)
+  end
+
+  @placement {:meta, [under: [:field, :object, :input_object, :enum, :scalar, :interface, :union]]}
+  @doc """
+  Defines a metadata key/value pair for a custom type.
+  """
+  defmacro meta(key, value) do
+    __CALLER__
+    |> recordable!(:meta, @placement[:meta])
+    |> record_private!(:meta, key, value)
   end
 
   @doc false

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -29,10 +29,17 @@ defmodule Absinthe.Type do
     nil
   end
 
-  @doc "Lookup a metadata field on a type"
+  @doc "Lookup a custom metadata field on a type"
   @spec meta(custom_t, atom) :: nil | any
   def meta(%{__private__: store}, key) do
     get_in(store, [:meta, key])
+  end
+
+  @doc "Return all custom metadata on a type"
+  @spec meta(custom_t) :: map
+  def meta(%{__private__: store}) do
+    Keyword.get(store, :meta, [])
+    |> Enum.into(%{})
   end
 
   @doc "Determine if a struct matches one of the types"

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -10,8 +10,11 @@ defmodule Absinthe.Type do
 
   @type_modules [Type.Scalar, Type.Object, Type.Interface, Type.Union, Type.Enum, Type.InputObject, Type.List, Type.NonNull]
 
-  @typedoc "These are all of the possible kinds of types."
-  @type t :: Type.Scalar.t | Type.Object.t | Type.Field.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t | Type.List.t | Type.NonNull.t
+  @typedoc "The types that can be custom-built in a schema"
+  @type custom_t :: Type.Scalar.t | Type.Object.t | Type.Field.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t
+
+  @typedoc "All the possible types"
+  @type t :: custom_t | Type.List.t | Type.NonNull.t
 
   @typedoc "A type identifier"
   @type identifier_t :: atom
@@ -24,6 +27,12 @@ defmodule Absinthe.Type do
   end
   def identifier(_) do
     nil
+  end
+
+  @doc "Lookup a metadata field on a type"
+  @spec meta(custom_t, atom) :: nil | any
+  def meta(%{__private__: store}, key) do
+    get_in(store, [:meta, key])
   end
 
   @doc "Determine if a struct matches one of the types"

--- a/lib/absinthe/type/enum.ex
+++ b/lib/absinthe/type/enum.ex
@@ -65,10 +65,26 @@ defmodule Absinthe.Type.Enum do
   * `:description` - A nice description for introspection.
   * `:values` - The enum values, usually provided using the `Absinthe.Schema.Notation.values/1` or `Absinthe.Schema.Notation.value/1` macro.
 
-  The `:__reference__` key is for internal use.
+
+  The `__private__` and `:__reference__` fields are for internal use.
   """
-  @type t :: %{name: binary, description: binary, values: %{binary => Type.Enum.Value.t}, __reference__: Type.Reference.t}
-  defstruct name: nil, description: nil, values: %{}, values_by_internal_value: %{}, values_by_name: %{}, __reference__: nil
+  @type t :: %{
+    name: binary,
+    description: binary,
+    values: %{binary => Type.Enum.Value.t},
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
+
+  defstruct [
+    name: nil,
+    description: nil,
+    values: %{},
+    values_by_internal_value: %{},
+    values_by_name: %{},
+    __private__: [],
+    __reference__: nil,
+  ]
 
 
   def build(%{attrs: attrs}) do

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -36,8 +36,31 @@ defmodule Absinthe.Type.InputObject do
 
   alias Absinthe.Type
 
-  @type t :: %{name: binary, description: binary, fields: map | (() -> map), __reference__: Type.Reference.t}
-  defstruct name: nil, description: nil, fields: %{}, __reference__: nil
+  @typedoc """
+  Note new input object types should be defined using
+  `Absinthe.Schema.Notation.input_object/3`.
+
+  * `:name` - The name of the input object type. Should be a TitleCased `binary`. Set automatically.
+  * `:description` - A nice description for introspection.
+  * `:fields` - A map of `Absinthe.Type.Field` structs. Usually built via `Absinthe.Schema.Notation.field/1`.
+
+  The `__private__` and `:__reference__` fields are for internal use.
+  """
+  @type t :: %{
+    name: binary,
+    description: binary,
+    fields: map | (() -> map),
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
+
+  defstruct [
+    name: nil,
+    description: nil,
+    fields: %{},
+    __private__: [],
+    __reference__: nil,
+  ]
 
   def build(%{attrs: attrs}) do
     fields = Type.Field.build(attrs[:fields] || [])

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -41,7 +41,14 @@ defmodule Absinthe.Type.Interface do
     interface :named_entity
   end
   ```
+  """
 
+  use Absinthe.Introspection.Kind
+
+  alias Absinthe.Type
+  alias Absinthe.Schema
+
+  @typedoc """
   * `:name` - The name of the interface type. Should be a TitleCased `binary`. Set automatically.
   * `:description` - A nice description for introspection.
   * `:fields` - A map of `Absinthe.Type.Field` structs. See `Absinthe.Schema.Notation.field/1` and
@@ -50,17 +57,25 @@ defmodule Absinthe.Type.Interface do
 
   The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Execution` struct providing the full execution context.
 
-  The `:__reference__` key is for internal use.
-
+  The `__private__` and `:__reference__` keys are for internal use.
   """
+  @type t :: %{
+    name: binary,
+    description: binary,
+    fields: map,
+    resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
 
-  use Absinthe.Introspection.Kind
-
-  alias Absinthe.Type
-  alias Absinthe.Schema
-
-  @type t :: %{name: binary, description: binary, fields: map, resolve_type: ((any, Absinthe.Execution.t) -> atom | nil), __reference__: Type.Reference.t}
-  defstruct name: nil, description: nil, fields: nil, resolve_type: nil, __reference__: nil
+  defstruct [
+    name: nil,
+    description: nil,
+    fields: nil,
+    resolve_type: nil,
+    __private__: [],
+    __reference__: nil
+  ]
 
   def build(%{attrs: attrs}) do
     fields = Type.Field.build(attrs[:fields] || [])

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -82,10 +82,28 @@ defmodule Absinthe.Type.Object do
   * `:interfaces` - A list of interfaces that this type guarantees to implement. See `Absinthe.Type.Interface`.
   * `:is_type_of` - A function used to identify whether a resolved object belongs to this defined type. For use with `:interfaces` entry and `Absinthe.Type.Interface`.
 
-  The `:__private__` and `:__reference__` keys are for internal use.
+  The `__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{name: binary, description: binary, fields: map, interfaces: [Absinthe.Type.Interface.t], is_type_of: ((any) -> boolean), __private__: Keyword.t, __reference__: Type.Reference.t}
-  defstruct name: nil, description: nil, fields: nil, interfaces: [], is_type_of: nil, __private__: [], __reference__: nil, field_imports: []
+  @type t :: %{
+    name: binary,
+    description: binary,
+    fields: map,
+    interfaces: [Absinthe.Type.Interface.t],
+    is_type_of: ((any) -> boolean),
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
+
+  defstruct [
+    name: nil,
+    description: nil,
+    fields: nil,
+    interfaces: [],
+    is_type_of: nil,
+    __private__: [],
+    __reference__: nil,
+    field_imports: []
+  ]
 
   def build(%{attrs: attrs}) do
     fields =

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -53,14 +53,29 @@ defmodule Absinthe.Type.Scalar do
   * `:serialize` - A function used to convert a value to a form suitable for JSON serialization
   * `:parse` - A function used to convert the raw, incoming form of a scalar to the canonical internal format.
 
-  The `:__reference__` key is for internal use.
+  The `:__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{name: binary, description: binary, serialize: (value_t -> any), parse: (any -> {:ok, value_t} | :error), __reference__: Type.Reference.t}
+  @type t :: %{
+    name: binary,
+    description: binary,
+    serialize: (value_t -> any),
+    parse: (any -> {:ok, value_t} | :error),
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
+
+  defstruct [
+    name: nil,
+    description: nil,
+    serialize: nil,
+    parse: nil,
+    __private__: [],
+    __reference__: nil,
+  ]
+
 
   @typedoc "The internal, canonical representation of a scalar value"
   @type value_t :: any
-
-  defstruct name: nil, description: nil, serialize: nil, parse: nil, __reference__: nil
 
   if System.get_env("DEBUG_INSPECT") do
     defimpl Inspect do

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -22,7 +22,13 @@ defmodule Absinthe.Type.Union do
     end
   end
   ```
+  """
 
+  use Absinthe.Introspection.Kind
+
+  alias Absinthe.{Schema, Type}
+
+  @typedoc """
   * `:name` - The name of the union type. Should be a TitleCased `binary`. Set automatically.
   * `:description` - A nice description for introspection.
   * `:types` - The list of possible types.
@@ -30,20 +36,26 @@ defmodule Absinthe.Type.Union do
 
   The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Execution` struct providing the full execution context.
 
-  The `:__reference__` key is for internal use.
+  The `__private__` and `:__reference__` keys are for internal use.
+
   """
+  @type t :: %{
+    name: binary,
+    description: binary,
+    types: [Type.identifier_t],
+    resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
+    __private__: Keyword.t,
+    __reference__: Type.Reference.t,
+  }
 
-  use Absinthe.Introspection.Kind
-
-  alias Absinthe.{Schema, Type}
-
-  @type t :: %{name: binary,
-               description: binary,
-               types: [Type.identifier_t],
-               resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
-               __reference__: Type.Reference.t}
-
-  defstruct name: nil, description: nil, resolve_type: nil, types: [], __reference__: nil
+  defstruct [
+    name: nil,
+    description: nil,
+    resolve_type: nil,
+    types: [],
+    __private__: [],
+    __reference__: nil,
+  ]
 
   def build(%{attrs: attrs}) do
     quote do: %unquote(__MODULE__){unquote_splicing(attrs)}

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -220,4 +220,106 @@ defmodule Absinthe.SchemaTest do
 
   end
 
+
+  defmodule MetadataSchema do
+    use Absinthe.Schema
+
+    object :foo do
+      meta :sql_table, "foos"
+      field :bar, :string do
+        meta :nice, "yup"
+      end
+    end
+
+    input_object :input_foo do
+      meta :is_input, true
+      field :bar, :string do
+        meta :nice, "nope"
+      end
+    end
+
+    enum :color do
+      meta :rgb_only, true
+      value :red
+      value :blue
+      value :green
+    end
+
+    scalar :my_scalar do
+      meta :is_scalar, true
+      # Missing parse and serialize
+    end
+
+    interface :named do
+      meta :is_interface, true
+      field :name, :string do
+        meta :is_name, true
+      end
+    end
+
+    union :result do
+      types [:foo]
+      meta :is_union, true
+    end
+
+  end
+
+  describe "can add metadata to an object" do
+
+    it "sets object metadata" do
+      foo = Schema.lookup_type(MetadataSchema, :foo)
+      assert %{__private__: [meta: [sql_table: "foos"]]} = foo
+      assert Type.meta(foo, :sql_table) == "foos"
+    end
+
+    it "sets field metadata" do
+      foo = Schema.lookup_type(MetadataSchema, :foo)
+      assert %{__private__: [meta: [nice: "yup"]]} = foo.fields[:bar]
+      assert Type.meta(foo.fields[:bar], :nice) == "yup"
+    end
+
+    it "sets input object metadata" do
+      input_foo = Schema.lookup_type(MetadataSchema, :input_foo)
+      assert %{__private__: [meta: [is_input: true]]} = input_foo
+      assert Type.meta(input_foo, :is_input) == true
+    end
+
+    it "sets input object field metadata" do
+      input_foo = Schema.lookup_type(MetadataSchema, :input_foo)
+      assert %{__private__: [meta: [nice: "nope"]]} = input_foo.fields[:bar]
+      assert Type.meta(input_foo.fields[:bar], :nice) == "nope"
+    end
+
+    it "sets enum metadata" do
+      color = Schema.lookup_type(MetadataSchema, :color)
+      assert %{__private__: [meta: [rgb_only: true]]} = color
+      assert Type.meta(color, :rgb_only) == true
+    end
+
+    it "sets scalar metadata" do
+      my_scalar = Schema.lookup_type(MetadataSchema, :my_scalar)
+      assert %{__private__: [meta: [is_scalar: true]]} = my_scalar
+      assert Type.meta(my_scalar, :is_scalar) == true
+    end
+
+    it "sets interface metadata" do
+      named = Schema.lookup_type(MetadataSchema, :named)
+      assert %{__private__: [meta: [is_interface: true]]} = named
+      assert Type.meta(named, :is_interface) == true
+    end
+
+    it "sets interface field metadata" do
+      named = Schema.lookup_type(MetadataSchema, :named)
+      assert %{__private__: [meta: [is_name: true]]} = named.fields[:name]
+      assert Type.meta(named.fields[:name], :is_name) == true
+    end
+
+    it "sets union metadata" do
+      result = Schema.lookup_type(MetadataSchema, :result)
+      assert %{__private__: [meta: [is_union: true]]} = result
+      assert Type.meta(result, :is_union) == true
+    end
+
+  end
+
 end

--- a/test/lib/absinthe/type_test.exs
+++ b/test/lib/absinthe/type_test.exs
@@ -43,4 +43,59 @@ defmodule Absinthe.TypeTest do
 
   end
 
+  defmodule MetadataSchema do
+    use Absinthe.Schema
+
+    object :with_meta do
+      meta :foo, "bar"
+    end
+
+    object :without_meta do
+    end
+
+  end
+
+  @with_meta Absinthe.Schema.lookup_type(MetadataSchema, :with_meta)
+  @without_meta Absinthe.Schema.lookup_type(MetadataSchema, :without_meta)
+
+
+  describe ".meta/1" do
+
+    describe "when no metadata is defined" do
+      it "returns an empty map" do
+        assert Type.meta(@without_meta) == %{}
+      end
+    end
+
+    describe "when metadata is defined" do
+      it "returns the metadata as a map" do
+        assert Type.meta(@with_meta) == %{foo: "bar"}
+      end
+    end
+
+  end
+
+  describe ".meta/2" do
+
+    describe "when no metadata field is defined" do
+      it "returns nil" do
+        assert Type.meta(@without_meta, :bar) == nil
+      end
+    end
+
+    describe "when the requested metadata field is not defined" do
+      it "returns nil" do
+        assert Type.meta(@with_meta, :bar) == nil
+      end
+    end
+
+
+    describe "when the metadata is defined" do
+      it "returns the value" do
+        assert Type.meta(@with_meta, :foo) == "bar"
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds a `meta` notation macro to add metadata for:

- Type.Object
- Type.InputObject
- Type.Field
- Type.Enum
- Type.Scalar
- Type.Union
- Type.Interface

Example usage, taken from `schema_test.exs`:

```elixir
  defmodule MetadataSchema do
    use Absinthe.Schema

    object :foo do
      meta :sql_table, "foos"
      field :bar, :string do
        meta :nice, "yup"
      end
    end

    input_object :input_foo do
      meta :is_input, true
      field :bar, :string do
        meta :nice, "nope"
      end
    end

    enum :color do
      meta :rgb_only, true
      value :red
      value :blue
      value :green
    end

    scalar :my_scalar do
      meta :is_scalar, true
      # Missing parse and serialize
    end

    interface :named do
      meta :is_interface, true
      field :name, :string do
        meta :is_name, true
      end
    end

    union :result do
      types [:foo]
      meta :is_union, true
    end

  end
```

Metadata is stored under the existing `:__private__` field (added to some types) that is used for other internal purposes, and keyed under `:meta` (private values are namespaced by an "owner" feature).

A utility function, `Absinthe.Type.meta/2` has been added to support querying supported types for metadata information:

```
foo = Schema.lookup_type(MetadataSchema, :foo)
assert Type.meta(foo, :sql_table) == "foos"
```

If a value is not present, `nil` is returned, as with `get_in`.
