### PR TITLE
Stricter, spec-compliant scalar parsing rules

### DIFF
--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -5,8 +5,8 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
 
   scalar :integer, name: "Int" do
     description """
-    The `Int` scalar type represents non-fractional signed whole numeric
-    values. Int can represent values between `-(2^53 - 1)` and `2^53 - 1` since
+    The `Int` scalar type represents non-fractional signed whole numeric values.
+    Int can represent values between `-(2^53 - 1)` and `2^53 - 1` since it is
     represented in JSON as double-precision floating point numbers specified
     by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
     """
@@ -65,25 +65,20 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   @max_int 9007199254740991
   @min_int -9007199254740991
 
-  @spec parse_int(integer | float | binary) :: {:ok, integer} | :error
+  @spec parse_int(any) :: {:ok, integer} | :error
   defp parse_int(value) when is_integer(value) and value >= @min_int and value <= @max_int do
     {:ok, value}
-  end
-  defp parse_int(value) when is_float(value) do
-    with {result, _} <- Integer.parse(String.to_integer(value, 10)) do
-      parse_int(result)
-    end
   end
   defp parse_int(_) do
     :error
   end
 
-  @spec parse_float(integer | float) :: {:ok, float} | :error
-  defp parse_float(value) when is_integer(value) do
-    {:ok, value * 1.0}
-  end
+  @spec parse_float(any) :: {:ok, float} | :error
   defp parse_float(value) when is_float(value) do
     {:ok, value}
+  end
+  defp parse_float(value) when is_integer(value) do
+    {:ok, value * 1.0}
   end
   defp parse_float(_) do
     :error
@@ -92,9 +87,6 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   @spec parse_string(any) :: {:ok, binary} | :error
   defp parse_string(value) when is_binary(value) do
     {:ok, value}
-  end
-  defp parse_string(value) when is_float(value) or is_integer(value) do
-    :error
   end
   defp parse_string(_) do
     :error
@@ -112,9 +104,6 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   end
 
   @spec parse_boolean(any) :: {:ok, boolean} | :error
-  defp parse_boolean(value) when is_number(value) do
-    {:ok, value > 0}
-  end
   defp parse_boolean(value) when is_boolean(value) do
     {:ok, value}
   end

--- a/test/lib/absinthe/type/built_ins/scalars_test.exs
+++ b/test/lib/absinthe/type/built_ins/scalars_test.exs
@@ -1,0 +1,134 @@
+defmodule Absinthe.Type.BuliltIns.ScalarsTest do
+  use Absinthe.Case, async: true
+
+  alias Absinthe.Type
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+  end
+
+  @max_int 9007199254740991
+  @min_int -9007199254740991
+
+  defp serialize(type, value) do
+    TestSchema.__absinthe_type__(type)
+    |> Type.Scalar.serialize(value)
+  end
+
+  defp parse(type, value) do
+    TestSchema.__absinthe_type__(type)
+    |> Type.Scalar.parse(value)
+  end
+
+  describe ":integer" do
+    it "serializes as an integer" do
+      assert 1 == serialize(:integer, 1)
+    end
+
+    it "can be parsed from an integer within the valid range" do
+      assert {:ok, 0} == parse(:integer, 0)
+      assert {:ok, 1} == parse(:integer, 1)
+      assert {:ok, -1} == parse(:integer, -1)
+      assert {:ok, @max_int} == parse(:integer, @max_int)
+      assert {:ok, @min_int} == parse(:integer, @min_int)
+      assert :error == parse(:integer, @max_int + 1)
+      assert :error == parse(:integer, @min_int - 1)
+    end
+
+    it "cannot be parsed from a float" do
+      assert :error == parse(:integer, 0.0)
+    end
+
+    it "cannot be parsed from a binary" do
+      assert :error == parse(:integer, "")
+      assert :error == parse(:integer, "0")
+    end
+  end
+
+  describe ":float" do
+    it "serializes as a float" do
+      assert 1.0 == serialize(:float, 1.0)
+    end
+
+    it "can be parsed from an integer" do
+      assert {:ok, 0.0} == parse(:float, 0)
+      assert {:ok, 1.0} == parse(:float, 1)
+      assert {:ok, -1.0} == parse(:float, -1)
+    end
+
+    it "can be parsed from a float" do
+      assert {:ok, 0.0} == parse(:float, 0.0)
+      assert {:ok, 1.9} == parse(:float, 1.9)
+      assert {:ok, -1.9} == parse(:float, -1.9)
+    end
+
+    it "cannot be parsed from a binary" do
+      assert :error == parse(:float, "")
+      assert :error == parse(:float, "0.0")
+    end
+  end
+
+  describe ":string" do
+    it "serializes as a string" do
+      assert "" == serialize(:string, "")
+      assert "string" == serialize(:string, "string")
+    end
+
+    it "can be parsed from a binary" do
+      assert {:ok, ""} == parse(:string, "")
+      assert {:ok, "string"} == parse(:string, "string")
+    end
+
+    it "cannot be parsed from an integer" do
+      assert :error == parse(:string, 0)
+    end
+
+    it "cannot be parsed from a float" do
+      assert :error == parse(:string, 1.9)
+    end
+  end
+
+  describe ":id" do
+    it "serializes as a string" do
+      assert "1" == serialize(:id, 1)
+      assert "1" == serialize(:id, "1")
+    end
+
+    it "can be parsed from a binary" do
+      assert {:ok, ""} == parse(:id, "")
+      assert {:ok, "abc123"} == parse(:id, "abc123")
+    end
+
+    it "can be parsed from an integer" do
+      assert {:ok, "0"} == parse(:id, 0)
+      assert {:ok, Integer.to_string(@max_int)} == parse(:id, @max_int)
+      assert {:ok, Integer.to_string(@min_int)} == parse(:id, @min_int)
+    end
+
+    it "cannot be parsed from a float" do
+      assert :error == parse(:id, 1.9)
+    end
+  end
+
+  describe ":boolean" do
+    it "serializes as a boolean" do
+      assert true == serialize(:boolean, true)
+      assert false == serialize(:boolean, false)
+    end
+
+    it "can be parsed from a boolean" do
+      assert {:ok, true} == parse(:boolean, true)
+      assert {:ok, false} == parse(:boolean, false)
+    end
+
+    it "cannot be parsed from a number" do
+      assert :error == parse(:boolean, 0)
+      assert :error == parse(:boolean, 0.0)
+    end
+
+    it "cannot be parsed from a binary" do
+      assert :error == parse(:boolean, "true")
+      assert :error == parse(:boolean, "false")
+    end
+  end
+end


### PR DESCRIPTION
The previous code supported more scalar input coercions that are allowed
by the spec. Specifically:

 - Floats are no longer considered valid inputs for an :integer field.
 - Numbers are no longer considered valid inputs for a :boolean field.

A test suite for the built-in scalar types has been included. It covers
both serialization and parsing.

This change also includes a minor description text change for the Int
type as well as two small @spec changes for parse_int and parse_float
(because, like the other parse_* functions, they can handle any input
type).