### PR TITLE
Fix interface union

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -289,10 +289,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp passes_type_condition?(%Type.Interface{} = condition, %Type.Object{} = type, _, _) do
     Type.Interface.member?(condition, type)
   end
-  # The condition is an Interface type and the current scope is a Union type;
-  # Verify that the current source object's concrete type is a member of the
-  # Interface.
-  defp passes_type_condition?(%Type.Interface{} = condition, %Type.Union{} = type, source, schema) do
+  # The condition is an Interface type and the current scope is an abstract
+  # (Union/Interface) type; Verify that the current source object's concrete
+  # type is a member of the Interface.
+  defp passes_type_condition?(%Type.Interface{} = condition, %abstract_mod{} = type, source, schema)
+      when abstract_mod in [Type.Interface, Type.Union] do
     concrete_type = Type.Union.resolve_type(type, source, %{schema: schema})
     passes_type_condition?(condition, concrete_type, source, schema)
   end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -266,12 +266,13 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   @spec passes_type_condition?(Type.t, Type.t, any, Schema.t) :: boolean
   defp passes_type_condition?(equal, equal, _, _), do: true
-  # The condition in an Object type and the current scope is a Union; Verify
-  # that the Union has the Object type as a member.
+  # The condition is an Object type and the current scope is a Union; Verify
+  # that the Union has the Object type as a member and that the current source
+  # object's concrete type matched the condition Object type.
   defp passes_type_condition?(%Type.Object{} = condition, %Type.Union{} = type, source, schema) do
     with true <- Type.Union.member?(type, condition) do
-      source_type = Type.Union.resolve_type(type, source, %{schema: schema})
-      passes_type_condition?(condition, source_type, source, schema)
+      concrete_type = Type.Union.resolve_type(type, source, %{schema: schema})
+      passes_type_condition?(condition, concrete_type, source, schema)
     end
   end
   # The condition is an Object type and the current scope is an Interface; verify
@@ -283,10 +284,17 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
       passes_type_condition?(condition, concrete_type, source, schema)
     end
   end
-  # The condition in an Interface type and the current scope is an Object type;
+  # The condition is an Interface type and the current scope is an Object type;
   # verify that the Object type is a member of the Interface.
   defp passes_type_condition?(%Type.Interface{} = condition, %Type.Object{} = type, _, _) do
     Type.Interface.member?(condition, type)
+  end
+  # The condition is an Interface type and the current scope is a Union type;
+  # Verify that the current source object's concrete type is a member of the
+  # Interface.
+  defp passes_type_condition?(%Type.Interface{} = condition, %Type.Union{} = type, source, schema) do
+    concrete_type = Type.Union.resolve_type(type, source, %{schema: schema})
+    passes_type_condition?(condition, concrete_type, source, schema)
   end
   # Otherwise, nope.
   defp passes_type_condition?(_, _, _, _) do

--- a/test/lib/absinthe/union_fragment_test.exs
+++ b/test/lib/absinthe/union_fragment_test.exs
@@ -7,15 +7,22 @@ defmodule Absinthe.UnionFragmentTest do
     object :user do
       field :name, :string
       field :todos, list_of(:todo)
+      interface :named
     end
 
     object :todo do
       field :name, :string
       field :completed, :boolean
+      interface :named
     end
 
     union :object do
       types [:user, :todo]
+      resolve_type fn %{type: type}, _ -> type end
+    end
+
+    interface :named do
+      field :name, :string
       resolve_type fn %{type: type}, _ -> type end
     end
 
@@ -42,11 +49,11 @@ defmodule Absinthe.UnionFragmentTest do
       viewer {
         objects {
           ... on User {
-          __typename
+            __typename
             name
           }
           ... on Todo {
-          __typename
+            __typename
             completed
           }
         }
@@ -57,6 +64,28 @@ defmodule Absinthe.UnionFragmentTest do
     expected = %{"viewer" => %{"objects" => [
       %{"__typename" => "User", "name" => "foo"},
       %{"__typename" => "Todo", "completed" => false},
+      %{"__typename" => "User", "name" => "bar"},
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
+  end
+
+  test "it queries an interface implemented by a union type" do
+    doc = """
+    {
+      viewer {
+        objects {
+          ... on Named {
+            __typename
+            name
+          }
+        }
+      }
+    }
+
+    """
+    expected = %{"viewer" => %{"objects" => [
+      %{"__typename" => "User", "name" => "foo"},
+      %{"__typename" => "Todo", "name" => "do stuff"},
       %{"__typename" => "User", "name" => "bar"},
     ]}}
     assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)


### PR DESCRIPTION
This PR fixes a bug where a query accesses an interface fragment on an "abstract" type (union or interface) in the schema. Previous behaviour was that the types were deemed incompatible and the fragment was not resolved