### PR TITLE
Always use the field resolvers of the concrete object type

### DIFF
--- a/test/lib/absinthe/union_fragment_test.exs
+++ b/test/lib/absinthe/union_fragment_test.exs
@@ -52,7 +52,7 @@ defmodule Absinthe.UnionFragmentTest do
               %{type: :user, username: "bar"},
             ],
             me: %{type: :user, username: "baz", todos: [], name: "should not be exposed"},
-            named_thing: %{type: :todo, name: "do stuff", completed: false}
+            named_thing: %{type: :todo, title: "do stuff", completed: false}
           }}
         end
       end

--- a/test/lib/absinthe/union_fragment_test.exs
+++ b/test/lib/absinthe/union_fragment_test.exs
@@ -5,13 +5,19 @@ defmodule Absinthe.UnionFragmentTest do
     use Absinthe.Schema
 
     object :user do
-      field :name, :string
+      field :name, :string do
+        resolve fn user, _, _ -> {:ok, user.username} end
+      end
       field :todos, list_of(:todo)
+      interface :named
     end
 
     object :todo do
-      field :name, :string
+      field :name, :string do
+        resolve fn todo, _, _ -> {:ok, todo.title} end
+      end
       field :completed, :boolean
+      interface :named
     end
 
     union :object do
@@ -19,18 +25,27 @@ defmodule Absinthe.UnionFragmentTest do
       resolve_type fn %{type: type}, _ -> type end
     end
 
+    interface :named do
+      field :name, :string
+      resolve_type fn %{type: type}, _ -> type end
+    end
+
     object :viewer do
       field :objects, list_of(:object)
+      field :me, :user
     end
 
     query do
       field :viewer, :viewer do
         resolve fn _, _ ->
-          {:ok, %{objects: [
-            %{type: :user, name: "foo", completed: true},
-            %{type: :todo, name: "do stuff", completed: false},
-            %{type: :user, name: "bar"},
-          ]}}
+          {:ok, %{
+            objects: [
+              %{type: :user, username: "foo", completed: true},
+              %{type: :todo, title: "do stuff", completed: false},
+              %{type: :user, username: "bar"},
+            ],
+            me: %{type: :user, username: "baz", todos: [], name: "should not be exposed"},
+          }}
         end
       end
     end
@@ -42,11 +57,11 @@ defmodule Absinthe.UnionFragmentTest do
       viewer {
         objects {
           ... on User {
-          __typename
+            __typename
             name
           }
           ... on Todo {
-          __typename
+            __typename
             completed
           }
         }
@@ -59,6 +74,24 @@ defmodule Absinthe.UnionFragmentTest do
       %{"__typename" => "Todo", "completed" => false},
       %{"__typename" => "User", "name" => "bar"},
     ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
+  end
+
+  test "it queries an interface with the concrete type's field resolvers" do
+    doc = """
+    {
+      viewer {
+        me {
+          ... on Named {
+            __typename
+            name
+          }
+        }
+      }
+    }
+
+    """
+    expected = %{"viewer" => %{"me" => %{"__typename" => "User", "name" => "baz"}}}
     assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
   end
 


### PR DESCRIPTION
This fixes a bug so that when querying on unions or interfaces, the resolvers defined in the schema on the type of the concrete object are always used.

Previous behaviour was to attempt to use the resolvers defined on the union/interface field (of which there are none) and then to fall back to the default `Map.fetch` resolver.