### PR TITLE
Fix escaped characters in input literals (#165)

### DIFF
--- a/test/lib/absinthe/phase/parse_test.exs
+++ b/test/lib/absinthe/phase/parse_test.exs
@@ -77,6 +77,80 @@ defmodule Absinthe.Phase.ParseTest do
     assert {:ok, _} = run(@query)
   end
 
+  @query ~S"""
+  mutation {
+    item(data: "{\"foo\": \"bar\"}") {
+      id
+      data
+    }
+  }
+  """
+  it "can parse escaped strings as inputs" do
+    assert {:ok, res} = run(@query)
+    path = [
+      Access.key(:definitions),
+      Access.at(0),
+      Access.key(:selection_set),
+      Access.key(:selections),
+      Access.at(0),
+      Access.key(:arguments),
+      Access.at(0),
+      Access.key(:value),
+      Access.key(:value)
+    ]
+    assert ~s({"foo": "bar"}) == get_in(res, path)
+  end
+
+
+  @query ~S"""
+  mutation {
+    item(data: "foo\nbar") {
+      id
+      data
+    }
+  }
+  """
+  it "can parse escaped characters in inputs" do
+    assert {:ok, res} = run(@query)
+    path = [
+      Access.key(:definitions),
+      Access.at(0),
+      Access.key(:selection_set),
+      Access.key(:selections),
+      Access.at(0),
+      Access.key(:arguments),
+      Access.at(0),
+      Access.key(:value),
+      Access.key(:value)
+    ]
+    assert ~s(foo\nbar) == get_in(res, path)
+  end
+
+  @query ~S"""
+  mutation {
+    item(data: "\" \\ \/ \b \f \n \r \t \u00F3 \u00f3 \u04F9") {
+      id
+      data
+    }
+  }
+  """
+  it "can parse all types of characters escaped according to GraphQL spec as inputs" do
+    assert {:ok, res} = run(@query)
+    path = [
+      Access.key(:definitions),
+      Access.at(0),
+      Access.key(:selection_set),
+      Access.key(:selections),
+      Access.at(0),
+      Access.key(:arguments),
+      Access.at(0),
+      Access.key(:value),
+      Access.key(:value)
+    ]
+
+    assert ~s(\" \\ \/ \b \f \n \r \t ó ó ӹ) == get_in(res, path)
+  end
+
   def run(input) do
     Absinthe.Phase.Parse.run(input)
   end


### PR DESCRIPTION
Fixes #165: Unescapes contents of StringValues according to https://facebook.github.io/graphql/#sec-String-Value inside the parser.

I had an idea of converting Unicode codepoints to UTF-8 bytes by hand instead of using `unicode:characters_to_binary/1`, but it seemed like a premature optimisation.