### PR TITLE
Fix argument normalization in fragments

### DIFF
--- a/lib/absinthe/phase/document/arguments/normalize.ex
+++ b/lib/absinthe/phase/document/arguments/normalize.ex
@@ -24,21 +24,10 @@ defmodule Absinthe.Phase.Document.Arguments.Normalize do
 
   @spec fetch_provided_values(Blueprint.t) :: map
   defp fetch_provided_values(input) do
-    default = %{}
-    {_, provided_values} = Blueprint.prewalk(input, default, &find_operation/2)
-    provided_values
+    Enum.reduce(input.operations, %{}, fn (operation, acc) ->
+      Map.merge(acc, operation.provided_values)
+    end)
   end
-
-  @spec find_operation(Blueprint.node_t, map)
-   :: {Blueprint.node_t, map} | {:halt, Blueprint.node_t, map}
-  defp find_operation(%Blueprint.Document.Operation{} = node, _) do
-    {
-      :halt,
-      node,
-      node.provided_values
-    }
-  end
-  defp find_operation(node, acc), do: {node, acc}
 
   @spec handle_node(Blueprint.node_t, map) :: {Blueprint.node_t, map}
   # Argument using a variable: Set provided value

--- a/lib/absinthe/phase/document/arguments/normalize.ex
+++ b/lib/absinthe/phase/document/arguments/normalize.ex
@@ -17,16 +17,17 @@ defmodule Absinthe.Phase.Document.Arguments.Normalize do
 
   @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
   def run(input, _options \\ []) do
-    acc = %{provided_values: fetch_provided_values(input)}
+    acc = %{provided_values: get_provided_values(input)}
     {node, _} = Blueprint.prewalk(input, acc, &handle_node/2)
     {:ok, node}
   end
 
-  @spec fetch_provided_values(Blueprint.t) :: map
-  defp fetch_provided_values(input) do
-    Enum.reduce(input.operations, %{}, fn (operation, acc) ->
-      Map.merge(acc, operation.provided_values)
-    end)
+  @spec get_provided_values(Blueprint.t) :: map
+  defp get_provided_values(input) do
+    case Blueprint.current_operation(input) do
+      nil -> %{}
+      operation -> operation.provided_values
+    end
   end
 
   @spec handle_node(Blueprint.node_t, map) :: {Blueprint.node_t, map}

--- a/test/lib/absinthe/phase/document/arguments/normalize_test.exs
+++ b/test/lib/absinthe/phase/document/arguments/normalize_test.exs
@@ -57,7 +57,7 @@ defmodule Absinthe.Phase.Document.Arguments.NormalizeTest do
 
   @fragment_query """
     query Things($id: ID!) {
-      baz {
+      things {
         ... thingsFragment
       }
     }


### PR DESCRIPTION
Adds a initialization step to the argument normalization phase to fetch
the provided values from the Operation before traversing the blueprint
to normalize all inputs.

Current behavior is dependent on ordering of node traversal in the
blueprint i.e. Operation node is expected to be visited before Input
nodes. However, Fragment nodes are visited before the Operation node so
the provided values are empty.

I am not sure this is the best solution so I am open to feedback.