### PR TITLE
Added the ability to mutate the context variables inside root mutation resolvers

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -143,6 +143,18 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> to_result(bp_field, full_type)
     |> walk_result(acc, bp_field, full_type, info)
   end
+  ## Mutation resolver may return a response to update the context
+  defp build_result({:ok, result, context}, acc, bp_field, info, source) do
+    unless is_mutation?(info) do
+      raise Absinthe.ExecutionError, """
+      Only mutation resovers may return `{:ok, val, context}`
+      Resolving field: #{bp_field.name}
+      Resolving on: #{inspect source}
+      Got: #{inspect {:ok, result, context}}
+      """
+    end
+    build_result({:ok, result}, acc, bp_field, %{info | context: context}, source)
+  end
   defp build_result({:error, msg}, acc, bp_field, info, _) do
     message = ~s(In field "#{bp_field.name}": #{msg})
     full_type = Type.expand(bp_field.schema_node.type, info.schema)
@@ -165,6 +177,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     Got: #{inspect other}
     """
   end
+
+  defp is_mutation?(%Absinthe.Resolution{parent_type: %Type.Object{__reference__: %{identifier: :mutation}}}), do: true
+  defp is_mutation?(_), do: false
 
   # Introspection Field
   defp call_resolution_function(args, %{schema_node: %{name: "__" <> _}} = field, info, _) do

--- a/test/lib/absinthe/mutate_context_test.exs
+++ b/test/lib/absinthe/mutate_context_test.exs
@@ -1,0 +1,84 @@
+defmodule Absinthe.MutateContextTest do
+  use Absinthe.Case, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    @foo %{bar: 42}
+
+    object :foo do
+      field :bar, :integer
+      field :context_value, :integer do
+        resolve fn _, info -> {:ok, info.context[:context_value]} end
+      end
+      field :change_context_forbidden, :integer do
+        resolve fn _, info ->
+          {:ok, 0, Map.put(info.context, :context_value, 10)}
+        end
+      end
+    end
+
+    query do
+      field :change_context_forbidden, :foo do
+        resolve fn _, info ->
+          {:ok, @foo, Map.put(info.context, :context_value, 7)}
+        end
+      end
+    end
+
+    mutation do
+      field :default, :foo, resolve: fn _, _ -> {:ok, @foo} end
+      field :change_context, :foo do
+        resolve fn _, info ->
+          {:ok, @foo, Map.put(info.context, :context_value, 7)}
+        end
+      end
+    end
+  end
+
+  test "it handles changes to the context returned from mutatuons" do
+    doc = """
+    mutation {
+      default {
+        bar
+        contextValue
+      }
+    }
+    """
+    assert {:ok, %{data: %{"default" => %{"bar" => 42, "contextValue" => nil}}}} == Absinthe.run(doc, Schema)
+
+    doc = """
+    mutation {
+      changeContext {
+        bar
+        contextValue
+      }
+    }
+    """
+    assert {:ok, %{data: %{"changeContext" => %{"bar" => 42, "contextValue" => 7}}}} == Absinthe.run(doc, Schema)
+  end
+
+  test "it forbids context changes on non mutation fields" do
+    doc = """
+    query {
+      changeContextForbidden {
+        bar
+        contextValue
+      }
+    }
+    """
+    assert_raise Absinthe.ExecutionError, fn -> Absinthe.run(doc, Schema) end
+
+    doc = """
+    mutation {
+      default {
+        bar
+        contextValue
+        changeContextForbidden
+      }
+    }
+    """
+    assert_raise Absinthe.ExecutionError, fn -> Absinthe.run(doc, Schema) end
+  end
+
+end


### PR DESCRIPTION
Added integration test to cover this behaviour, while validating that non-mutation resolvers are forbidden from attempting to mutate the context.