### PR TITLE
Fix Elixir 1.4 warnings on missing parens for function calls.

### DIFF
--- a/lib/absinthe/phase/document/validation/provided_an_operation.ex
+++ b/lib/absinthe/phase/document/validation/provided_an_operation.ex
@@ -26,7 +26,7 @@ defmodule Absinthe.Phase.Document.Validation.ProvidedAnOperation do
   defp handle_node(%Blueprint{operations: []} = node) do
     node
     |> flag_invalid(:no_operations)
-    |> put_error(error)
+    |> put_error(error())
   end
   defp handle_node(node) do
     node
@@ -45,7 +45,7 @@ defmodule Absinthe.Phase.Document.Validation.ProvidedAnOperation do
   defp error do
     Phase.Error.new(
       __MODULE__,
-      error_message
+      error_message()
     )
   end
 

--- a/lib/absinthe/phase/document/validation/selected_current_operation.ex
+++ b/lib/absinthe/phase/document/validation/selected_current_operation.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
       {nil, count} when count > 1 ->
         input
         |> flag_invalid(:no_current_operation)
-        |> put_error(error)
+        |> put_error(error())
       _ ->
         input
     end
@@ -29,7 +29,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
   defp error do
     Phase.Error.new(
       __MODULE__,
-      error_message
+      error_message()
     )
   end
 

--- a/lib/absinthe/phase/document/validation/unique_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_argument_names.ex
@@ -55,7 +55,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   defp error(node) do
     Phase.Error.new(
       __MODULE__,
-      error_message,
+      error_message(),
       location: node.source_location
     )
   end

--- a/lib/absinthe/phase/document/validation/unique_input_field_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_input_field_names.ex
@@ -50,7 +50,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueInputFieldNames do
   defp error(node) do
     Phase.Error.new(
       __MODULE__,
-      error_message,
+      error_message(),
       location: node.source_location
     )
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,10 +10,10 @@ defmodule Absinthe.Mixfile do
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
+     package: package(),
      source_url: "https://github.com/absinthe-graphql/absinthe",
      docs: [source_ref: "v#{@version}", main: "Absinthe"],
-     deps: deps
+     deps: deps()
     ]
   end
 


### PR DESCRIPTION
Automatically fixed with a little utility I just wrote:

https://gist.github.com/vic/7764646521bfa4d4449e8539e3a25892