### PR TITLE
Add failing case for camel case strings resolution

### DIFF
--- a/test/lib/absinthe/execution/default_resolver_test.exs
+++ b/test/lib/absinthe/execution/default_resolver_test.exs
@@ -1,8 +1,8 @@
 defmodule Absinthe.Execution.DefaultResolverTest do
   use Absinthe.Case, async: true
 
-  @root %{:foo => "baz", "bar" => "quux"}
-  @query "{ foo bar }"
+  @root %{:foo => "baz", "bar" => "quux", "foo_bar" => "quix"}
+  @query "{ foo bar fooBar }"
 
   describe "without a custom default resolver defined" do
 
@@ -12,12 +12,13 @@ defmodule Absinthe.Execution.DefaultResolverTest do
       query do
         field :foo, :string
         field :bar, :string
+        field :foo_bar, :string
       end
 
     end
 
     it "should resolve using atoms" do
-      assert {:ok, %{data: %{"foo" => "baz", "bar" => nil}}} == Absinthe.run(@query, NormalSchema, root_value: @root)
+      assert {:ok, %{data: %{"foo" => "baz", "bar" => nil, "fooBar" => nil}}} == Absinthe.run(@query, NormalSchema, root_value: @root)
     end
 
   end
@@ -30,6 +31,7 @@ defmodule Absinthe.Execution.DefaultResolverTest do
       query do
         field :foo, :string
         field :bar, :string
+        field :foo_bar, :string
       end
 
       default_resolve fn
@@ -42,8 +44,8 @@ defmodule Absinthe.Execution.DefaultResolverTest do
 
     end
 
-    it "should resolve using as defined" do
-      assert {:ok, %{data: %{"foo" => "baz", "bar" => "quux"}}} == Absinthe.run(@query, CustomSchema, root_value: @root)
+    it "should resolve using strings or atoms" do
+      assert {:ok, %{data: %{"foo" => "baz", "bar" => "quux", "fooBar" => "quix"}}} == Absinthe.run(@query, CustomSchema, root_value: @root)
     end
 
   end


### PR DESCRIPTION
When a default resolver is used it doesn't play nicely with the `LanguageConventions` adapter. In this case, using camel case string keys causes an atom lookup error because the key hasn't been converted to snake case.

The initial commit adds a failing test to `default_resolver_test.exs` illustrating the issue. I don't entirely understand the flow of queries through to resolution and where/what to alter to get this working. It seems like key conversion should happen before fields are resolved, right?

Within the app I'm working on I'm manually calling `to_internal_name/2` to work around the issue:

```elixir
  default_resolve fn
    _, %{source: source, definition: %{name: name}} when is_map(source) ->
      name = LanguageConventions.to_internal_name(name, nil)

      {:ok, Map.get(source, name) || Map.get(source, String.to_existing_atom(name))}
    _, _ ->
      {:ok, nil}
  end
```

Though I could dynamically get the adapter, this seems unnecessary.