### PR TITLE
Adding failing tests for enforcing non_null fields in input variables

### DIFF
--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -202,8 +202,8 @@ defmodule AbsintheTest do
 
   it "enforces non_null fields in input passed as variable" do
     query = """
-    mutation UpdateStuff($input: InputStuff!) {
-      stuff_result: update_stuff(stuff: $input)
+    query Stuff($input: InputStuff!) {
+      stuff_result: stuff(stuff: $input)
     }
     """
     result = run(query, Things, variables: %{"input" => %{"value" => 5, "nonNullField" => nil}})

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -200,6 +200,19 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"thing" => %{"name" => "Foo", "value" => 100}}}}, result
   end
 
+  it "enforces non_null fields in input passed as variable" do
+    query = """
+    mutation UpdateStuff($input: InputStuff!) {
+      stuff_result: update_stuff(stuff: $input)
+    }
+    """
+    result = run(query, Things, variables: %{"input" => %{"value" => 5, "nonNullField" => nil}})
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "stuff" has invalid value $input.\nIn field "nonNullField": Expected type "String!", found null.)}]}}, result
+
+    result = run(query, Things, variables: %{"input" => %{"value" => 5}})
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "stuff" has invalid value $input.\nIn field "nonNullField": Expected type "String!", found null.)}]}}, result
+  end
+
   it "checks for badly formed nested arguments" do
     query = """
     mutation UpdateThingValueBadly {

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -13,6 +13,16 @@ defmodule Things do
 
   mutation do
 
+    field :update_stuff,
+      type: :integer,
+      args: [
+        stuff: [type: non_null(:input_stuff)]
+      ],
+      resolve: fn
+        %{}, _ ->
+          {:ok, 14}
+      end
+
     field :update_thing,
       type: :thing,
       args: [
@@ -156,6 +166,11 @@ defmodule Things do
     field :deprecated_field_with_reason, :string, deprecate: "reason"
     field :deprecated_non_null_field, non_null(:string), deprecate: true
     field :deprecated_field_with_reason, :string, deprecate: "reason"
+  end
+
+  input_object :input_stuff do
+    field :value, :integer
+    field :non_null_field, non_null(:string)
   end
 
   object :thing do

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -13,16 +13,6 @@ defmodule Things do
 
   mutation do
 
-    field :update_stuff,
-      type: :integer,
-      args: [
-        stuff: [type: non_null(:input_stuff)]
-      ],
-      resolve: fn
-        %{}, _ ->
-          {:ok, 14}
-      end
-
     field :update_thing,
       type: :thing,
       args: [
@@ -68,6 +58,16 @@ defmodule Things do
       resolve: fn
        %{val: v}, _ -> {:ok, v |> to_string}
        args, _ -> {:error, "got #{inspect args}"}
+      end
+
+    field :stuff,
+      type: :integer,
+      args: [
+        stuff: [type: non_null(:input_stuff)]
+      ],
+      resolve: fn
+        %{}, _ ->
+          {:ok, 14}
       end
 
     field :thing_by_context,


### PR DESCRIPTION
Currently if an input object is passed as a variable and one of its `non_null` fields has a null value, Absinthe returns an error. If the `non_null` field is omitted altogether, the mutation succeeds. 

IIRC, this this behaviour doesn't manifest itself when the input object is inlined instead of being passed as a variable.

This PR adds tests verifying that the mutation returns an error in both cases.