### PR TITLE
Fix: enforcing non_null fields in input variables

### DIFF
--- a/lib/absinthe/blueprint/input/object.ex
+++ b/lib/absinthe/blueprint/input/object.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Input.Object do
   @type t :: %__MODULE__{
     fields: [Blueprint.Input.Field.t],
     flags: Blueprint.flags_t,
-    schema_node: nil | Absinthe.Type.InputObject.t,
+    schema_node: nil | Absinthe.Type.InputObject.t | Absinthe.Type.NonNull.t,
     source_location: Blueprint.Document.SourceLocation.t,
     errors: [Absinthe.Phase.Error.t],
   }

--- a/lib/absinthe/phase/document/missing_literals.ex
+++ b/lib/absinthe/phase/document/missing_literals.ex
@@ -24,6 +24,10 @@ defmodule Absinthe.Phase.Document.MissingLiterals do
     arguments = fill_missing_nodes(Blueprint.Input.Argument, arguments, schema_args, node.source_location, adapter, schema)
     %{node | arguments: arguments}
   end
+  defp populate_node(%Blueprint.Input.Object{fields: fields, schema_node: %Absinthe.Type.NonNull{of_type: %Absinthe.Type.InputObject{fields: schema_fields}}} = node, adapter, schema) do
+    fields = fill_missing_nodes(Blueprint.Input.Field, fields, schema_fields, node.source_location, adapter, schema)
+    %{node | fields: fields}
+  end
   defp populate_node(%Blueprint.Input.Object{fields: fields, schema_node: %{fields: schema_fields}} = node, adapter, schema) do
     fields = fill_missing_nodes(Blueprint.Input.Field, fields, schema_fields, node.source_location, adapter, schema)
     %{node | fields: fields}

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -202,8 +202,8 @@ defmodule AbsintheTest do
 
   it "enforces non_null fields in input passed as variable" do
     query = """
-    mutation UpdateStuff($input: InputStuff!) {
-      stuff_result: update_stuff(stuff: $input)
+    query Stuff($input: InputStuff!) {
+      stuff_result: stuff(stuff: $input)
     }
     """
     result = run(query, Things, variables: %{"input" => %{"value" => 5, "nonNullField" => nil}})

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -200,6 +200,19 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"thing" => %{"name" => "Foo", "value" => 100}}}}, result
   end
 
+  it "enforces non_null fields in input passed as variable" do
+    query = """
+    mutation UpdateStuff($input: InputStuff!) {
+      stuff_result: update_stuff(stuff: $input)
+    }
+    """
+    result = run(query, Things, variables: %{"input" => %{"value" => 5, "nonNullField" => nil}})
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "stuff" has invalid value $input.\nIn field "nonNullField": Expected type "String!", found null.)}]}}, result
+
+    result = run(query, Things, variables: %{"input" => %{"value" => 5}})
+    assert_result {:ok, %{errors: [%{message: ~s(Argument "stuff" has invalid value $input.\nIn field "nonNullField": Expected type "String!", found null.)}]}}, result
+  end
+
   it "checks for badly formed nested arguments" do
     query = """
     mutation UpdateThingValueBadly {

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -13,6 +13,16 @@ defmodule Things do
 
   mutation do
 
+    field :update_stuff,
+      type: :integer,
+      args: [
+        stuff: [type: non_null(:input_stuff)]
+      ],
+      resolve: fn
+        %{}, _ ->
+          {:ok, 14}
+      end
+
     field :update_thing,
       type: :thing,
       args: [
@@ -156,6 +166,11 @@ defmodule Things do
     field :deprecated_field_with_reason, :string, deprecate: "reason"
     field :deprecated_non_null_field, non_null(:string), deprecate: true
     field :deprecated_field_with_reason, :string, deprecate: "reason"
+  end
+
+  input_object :input_stuff do
+    field :value, :integer
+    field :non_null_field, non_null(:string)
   end
 
   object :thing do

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -13,16 +13,6 @@ defmodule Things do
 
   mutation do
 
-    field :update_stuff,
-      type: :integer,
-      args: [
-        stuff: [type: non_null(:input_stuff)]
-      ],
-      resolve: fn
-        %{}, _ ->
-          {:ok, 14}
-      end
-
     field :update_thing,
       type: :thing,
       args: [
@@ -68,6 +58,16 @@ defmodule Things do
       resolve: fn
        %{val: v}, _ -> {:ok, v |> to_string}
        args, _ -> {:error, "got #{inspect args}"}
+      end
+
+    field :stuff,
+      type: :integer,
+      args: [
+        stuff: [type: non_null(:input_stuff)]
+      ],
+      resolve: fn
+        %{}, _ ->
+          {:ok, 14}
       end
 
     field :thing_by_context,


### PR DESCRIPTION
These are the tests from https://github.com/absinthe-graphql/absinthe/pull/237 plus a proposed fix.

I was thinking of handling both cases in one function head, like this:
```elixir
defp populate_node(%Blueprint.Input.Object{fields: fields, schema_node: %{} = schema_node} = node, adapter, schema) do
  %{fields: schema_fields} = Type.unwrap_non_null(schema_node)
  fields = fill_missing_nodes(Blueprint.Input.Field, fields, schema_fields, node.source_location, adapter, schema)
  %{node | fields: fields}
end
```
but this approach failed another test:
```
1) test literal arguments boolean arguments returns a correct error when passed the wrong type (Absinthe.Execution.ArgumentsTest)
    test/lib/absinthe/execution/arguments_test.exs:398
```

I'm not sure if this is the best way of implementing the fix - hence the separate PR in case you want to use the tests and change how the fix is implemented.