### PR TITLE
Fix `nil` arguments collection passed to the resolvers if all optional arguments are omitted.

### DIFF
--- a/lib/absinthe/blueprint/document/field.ex
+++ b/lib/absinthe/blueprint/document/field.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Blueprint.Document.Field do
     alias: nil,
     selections: [],
     arguments: [],
-    argument_data: nil,
+    argument_data: %{},
     directives: [],
     # Added by phases
     flags: %{},

--- a/test/lib/absinthe/execution/arguments_test.exs
+++ b/test/lib/absinthe/execution/arguments_test.exs
@@ -71,7 +71,7 @@ defmodule Absinthe.Execution.ArgumentsTest do
       field :contact, :contact_type do
         arg :type, :contact_type
 
-        resolve fn %{type: val}, _ -> {:ok, val} end
+        resolve fn args, _ -> {:ok, Map.get(args, :type)} end
       end
 
       field :contacts, list_of(:string) do
@@ -269,6 +269,15 @@ defmodule Absinthe.Execution.ArgumentsTest do
         assert_result {:ok, %{data: %{"contacts" => []}}}, doc |> run(Schema, variables: %{})
       end
 
+    end
+
+    describe "nullable arguments" do
+      it "if omitted should still be passed as an argument map to the resolver" do
+        doc = """
+        query GetContact{ contact }
+        """
+        assert_result {:ok, %{data: %{"contact" => nil}}}, doc |> run(Schema)
+      end
     end
 
     describe "enum types" do


### PR DESCRIPTION
In the resolvers we are assuming that the arguments are a map and I think it's a sane assumption to make. It used to be the case before 1.2.2, but https://github.com/absinthe-graphql/absinthe/commit/55d023cc6df48386fddf41cd15e5e9ca1d2f1813#diff-9e88b6c0fafa4e1d518da81f1c8f16a8L106 introduced the change in behaviour.

Without the fix, the change pushes the responsibility of `nil`-checking the arguments onto the individual resolvers.