### PR TITLE
Support multiple field errors / Better exception message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ erl_crash.dump
 *.ez
 src/*.erl
 .tool-versions*
+missing_rules.rb

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -220,11 +220,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> to_result(bp_field, full_type)
     |> walk_result(acc, bp_field, full_type, info)
   end
-  # Error result; force wrap of single, single-value Keyword.t errors
-  defp build_result({:error, [{_, _}] = error_value} = err, acc, bp_field, info, source) do
-    build_error_result(err, [error_value], acc, bp_field, info, source)
-  end
-  # Error result; force wrap of single, multiple-value Keyword.t errors
+  # Error result; force wrap of single Keyword.t errors
   defp build_result({:error, [{_, _} | _] = error_value} = err, acc, bp_field, info, source) do
     build_error_result(err, [error_value], acc, bp_field, info, source)
   end  

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -14,7 +14,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   alias Absinthe.Phase
   use Absinthe.Phase
 
-  @resultdoc """
+  @error_detail """
   ## For a data result
 
   `{:ok, any}` result will do.
@@ -65,32 +65,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   See `Absinthe.Resolution.Plugin` for more information.
       
   """
-
-  @typedoc @resultdoc
-  @type result :: {:ok, any} | {:error, error_value}
-
-  @typedoc """
-  An error message is a human-readable string describing the error that occurred.
-  """
-  @type error_message :: String.t
-
-  @typedoc """
-  Any serializable value.
-  """
-  @type serializable :: any  
-
-  @typedoc """
-  A custom error may be a `map` or a `Keyword.t`, but must contain a `:message` key.
-
-  Note that the values that make up a custom error must be serializable.
-  """
-  @type custom_error :: %{required(:message) => error_message, optional(atom) => serializable} | Keyword.t
-
-  @typedoc """
-  An error value is a simple error message, a custom error, or a list of either/both of them.
-  """
-  @type error_value :: error_message | custom_error | [error_message | custom_error]
-
+  
   @spec run(Blueprint.t, Keyword.t) :: Phase.result_t
   def run(bp_root, options \\ []) do
     case Blueprint.current_operation(bp_root) do
@@ -278,7 +253,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
     The result must be one of the following...
 
-    #{@resultdoc}
+    #{@error_detail}
     """
   end
 

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -57,6 +57,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   Three errors of mixed types:
 
       {:error, ["Simple message", [message: "A keyword list error", code: 1], %{message: "A map error"}]}
+
+  ## To activate a plugin
+
+  `{:plugin, NameOfPluginModule, term}` to activate a plugin.
+
+  See `Absinthe.Resolution.Plugin` for more information.
       
   """
 

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -20,18 +20,44 @@ defmodule Absinthe.Type.Field do
 
   See the `Absinthe.Type.Field.t` explanation of `:resolve` for more information.
   """
-  @type resolver_t :: ((%{atom => any}, Absinthe.Resolution.t) -> resolver_output)
-  @type resolver_output :: ok_output | error_output | plugin_output
+  @type resolver_t :: ((%{atom => any}, Absinthe.Resolution.t) -> result)
 
-  @type ok_output :: {:ok, any}
-  @type error_output :: {:error, binary} | {:error, map | Keyword.t}
-  @type plugin_output :: {:plugin, Absinthe.Resolution.Plugin.t, term}
+  @typedoc """
+  The result of a resolver.
+  """
+  @type result :: ok_result | error_result | plugin_result
+
+  @type ok_result :: {:ok, any}
+  @type error_result :: {:error, error_value}
+  @type plugin_result :: {:plugin, Absinthe.Resolution.Plugin.t, term}
+
+  @typedoc """
+  An error message is a human-readable string describing the error that occurred.
+  """
+  @type error_message :: String.t
+
+  @typedoc """
+  Any serializable value.
+  """
+  @type serializable :: any  
+
+  @typedoc """
+  A custom error may be a `map` or a `Keyword.t`, but must contain a `:message` key.
+
+  Note that the values that make up a custom error must be serializable.
+  """
+  @type custom_error :: %{required(:message) => error_message, optional(atom) => serializable} | Keyword.t
+
+  @typedoc """
+  An error value is a simple error message, a custom error, or a list of either/both of them.
+  """
+  @type error_value :: error_message | custom_error | [error_message | custom_error]
 
   @typedoc """
   The configuration for a field.
 
   * `:name` - The name of the field, usually assigned automatically by
-  the `Absinthe.Schema.Notation.field/1`.
+     the `Absinthe.Schema.Notation.field/1`.
   * `:description` - Description of a field, useful for introspection.
   * `:deprecation` - Deprecation information for a field, usually
      set-up using `Absinthe.Schema.Notation.deprecate/1`.

--- a/missing_rules.rb
+++ b/missing_rules.rb
@@ -1,0 +1,37 @@
+require 'yaml'
+
+def cram(str)
+  str.tr('_', ' ').
+  gsub(/\s+/, ' ').
+  gsub(/\b\w/){ $`[-1,1] == "'" ? $& : $&.upcase }.
+  gsub(/\s+/, '')
+end
+
+def filesize(f)
+  YAML.load(`cloc '#{f}' --quiet --yaml`)['SUM']['code']
+end
+
+js = {}
+ex = {}
+
+implemented = Dir['lib/absinthe/phase/**/*.ex'].select { |f|
+  f.include?('validation')
+}.map { |f|
+  result = cram(File.basename(f, '.ex'))
+  ex[result] = filesize(f)
+  result
+}.select { |f|
+  f != 'Validation'
+}
+
+needed = Dir['../../src/graphql-js/src/validation/rules/**/*.js'].map { |f|
+  result = File.basename(f, '.js')
+  js[result] = filesize(f)
+  result
+}
+
+puts "Implemented #{implemented.size}/#{needed.size} rules"
+puts "Done:"
+puts implemented.sort.map { |f| "- #{f} (.js LOC: #{js[f]}, .ex LOC: #{ex[f]})" }
+puts "Missing:"
+puts (needed - implemented).sort.map { |f| "- #{f} (.js LOC: #{js[f]})"}

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -2,6 +2,11 @@ defmodule AbsintheTest do
   use Absinthe.Case, async: true
   import AssertResult
 
+  it "can return multiple errors" do
+    query = "mutation { FailingThing(type: MULTIPLE) { name } }"
+    assert_result {:ok, %{data: %{}, errors: [%{message: "In field \"FailingThing\": one"}, %{message: "In field \"FailingThing\": two"}]}}, run(query, Things)    
+  end
+
   it "can return extra error fields" do
     query = "mutation { FailingThing(type: WITH_CODE) { name } }"
     assert_result {:ok, %{data: %{}, errors: [%{code: 42, message: "In field \"FailingThing\": Custom Error"}]}}, run(query, Things)
@@ -11,6 +16,16 @@ defmodule AbsintheTest do
     query = "mutation { FailingThing(type: WITHOUT_MESSAGE) { name } }"
     assert_raise Absinthe.ExecutionError, fn -> run(query, Things) end
   end
+
+  it "can return multiple errors, with extra error fields" do
+    query = "mutation { FailingThing(type: MULTIPLE_WITH_CODE) { name } }"
+    assert_result {:ok, %{data: %{}, errors: [%{code: 1, message: "In field \"FailingThing\": Custom Error 1"}, %{code: 2, message: "In field \"FailingThing\": Custom Error 2"}]}}, run(query, Things)
+  end
+
+  it "requires message in extended errors, when multiple errors are given" do
+    query = "mutation { FailingThing(type: MULTIPLE_WITHOUT_MESSAGE) { name } }"
+    assert_raise Absinthe.ExecutionError, fn -> run(query, Things) end
+  end  
 
   it "can do a simple query" do
     query = """

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -7,8 +7,11 @@ defmodule Things do
   }
 
   enum :failure_type do
+    value :multiple
     value :with_code
     value :without_message
+    value :multiple_with_code
+    value :multiple_without_message
   end
 
   mutation do
@@ -31,10 +34,16 @@ defmodule Things do
     field :failing_thing, type: :thing do
       arg :type, type: :failure_type
       resolve fn
-        (%{type: :with_code}, _) ->
+        %{type: :multiple}, _ ->
+          {:error, ["one", "two"]}
+        %{type: :with_code}, _ ->
           {:error, message: "Custom Error", code: 42}
-        (%{type: :without_message}, _) ->
+        %{type: :without_message}, _ ->
           {:error, code: 42}
+        %{type: :multiple_with_code}, _ ->
+          {:error, [%{message: "Custom Error 1", code: 1}, %{message: "Custom Error 2", code: 2}]}
+        %{type: :multiple_without_message}, _ ->
+          {:error, [%{message: "Custom Error 1", code: 1}, %{code: 2}]}
       end
     end
 


### PR DESCRIPTION
- Support for returning multiple field errors during resolution
- Clean up and expand exception message when a field resolver returns an invalid result.

Here's an example exception (which also includes details about the possible, valid shapes of values returned from resolvers):

```
** (Absinthe.ExecutionError) Invalid value returned from resolver.

     Resolving field:

         FailingThing

     Defined at:

         /Users/bruce/Code/CS/absinthe/test/support/things.ex:34

     Resolving on:

         %{}

     Got value:

         {:error, [code: 42]}

     ...

     You're returning an :error tuple, but did you forget to include a `:message`
     key in every custom error (map or keyword list)?

     The result must be one of the following...

     ## For a valid result

     `{:ok, any}` result will do.

     ### Examples:

     A simple integer result:

         {:ok, 1}

     Something more complex:

         {:ok, %Model.Thing{some: %{complex: :data}}}

     ## For an error result

     One or more errors for a field can be returned in a single `{:error, error_value}` tuple.

     `error_value` can be:
     - A simple error message string.
     - A map containing `:message` key, plus any additional serializable metadata.
     - A keyword list containing a `:message` key, plus any additional serializable metadata.
     - A list containing multiple of any/all of these.

     ### Examples

     A simple error message:

         {:error, "Something bad happened"}

     Multiple error messages:

         {:error, ["Something bad", "Even worse"]

     Single custom errors (note the required `:message` keys):

         {:error, message: "Unknown user", code: 21}
         {:error, %{message: "A database error occurred", details: format_db_error(some_value)}}

     Three errors of mixed types:

         {:error, ["Simple message", [message: "A keyword list error", code: 1], %{message: "A map error"}]}
```