### PR TITLE
Deep merge for different levels

### DIFF
--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -68,7 +68,6 @@ defmodule Absinthe.Phase.Document.Result do
   defp deep_merge(list) when is_list(list) and length(list) <= 1 do
     :maps.from_list(list)
   end
-
   defp deep_merge(list) when is_list(list) do
     list
     |> Enum.map(&Map.new([&1]))
@@ -82,7 +81,9 @@ defmodule Absinthe.Phase.Document.Result do
   defp do_deep_resolve(_key, [%{} = left], [%{} = right]) do
     [do_deep_merge(right, left)]
   end
-
+  defp do_deep_resolve(_key, %{} = left, %{} = right) do
+    do_deep_merge(right, left)
+  end
   defp do_deep_resolve(_key, _left, right) do
    right
   end

--- a/test/lib/absinthe/fragment_merge_test.exs
+++ b/test/lib/absinthe/fragment_merge_test.exs
@@ -45,4 +45,30 @@ defmodule Absinthe.FragmentMergeTest do
     """
     assert {:ok, %{data: %{"viewer" => %{"todos" => [%{"totalCount" => 1, "completedCount" => 2}]}}}} == Absinthe.run(doc, Schema)
   end
+
+  test "it deep merges fields properly different levels" do
+    doc = """
+    {
+      viewer {
+        ...fragmentWithOneField
+      }
+      ...fragmentWithOtherField
+    }
+
+    fragment fragmentWithOneField on User {
+      todos {
+        totalCount,
+      }
+    }
+
+    fragment fragmentWithOtherField on RootQueryType {
+      viewer {
+        todos {
+          completedCount
+        }
+      }
+    }
+    """
+    assert {:ok, %{data: %{"viewer" => %{"todos" => [%{"totalCount" => 1, "completedCount" => 2}]}}}} == Absinthe.run(doc, Schema)
+  end
 end


### PR DESCRIPTION
Currently deep merge of fragments allows you to merge on the same
level but if you have fragments being included on different levels
the changes are ignored.