### PR TITLE
Demonstrate failing query

### DIFF
--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -38,6 +38,17 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"thing" => %{"name" => "Foo"}}}}, run(query, Things)
   end
 
+  it "will fail here" do
+    query = """
+    query GimmeFoo {
+      thing(id: ["foo"]) {
+        name
+      }
+    }
+    """
+    run(query, Things)
+  end
+
   it "can do a simple query with fragments" do
     query = """
     {


### PR DESCRIPTION
This test case shows that an error is raised in this query..

```
    query GimmeFoo {
      thing(id: ["foo"]) {
        name
      }
    }
```

The error arises when a `["list"]` is used instead of a single `"item"`... `id` is a `non_null(:string)`

```
  1) test will fail here (AbsintheTest)
     test/lib/absinthe_test.exs:41
     ** (FunctionClauseError) no function clause matching in Absinthe.Type.name/1
     stacktrace:
       (absinthe) lib/absinthe/type.ex:238: Absinthe.Type.name(nil)
       (absinthe) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:57: anonymous fn/2 in Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.collect_child_errors/2
       (elixir) lib/enum.ex:966: Enum.flat_map_list/2
       (absinthe) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:30: Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.handle_node/2
       (absinthe) lib/absinthe/blueprint/transform.ex:13: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
       (absinthe) lib/absinthe/blueprint/transform.ex:105: Absinthe.Blueprint.Transform.node_with_children/5
       (elixir) lib/enum.ex:1325: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:119: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.node_with_children/5
       (elixir) lib/enum.ex:1325: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:119: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.node_with_children/5
       (elixir) lib/enum.ex:1325: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:119: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.node_with_children/5
       (absinthe) lib/absinthe/blueprint/transform.ex:12: Absinthe.Blueprint.Transform.prewalk/2
       (absinthe) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:15: Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.run/2
```