### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -219,14 +219,14 @@ defmodule Absinthe do
     max_complexity: non_neg_integer | :infinity
   ]
 
-  @spec run(binary | Absinthe.Language.Source.t | Absinthe.Language.Document.t, Absinthe.Schema.t, run_opts) :: {:ok, result_t} | {:error, any}
+  @spec run(binary | Absinthe.Language.Source.t | Absinthe.Language.Document.t, Absinthe.Schema.t, run_opts) :: {:ok, result_t} | {:error, String.t}
   def run(document, schema, options \\ []) do
     pipeline = Absinthe.Pipeline.for_document(schema, options)
     case Absinthe.Pipeline.run(document, pipeline) do
       {:ok, result, _phases} ->
         {:ok, result}
-      other ->
-        other
+      {:error, msg, _phases} ->
+        {:error, msg}
     end
   end
 

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -30,8 +30,8 @@ defmodule Absinthe.Blueprint do
     schema: nil | Absinthe.Schema.t,
     adapter: nil | Absinthe.Adapter.t,
     # Added by phases
-    errors: [Blueprint.Phase.Error.t],
-    flags: Blueprint.flags_t,
+    errors: [Absinthe.Phase.Error.t],
+    flags: flags_t,
     resolution: Blueprint.Document.Resolution.t
   }
 
@@ -93,7 +93,7 @@ defmodule Absinthe.Blueprint do
   @doc """
   Get the currently selected operation.
   """
-  @spec current_operation(t) :: nil | Blueprint.Operation.t
+  @spec current_operation(t) :: nil | Blueprint.Document.Operation.t
   def current_operation(blueprint) do
     Enum.find(blueprint.operations, &(&1.current == true))
   end
@@ -101,7 +101,7 @@ defmodule Absinthe.Blueprint do
   @doc """
   Update the current operation.
   """
-  @spec update_current(t, (Blueprint.Operation.t -> Blueprint.Operation.t)) :: t
+  @spec update_current(t, (Blueprint.Document.Operation.t -> Blueprint.Document.Operation.t)) :: t
   def update_current(blueprint, change) do
     ops = Enum.map(blueprint.operations, fn
       %{current: true} = op ->

--- a/lib/absinthe/blueprint/document.ex
+++ b/lib/absinthe/blueprint/document.ex
@@ -1,6 +1,7 @@
 defmodule Absinthe.Blueprint.Document do
 
   @moduledoc false
+  alias Absinthe.Blueprint
 
   @type t ::
       Blueprint.Document.Field.t
@@ -9,7 +10,7 @@ defmodule Absinthe.Blueprint.Document do
     | Blueprint.Document.VariableDefinition.t
 
   @type selection_t ::
-      Field.t
+      Blueprint.Document.Field.t
     | Blueprint.Document.Fragment.Inline.t
     | Blueprint.Document.Fragment.Spread.t
 

--- a/lib/absinthe/blueprint/document/fragment.ex
+++ b/lib/absinthe/blueprint/document/fragment.ex
@@ -5,8 +5,8 @@ defmodule Absinthe.Blueprint.Document.Fragment do
   alias __MODULE__
 
   @type t ::
-      Fragment.Inline
-    | Fragment.Named
-    | Fragment.Spread
+      Fragment.Inline.t
+    | Fragment.Named.t
+    | Fragment.Spread.t
 
 end

--- a/lib/absinthe/blueprint/document/fragment/named/use.ex
+++ b/lib/absinthe/blueprint/document/fragment/named/use.ex
@@ -2,6 +2,8 @@ defmodule Absinthe.Blueprint.Document.Fragment.Named.Use do
 
   @moduledoc false
 
+  alias Absinthe.Blueprint
+
   @enforce_keys [:name, :source_location]
   defstruct [
     :name,

--- a/lib/absinthe/blueprint/document/fragment/spread.ex
+++ b/lib/absinthe/blueprint/document/fragment/spread.ex
@@ -15,7 +15,7 @@ defmodule Absinthe.Blueprint.Document.Fragment.Spread do
   ]
 
   @type t :: %__MODULE__{
-    directives: [Blueprint.Document.Directive.t],
+    directives: [Blueprint.Directive.t],
     errors: [Absinthe.Phase.Error.t],
     name: String.t,
     flags: Blueprint.flags_t,

--- a/lib/absinthe/blueprint/document/resolution.ex
+++ b/lib/absinthe/blueprint/document/resolution.ex
@@ -5,7 +5,7 @@ defmodule Absinthe.Blueprint.Document.Resolution do
   alias Absinthe.Phase
   alias __MODULE__
 
-  @type acc :: Map.t
+  @type acc :: map
 
   defstruct [
     validation: [],

--- a/lib/absinthe/blueprint/document/resolution/leaf.ex
+++ b/lib/absinthe/blueprint/document/resolution/leaf.ex
@@ -16,7 +16,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.Leaf do
     emitter: Blueprint.Document.Field.t,
     value: Blueprint.Document.Resolution.node_t,
     errors: [Phase.Error.t],
-    flags: [Blueprint.flag_t],
+    flags: Blueprint.flags_t,
   }
 
 end

--- a/lib/absinthe/blueprint/document/resolution/list.ex
+++ b/lib/absinthe/blueprint/document/resolution/list.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.List do
     emitter: Blueprint.Document.Field.t,
     values: [Blueprint.Document.Resolution.node_t],
     errors: [Phase.Error.t],
-    flags: [Blueprint.flag_t],
+    flags: Blueprint.flags_t,
   }
 
 end

--- a/lib/absinthe/blueprint/document/resolution/object.ex
+++ b/lib/absinthe/blueprint/document/resolution/object.ex
@@ -18,7 +18,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.Object do
     emitter: Blueprint.Document.Field.t,
     fields: [Blueprint.Document.Resolution.node_t],
     errors: [Phase.Error.t],
-    flags: [Blueprint.flag_t]
+    flags: Blueprint.flags_t
   }
 
 end

--- a/lib/absinthe/blueprint/document/source_location.ex
+++ b/lib/absinthe/blueprint/document/source_location.ex
@@ -2,13 +2,14 @@ defmodule Absinthe.Blueprint.Document.SourceLocation do
 
   @moduledoc false
 
+  @enforce_keys [:line]
   defstruct [
     line: nil,
     column: nil,
   ]
 
   @type t :: %__MODULE__{
-    line: nil | integer,
+    line: integer,
     column: nil | integer,
   }
 
@@ -16,8 +17,12 @@ defmodule Absinthe.Blueprint.Document.SourceLocation do
   Easily generate a SourceLocation.t give a line and optional column.
   """
   @spec at(integer) :: t
+  def at(line) do
+    %__MODULE__{line: line}
+  end
+
   @spec at(integer, integer) :: t
-  def at(line, column \\ nil) do
+  def at(line, column) do
     %__MODULE__{line: line, column: column}
   end
 

--- a/lib/absinthe/blueprint/input.ex
+++ b/lib/absinthe/blueprint/input.ex
@@ -19,7 +19,7 @@ defmodule Absinthe.Blueprint.Input do
       Blueprint.Input.List.t
     | Input.Object.t
 
-  @type t :: leaf | collection
+  @type t :: leaf | collection | Input.Value.t | Input.Argument.t
 
   @parse_types [
     Input.Boolean,

--- a/lib/absinthe/blueprint/input/boolean.ex
+++ b/lib/absinthe/blueprint/input/boolean.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Blueprint.Input.Boolean do
 
   @moduledoc false
 
-  alias Absinthe.Phase
+  alias Absinthe.{Blueprint, Phase}
 
   @enforce_keys [:value]
   defstruct [

--- a/lib/absinthe/blueprint/input/enum.ex
+++ b/lib/absinthe/blueprint/input/enum.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Blueprint.Input.Enum do
 
   @moduledoc false
 
-  alias Absinthe.{Phase}
+  alias Absinthe.{Blueprint, Phase}
 
   @enforce_keys [:value, :source_location]
   defstruct [

--- a/lib/absinthe/blueprint/input/float.ex
+++ b/lib/absinthe/blueprint/input/float.ex
@@ -2,6 +2,8 @@ defmodule Absinthe.Blueprint.Input.Float do
 
   @moduledoc false
 
+  alias Absinthe.Blueprint
+
   @enforce_keys [:value]
   defstruct [
     :value,

--- a/lib/absinthe/blueprint/input/integer.ex
+++ b/lib/absinthe/blueprint/input/integer.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Blueprint.Input.Integer do
 
   @moduledoc false
 
-  alias Absinthe.{Phase}
+  alias Absinthe.{Blueprint, Phase}
 
   @enforce_keys [:value]
   defstruct [

--- a/lib/absinthe/blueprint/input/string.ex
+++ b/lib/absinthe/blueprint/input/string.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Blueprint.Input.String do
 
   @moduledoc false
 
-  alias Absinthe.{Phase}
+  alias Absinthe.{Blueprint, Phase}
 
   @enforce_keys [:value]
   defstruct [

--- a/lib/absinthe/blueprint/input/variable/use.ex
+++ b/lib/absinthe/blueprint/input/variable/use.ex
@@ -2,6 +2,8 @@ defmodule Absinthe.Blueprint.Input.Variable.Use do
 
   @moduledoc false
 
+  alias Absinthe.Blueprint
+
   @enforce_keys [:name, :source_location]
   defstruct [
     :name,

--- a/lib/absinthe/blueprint/schema/directive_definition.ex
+++ b/lib/absinthe/blueprint/schema/directive_definition.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
   @type t :: %__MODULE__{
     name: String.t,
     description: nil,
-    arguments: [Blueprint.ArgumentDefinition.t],
+    arguments: [Blueprint.Schema.InputValueDefinition.t],
     locations: [String.t],
     errors: [Absinthe.Phase.Error.t],
   }

--- a/lib/absinthe/blueprint/schema/interface_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/interface_type_definition.ex
@@ -2,6 +2,8 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
 
   @moduledoc false
 
+  alias Absinthe.Blueprint
+
   @enforce_keys [:name]
   defstruct [
     :name,

--- a/lib/absinthe/language/field_definition.ex
+++ b/lib/absinthe/language/field_definition.ex
@@ -1,7 +1,7 @@
 defmodule Absinthe.Language.FieldDefinition do
   @moduledoc false
 
-  alias Absinthe.{Blueprint ,Language}
+  alias Absinthe.{Blueprint, Language}
 
   defstruct [
     name: nil,

--- a/lib/absinthe/language/input_value_definition.ex
+++ b/lib/absinthe/language/input_value_definition.ex
@@ -15,7 +15,7 @@ defmodule Absinthe.Language.InputValueDefinition do
   @type t :: %__MODULE__{
     name: String.t,
     type: Language.input_t,
-    default_value: Language.Input.t,
+    default_value: Language.input_t,
     directives: [Language.Directive.t],
     loc: Language.loc_t,
   }

--- a/lib/absinthe/language/int_value.ex
+++ b/lib/absinthe/language/int_value.ex
@@ -1,7 +1,7 @@
 defmodule Absinthe.Language.IntValue do
   @moduledoc false
 
-  alias Absinthe.Blueprint
+  alias Absinthe.{Blueprint, Language}
 
   defstruct [
     :value,

--- a/lib/absinthe/phase.ex
+++ b/lib/absinthe/phase.ex
@@ -18,6 +18,7 @@ defmodule Absinthe.Phase do
     | {:error, String.t}
 
   alias __MODULE__
+  alias Absinthe.Blueprint
 
   defmacro __using__(_) do
     quote do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -209,24 +209,24 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
   # Everything else; raise
   defp build_result(other, _, field, _, source) do
-    raise_result_error!(other, field, source)
+    raise result_error(other, field, source)
   end
 
-  defp raise_result_error!({:error, _} = value, field, source) do
-    raise_result_error!(
+  defp result_error({:error, _} = value, field, source) do
+    result_error(
       value, field, source,
       "You're returning an :error tuple, but did you forget to include a `:message`\nkey in every custom error (map or keyword list)?"
     )
   end
-  defp raise_result_error!(value, field, source) do
-    raise_result_error!(
+  defp result_error(value, field, source) do
+    result_error(
       value, field, source,
       "Did you forget to return a valid `{:ok, any}` | `{:error, error_value}` tuple?"
     )
   end
 
-  defp raise_result_error!(value, field, source, guess) do
-    raise Absinthe.ExecutionError, """
+  defp result_error(value, field, source, guess) do
+    Absinthe.ExecutionError.exception("""
     Invalid value returned from resolver.
 
     Resolving field:
@@ -254,7 +254,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     The result must be one of the following...
 
     #{@error_detail}
-    """
+    """)
   end
 
   defp build_error_result(original_value, error_values, acc, bp_field, info, source) do
@@ -267,7 +267,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp put_result_error_value(error_value, result, original_value, bp_field, source) do
     case split_error_value(error_value) do
       {[], _} ->
-        raise_result_error!(original_value, bp_field, source)
+        raise result_error(original_value, bp_field, source)
       {[message: message], extra} ->
         message = ~s(In field "#{bp_field.name}": #{message})
         put_error(result, error(bp_field, message, extra))

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -297,7 +297,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     Type.Field.resolve(concrete_schema_node, args, source, info)
   end
 
-  @spec to_result(resolution_result :: term, blueprint :: Blueprint.t, schema_type :: Type.t) :: Resolution.t
+  @spec to_result(resolution_result :: term, blueprint :: Blueprint.Document.Field.t, schema_type :: Type.t) ::
+    Resolution.node_t
   defp to_result(nil, blueprint, %Type.NonNull{} = schema_type) do
     raise Absinthe.ExecutionError, nil_value_error(blueprint, schema_type)
   end

--- a/lib/absinthe/phase/document/uses.ex
+++ b/lib/absinthe/phase/document/uses.ex
@@ -38,7 +38,7 @@ defmodule Absinthe.Phase.Document.Uses do
 
   @spec handle_use(Blueprint.node_t, acc_t) :: {Blueprint.node_t, acc_t}
   defp handle_use(%Blueprint.Document.Fragment.Spread{} = node, acc) do
-    if uses?(acc, node) do
+    if uses?(acc.fragments, node) do
       {node, acc}
     else
       target_fragment = Enum.find(acc.fragments_available, &(&1.name == node.name))
@@ -59,21 +59,8 @@ defmodule Absinthe.Phase.Document.Uses do
     {node, acc}
   end
 
-  @fragment_types [
-    Blueprint.Document.Fragment.Named,
-    Blueprint.Document.Fragment.Spread
-  ]
-
-  @spec uses?(acc_t, Blueprint.node_t) :: boolean
-  defp uses?(acc, %struct{} = node) when struct in @fragment_types do
-    do_uses?(acc.fragments, node)
-  end
-  defp uses?(acc, %Blueprint.Input.Variable{} = node) do
-    do_uses?(acc.variables, node)
-  end
-
-  @spec do_uses?([Blueprint.use_t], Blueprint.node_t) :: boolean
-  defp do_uses?(list, node) do
+  @spec uses?([Blueprint.use_t], Blueprint.Document.Fragment.Spread.t) :: boolean
+  defp uses?(list, node) do
     Enum.find(list, &(&1.name == node.name))
   end
 

--- a/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
+++ b/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
@@ -33,19 +33,28 @@ defmodule Absinthe.Phase.Document.Validation.NoFragmentCycles do
   # Check a list of fragments for cycles
   @spec check([Blueprint.Document.Fragment.Named.t]) :: {[Blueprint.Document.Fragment.Named.t], integer}
   defp check(fragments) do
-    {_, graph} = Blueprint.prewalk(fragments, :digraph.new([:cyclic]), &vertex/2)
+    graph = :digraph.new([:cyclic])
+    try do
+      check(fragments, graph)
+    after
+      :digraph.delete(graph)
+    end
+  end
+
+  @spec check([Blueprint.Document.Fragment.Named.t], :digraph.graph) :: {[Blueprint.Document.Fragment.Named.t], integer}
+  defp check(fragments, graph) do
+    Enum.each(fragments, fn(node) -> Blueprint.prewalk(node, &vertex(&1, graph)) end)
     {modified, error_count} = Enum.reduce(fragments, {[], 0}, fn
       fragment, {processed, error_count} ->
         errors_to_add = cycle_errors(fragment, :digraph.get_cycle(graph, fragment.name))
         fragment_with_errors = update_in(fragment.errors, &(errors_to_add ++ &1))
         {[fragment_with_errors | processed], error_count + length(errors_to_add)}
     end)
-    :digraph.delete(graph)
     {modified, error_count}
   end
 
   # Add a vertex modeling a fragment
-  @spec vertex(Blueprint.Document.Fragment.Named.t, :digraph.graph) :: {Blueprint.Document.Fragment.Named.t, :digraph.graph}
+  @spec vertex(Blueprint.Document.Fragment.Named.t, :digraph.graph) :: Blueprint.Document.Fragment.Named.t
   defp vertex(%Blueprint.Document.Fragment.Named{} = fragment, graph) do
     :digraph.add_vertex(graph, fragment.name)
     Enum.each(fragment.selections, fn
@@ -54,10 +63,10 @@ defmodule Absinthe.Phase.Document.Validation.NoFragmentCycles do
       _ ->
         false
     end)
-    {fragment, graph}
+    fragment
   end
-  defp vertex(fragment, graph) do
-    {fragment, graph}
+  defp vertex(fragment, _graph) do
+    fragment
   end
 
   # Add an edge, modeling the relationship between two fragments

--- a/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
+++ b/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
@@ -90,7 +90,7 @@ defmodule Absinthe.Phase.Document.Validation.NoFragmentCycles do
   end
 
   # Generate the error for a fragment cycle
-  @spec cycle_error(Blueprint.Document.Fragment.Named.t, String.t) :: Phase.t
+  @spec cycle_error(Blueprint.Document.Fragment.Named.t, String.t) :: Phase.Error.t
   defp cycle_error(fragment, message) do
     %Phase.Error{
       message: message,

--- a/lib/absinthe/phase/document/validation/no_undefined_variables.ex
+++ b/lib/absinthe/phase/document/validation/no_undefined_variables.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Phase.Document.Validation.NoUndefinedVariables do
   end
 
   # Generate the error for the node
-  @spec error(Blueprint.Input.Variable.t, Blueprint.Operation.t) :: Phase.Error.t
+  @spec error(Blueprint.Input.Variable.t, Blueprint.Document.Operation.t) :: Phase.Error.t
   defp error(node, operation) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/document/validation/no_unused_variables.ex
+++ b/lib/absinthe/phase/document/validation/no_unused_variables.ex
@@ -43,7 +43,7 @@ defmodule Absinthe.Phase.Document.Validation.NoUnusedVariables do
   end
 
   # Generate the error for the node
-  @spec error(Blueprint.Document.VariableDefinition.t, Blueprint.Operation.t) :: Phase.Error.t
+  @spec error(Blueprint.Document.VariableDefinition.t, Blueprint.Document.Operation.t) :: Phase.Error.t
   defp error(node, operation) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/document/validation/unique_argument_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_argument_names.ex
@@ -34,13 +34,13 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   end
 
   # Check an argument, finding any duplicates
-  @spec process(Blueprint.Argument.t, [Blueprint.Input.Argument.t]) :: Blueprint.Input.Argument.t
+  @spec process(Blueprint.Input.Argument.t, [Blueprint.Input.Argument.t]) :: Blueprint.Input.Argument.t
   defp process(argument, arguments) do
     check_duplicates(argument, Enum.filter(arguments, &(&1.name == argument.name)))
   end
 
   # Add flags and errors if necessary for each argument.
-  @spec check_duplicates(Blueprint.Argument.t, [Blueprint.Input.Argument.t]) :: Blueprint.Input.Argument.t
+  @spec check_duplicates(Blueprint.Input.Argument.t, [Blueprint.Input.Argument.t]) :: Blueprint.Input.Argument.t
   defp check_duplicates(argument, [_single]) do
     argument
   end
@@ -51,7 +51,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueArgumentNames do
   end
 
   # Generate an error for a duplicate argument.
-  @spec error(Blueprint.Argument.t) :: Phase.Error.t
+  @spec error(Blueprint.Input.Argument.t) :: Phase.Error.t
   defp error(node) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/document/validation/unique_fragment_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_fragment_names.ex
@@ -20,7 +20,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueFragmentNames do
     {:ok, result}
   end
 
-  @spec process(Blueprint.Document.Fragment.Named.t, [Blueprint.Document.Fragment.Named.t]) :: boolean
+  @spec process(Blueprint.Document.Fragment.Named.t, [Blueprint.Document.Fragment.Named.t]) ::
+    Blueprint.Document.Fragment.Named.t
   defp process(fragment, fragments) do
     if duplicate?(fragments, fragment) do
       fragment

--- a/lib/absinthe/phase/document/validation/unique_input_field_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_input_field_names.ex
@@ -46,7 +46,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueInputFieldNames do
   end
 
   # Generate an error for an input field
-  @spec error(Blueprint.Input.Field.t) :: Phase.t
+  @spec error(Blueprint.Input.Field.t) :: Phase.Error.t
   defp error(node) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/document/validation/unique_operation_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_operation_names.ex
@@ -20,7 +20,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueOperationNames do
     {:ok, result}
   end
 
-  @spec process(Blueprint.Document.Operation.t, [Blueprint.Document.Operation.t]) :: boolean
+  @spec process(Blueprint.Document.Operation.t, [Blueprint.Document.Operation.t]) ::
+    Blueprint.Document.Operation.t
   defp process(%{name: nil} = operation, _) do
     operation
   end

--- a/lib/absinthe/phase/document/validation/unique_variable_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_variable_names.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueVariableNames do
   end
 
   # Generate an error for a duplicate variable_definition.
-  @spec error(Blueprint.Document.Variable.t) :: Phase.Error.t
+  @spec error(Blueprint.Document.VariableDefinition.t) :: Phase.Error.t
   defp error(node) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/document/validation/unique_variable_names.ex
+++ b/lib/absinthe/phase/document/validation/unique_variable_names.ex
@@ -24,7 +24,8 @@ defmodule Absinthe.Phase.Document.Validation.UniqueVariableNames do
     {:ok, result}
   end
 
-  @spec process(Blueprint.Document.VariableDefinition.t, [Blueprint.Document.VariableDefinition.t]) :: boolean
+  @spec process(Blueprint.Document.VariableDefinition.t,[Blueprint.Document.VariableDefinition.t]) ::
+    Blueprint.Document.VariableDefinition.t
   defp process(variable_definition, variable_definitions) do
     if duplicate?(variable_definitions, variable_definition) do
       variable_definition
@@ -36,7 +37,7 @@ defmodule Absinthe.Phase.Document.Validation.UniqueVariableNames do
   end
 
   # Whether a duplicate variable_definition is present
-  @spec duplicate?([Blueprint.Document.Variable.t], Blueprint.Document.Variable.t) :: boolean
+  @spec duplicate?([Blueprint.Document.VariableDefinition.t], Blueprint.Document.VariableDefinition.t) :: boolean
   defp duplicate?(variable_definitions, variable_definition) do
     Enum.count(variable_definitions, &(&1.name == variable_definition.name)) > 1
   end

--- a/lib/absinthe/phase/document/validation/variables_are_input_types.ex
+++ b/lib/absinthe/phase/document/validation/variables_are_input_types.ex
@@ -38,7 +38,7 @@ defmodule Absinthe.Phase.Document.Validation.VariablesAreInputTypes do
   end
 
   # Generate an error for an input field
-  @spec error(Blueprint.Document.VariableDefinition.t, String.t) :: Phase.t
+  @spec error(Blueprint.Document.VariableDefinition.t, String.t) :: Phase.Error.t
   defp error(node, type_rep) do
     Phase.Error.new(
       __MODULE__,

--- a/lib/absinthe/phase/error.ex
+++ b/lib/absinthe/phase/error.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Phase.Error do
     extra: %{}
   ]
 
-  @type loc_t :: %{line: integer, column: nil | integer}
+  @type loc_t :: %{optional(any) => any, line: integer, column: nil | integer}
 
   @type t :: %__MODULE__{
     message: String.t,

--- a/lib/absinthe/phase/validation.ex
+++ b/lib/absinthe/phase/validation.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Phase.Validation do
 
   @moduledoc false
 
-  alias Absinthe.{Blueprint}
+  alias Absinthe.Blueprint
 
   defmacro __using__(_) do
     quote do

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -178,7 +178,7 @@ defmodule Absinthe.Pipeline do
     beginning ++ [additional] ++ (pipeline -- beginning)
   end
 
-  @spec insert_before(t, Phase.t, Phase.t) :: t
+  @spec insert_after(t, Phase.t, Phase.t) :: t
   def insert_after(pipeline, phase, additional) do
     beginning = upto(pipeline, phase)
     beginning ++ [additional] ++ (pipeline -- beginning)

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -4,7 +4,7 @@ defmodule Absinthe.Resolution do
   the current field's execution environment.
   """
 
-  alias Absinthe.{Schema, Type}
+  alias Absinthe.{Blueprint, Schema, Type}
 
   @typedoc """
   Information about the current resolution.

--- a/lib/absinthe/resolution/plugin.ex
+++ b/lib/absinthe/resolution/plugin.ex
@@ -61,7 +61,7 @@ defmodule Absinthe.Resolution.Plugin do
   NOTE: This function is given the whole pipeline to be inserted after the current
   phase completes.
   """
-  @callback pipeline(next_pipeline :: Absinthe.Pipeline.t, resolution_acc :: Map.t) :: Absinthe.Pipeline.t
+  @callback pipeline(next_pipeline :: Absinthe.Pipeline.t, resolution_acc :: map) :: Absinthe.Pipeline.t
 
   @doc """
   Called after a field invokes the plugin.

--- a/lib/absinthe/resolution/plugin.ex
+++ b/lib/absinthe/resolution/plugin.ex
@@ -77,7 +77,7 @@ defmodule Absinthe.Resolution.Plugin do
   NOTE: This function is given the full accumulator. Namespacing is suggested to
   avoid conflicts.
   """
-  @callback init(any, Document.Resolution.acc) :: {any :: Document.Resolution.acc}
+  @callback init(any, Document.Resolution.acc) :: {any, Document.Resolution.acc}
 
   @doc """
   The default list of resolution plugins

--- a/lib/absinthe/resolution/plugin/batch.ex
+++ b/lib/absinthe/resolution/plugin/batch.ex
@@ -87,7 +87,7 @@ defmodule Absinthe.Resolution.Plugin.Batch do
   """
   @type batch_fun :: {module, atom} | {module, atom, term}
 
-  @type post_batch_fun :: (term -> Absinthe.Type.Field.resolver_output)
+  @type post_batch_fun :: (term -> Absinthe.Type.Field.result)
 
   def before_resolution(acc) do
     case acc do

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -245,16 +245,16 @@ defmodule Absinthe.Schema do
   @spec lookup_type(atom, Type.wrapping_t | Type.t | Type.identifier_t, Keyword.t) :: Type.t | nil
   def lookup_type(schema, type, options \\ [unwrap: true]) do
     cond do
+      is_atom(type) ->
+        schema.__absinthe_type__(type)
+      is_binary(type) ->
+        schema.__absinthe_type__(type)
       Type.wrapped?(type) ->
         if Keyword.get(options, :unwrap) do
           lookup_type(schema, type |> Type.unwrap)
         else
           type
         end
-      is_atom(type) ->
-        schema.__absinthe_type__(type)
-      is_binary(type) ->
-        schema.__absinthe_type__(type)
       true ->
         type
     end

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -297,7 +297,7 @@ defmodule Absinthe.Schema do
   @doc """
   List all implementors of an interface on a schema
   """
-  @spec implementors(t, atom) :: [Type.Object.t]
+  @spec implementors(t, Type.identifier_t | Type.Interface.t) :: [Type.Object.t]
   def implementors(schema, ident) when is_atom(ident) do
     schema.__absinthe_interface_implementors__
     |> Map.get(ident, [])

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -139,7 +139,7 @@ defmodule Absinthe.Schema do
   @typedoc """
   A module defining a schema.
   """
-  @type t :: atom
+  @type t :: module
 
   alias Absinthe.Type
   alias Absinthe.Language

--- a/lib/absinthe/schema/rule.ex
+++ b/lib/absinthe/schema/rule.ex
@@ -19,8 +19,10 @@ defmodule Absinthe.Schema.Rule do
     end
   end
 
-  @callback check(Absithe.Schema.t) :: [Absinthe.Error.detail_t]
-  @callback explanation(Absithe.Error.detail_t) :: binary
+  @callback check(Absinthe.Schema.t) :: [Absinthe.Schema.Error.detail_t]
+  @callback explanation(Absinthe.Schema.Error.detail_t) :: binary
+
+  @type t :: module
 
   @rules [
     Rule.TypeNamesAreReserved,
@@ -30,7 +32,7 @@ defmodule Absinthe.Schema.Rule do
     Rule.InterfacesMustResolveTypes,
   ]
 
-  @spec check(Absinthe.Schema.t) :: [Absinthe.Error.detail_t]
+  @spec check(Absinthe.Schema.t) :: [Absinthe.Schema.Error.detail_t]
   def check(schema) do
     Enum.flat_map(@rules, &(&1.check(schema)))
   end

--- a/lib/absinthe/traversal.ex
+++ b/lib/absinthe/traversal.ex
@@ -20,18 +20,18 @@ defmodule Absinthe.Traversal do
   #   traversal should NOT continue to children, but to siblings (using
   #   `traversal`)
   # * `{:error, message}`: Bad stuff happened, explained by `message`
-  @type instruction_t :: {:ok, any} | {:prune, any} | {:error, any}
+  @type instruction_t :: {:ok, any, t} | {:prune, any, t} | {:error, any}
 
   # Traverse, reducing nodes using a given function to evaluate their value.
   @doc false
-  @spec reduce(Node.t, any, any, (Node.t -> instruction_t)) :: any
+  @spec reduce(Node.t, any, acc, (Node.t, t, acc -> instruction_t)) :: acc when acc: var
   def reduce(node, context, initial_value, node_evaluator) do
     {result, _traversal} = do_reduce(node, %Traversal{context: context}, initial_value, node_evaluator)
     result
   end
 
   # Reduce using a traversal struct
-  @spec do_reduce(Node.t, t, any, (Node.t -> instruction_t)) :: {any, t}
+  @spec do_reduce(Node.t, t, acc, (Node.t, t, acc -> instruction_t)) :: {acc, t} when acc: var
   defp do_reduce(node, traversal, initial_value, node_evaluator) do
     if seen?(traversal, node) do
       {initial_value, traversal}
@@ -46,7 +46,7 @@ defmodule Absinthe.Traversal do
   end
 
   # Traverse a node's children
-  @spec reduce(Node.t, t, any, (Node.t -> instruction_t)) :: any
+  @spec reduce_children(Node.t, t, acc, (Node.t, t, acc -> instruction_t)) :: {acc, t} when acc: var
   defp reduce_children(node, traversal, initial, node_evalator) do
     Enum.reduce(Node.children(node, traversal), {initial, traversal}, fn
       child, {this_value, this_traversal} ->

--- a/lib/absinthe/traversal.ex
+++ b/lib/absinthe/traversal.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Traversal do
   alias __MODULE__
   alias Absinthe.Traversal.Node
 
-  @type t :: %{context: any, seen: [Node.t], path: [Node.t]}
+  @type t :: %__MODULE__{context: any, seen: [Node.t], path: [Node.t]}
   defstruct context: nil, seen: [], path: []
 
   # Instructions defining behavior during traversal

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -14,13 +14,13 @@ defmodule Absinthe.Type do
   @type custom_t :: Type.Scalar.t | Type.Object.t | Type.Field.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t
 
   @typedoc "All the possible types"
-  @type t :: custom_t | Type.List.t | Type.NonNull.t
+  @type t :: custom_t | wrapping_t
 
   @typedoc "A type identifier"
   @type identifier_t :: atom
 
   @typedoc "A type reference"
-  @type reference_t :: identifier_t | t | wrapping_t
+  @type reference_t :: identifier_t | t
 
   def identifier(%{__reference__: %{identifier: ident}}) do
     ident
@@ -209,12 +209,14 @@ defmodule Absinthe.Type do
   def wrapped?(_), do: false
 
   @doc "Unwrap a type from a List or NonNull"
-  @spec unwrap(wrapping_t | t) :: t
+  @spec unwrap(wrapping_t) :: custom_t
+  @spec unwrap(type) :: type when type: custom_t
   def unwrap(%{of_type: t}), do: unwrap(t)
   def unwrap(type), do: type
 
   @doc "Unwrap a type from NonNull"
-  @spec unwrap_non_null(Type.NonNull.t | t) :: t
+  @spec unwrap_non_null(Type.NonNull.t) :: custom_t
+  @spec unwrap_non_null(type) :: type when type: custom_t | Type.List.t
   def unwrap_non_null(%Type.NonNull{of_type: t}), do: unwrap_non_null(t)
   def unwrap_non_null(type), do: type
 

--- a/lib/absinthe/type/argument.ex
+++ b/lib/absinthe/type/argument.ex
@@ -19,12 +19,13 @@ defmodule Absinthe.Type.Argument do
     set-up using `Absinthe.Schema.Notation.deprecate/1`.
   * `:description` - Description of an argument, useful for introspection.
   """
-  @type t :: %{name: binary,
-               type: Type.identifier_t,
-               default_value: any,
-               deprecation: Type.Deprecation.t | nil,
-               description: binary | nil,
-               __reference__: Type.Reference.t}
+  @type t :: %__MODULE__{
+    name: binary,
+    type: Type.identifier_t,
+    default_value: any,
+    deprecation: Type.Deprecation.t | nil,
+    description: binary | nil,
+    __reference__: Type.Reference.t}
 
   defstruct name: nil, description: nil, type: nil, deprecation: nil, default_value: nil, __reference__: nil
 

--- a/lib/absinthe/type/enum.ex
+++ b/lib/absinthe/type/enum.ex
@@ -68,7 +68,7 @@ defmodule Absinthe.Type.Enum do
 
   The `__private__` and `:__reference__` fields are for internal use.
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     values: %{binary => Type.Enum.Value.t},

--- a/lib/absinthe/type/enum/value.ex
+++ b/lib/absinthe/type/enum/value.ex
@@ -27,7 +27,7 @@ defmodule Absinthe.Type.Enum.Value do
   @type t :: %{name: binary, description: binary, value: any, deprecation: Type.Deprecation.t | nil, __reference__: Type.Reference.t}
   defstruct name: nil, description: nil, value: nil, deprecation: nil, __reference__: nil
 
-  @spec build(Keyword.t) :: %{atom => Absinthe.Type.Enum.Value.t}
+  @spec build(Keyword.t) :: Macro.expr
   def build(raw_values) when is_list(raw_values) do
     ast = for {identifier, value_attrs} <- normalize(raw_values) do
       value_data = value_data(identifier, value_attrs)

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -182,7 +182,8 @@ defmodule Absinthe.Type.Field do
   ```
 
   """
-  @type t :: %{name: binary,
+  @type t :: %__MODULE__{
+               name: binary,
                description: binary | nil,
                type: Type.identifier_t,
                deprecation: Deprecation.t | nil,

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -223,7 +223,7 @@ defmodule Absinthe.Type.Field do
       field_data = [name: name] ++ Keyword.update(field_attrs, :args, quoted_empty_map, fn
         raw_args ->
           args = for {name, attrs} <- raw_args, do: {name, ensure_reference(attrs, name, default_ref)}
-          Type.Argument.build(args || [])
+          Type.Argument.build(args)
       end)
       field_ast = quote do: %Absinthe.Type.Field{unquote_splicing(field_data |> Absinthe.Type.Deprecation.from_attribute)}
       {field_name, field_ast}

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -46,7 +46,7 @@ defmodule Absinthe.Type.InputObject do
 
   The `__private__` and `:__reference__` fields are for internal use.
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     fields: map | (() -> map),

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -59,7 +59,7 @@ defmodule Absinthe.Type.Interface do
 
   The `__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     fields: map,

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -63,7 +63,7 @@ defmodule Absinthe.Type.Interface do
     name: binary,
     description: binary,
     fields: map,
-    resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
+    resolve_type: ((any, Absinthe.Resolution.t) -> atom | nil),
     __private__: Keyword.t,
     __reference__: Type.Reference.t,
   }

--- a/lib/absinthe/type/list.ex
+++ b/lib/absinthe/type/list.ex
@@ -28,6 +28,6 @@ defmodule Absinthe.Type.List do
 
   * `:of_type` - The underlying, wrapped type.
  "
-  @type t :: %{of_type: Absinthe.Type.t}
+  @type t :: %__MODULE__{of_type: Absinthe.Type.t}
   defstruct of_type: nil
 end

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -84,7 +84,7 @@ defmodule Absinthe.Type.Object do
 
   The `__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     fields: map,

--- a/lib/absinthe/type/reference.ex
+++ b/lib/absinthe/type/reference.ex
@@ -3,7 +3,7 @@ defmodule Absinthe.Type.Reference do
   @moduledoc false
 
   @typedoc false
-  @type t :: %{module: atom, identifier: atom, name: binary}
+  @type t :: %__MODULE__{module: atom, identifier: atom, name: binary}
 
   defstruct module: nil, identifier: nil, name: nil
 

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -31,6 +31,8 @@ defmodule Absinthe.Type.Scalar do
 
   use Absinthe.Introspection.Kind
 
+  alias Absinthe.Type
+
   def build(%{attrs: attrs}) do
     quote do: %unquote(__MODULE__){unquote_splicing(attrs)}
   end

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -62,7 +62,7 @@ defmodule Absinthe.Type.Scalar do
 
   The `:__private__` and `:__reference__` keys are for internal use.
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     serialize: (value_t -> any),

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -39,7 +39,7 @@ defmodule Absinthe.Type.Union do
   The `__private__` and `:__reference__` keys are for internal use.
 
   """
-  @type t :: %{
+  @type t :: %__MODULE__{
     name: binary,
     description: binary,
     types: [Type.identifier_t],

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -43,7 +43,7 @@ defmodule Absinthe.Type.Union do
     name: binary,
     description: binary,
     types: [Type.identifier_t],
-    resolve_type: ((any, Absinthe.Execution.t) -> atom | nil),
+    resolve_type: ((any, Absinthe.Resolution.t) -> atom | nil),
     __private__: Keyword.t,
     __reference__: Type.Reference.t,
   }


### PR DESCRIPTION
This fixes the majority of the warnings but there are still a few left. These are largely to do with `nil` being present in a value of a struct when the type contract for that struct does not allow `nil`. I am not familiar enough with the code to solve them. There is also `Absinthe.Schema.TypeMap.t`, which I didn't investigate.

When code is changed (and not type specs) please advise on testing if required.