### PR TITLE
fix adapter config option not being used

### DIFF
--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -12,6 +12,8 @@ defmodule Absinthe.Phase.Schema do
 
   alias Absinthe.{Blueprint, Type, Schema}
 
+  @default_adapter Application.get_env(:absinthe, :adapter, Absinthe.Adapter.LanguageConventions)
+
   # The approach here is pretty simple.
   # We start at the top blueprint node and set the appropriate schema node on operations
   # directives and so forth.
@@ -24,7 +26,7 @@ defmodule Absinthe.Phase.Schema do
   @spec run(Blueprint.t, Keyword.t) :: {:ok, Blueprint.t}
   def run(input, options \\ []) do
     schema = Keyword.fetch!(options, :schema)
-    adapter = Keyword.get(options, :adapter, Absinthe.Adapter.LanguageConventions)
+    adapter = Keyword.get(options, :adapter, @default_adapter)
 
     result = Blueprint.prewalk(input, &handle_node(&1, schema, adapter))
     {:ok, result}

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -24,8 +24,10 @@ defmodule Absinthe.Pipeline do
     |> run_phase(input)
   end
 
+  @default_adapter Application.get_env(:absinthe, :adapter, Absinthe.Adapter.LanguageConventions)
+
   @defaults [
-    adapter: Absinthe.Adapter.LanguageConventions,
+    adapter: @default_adapter,
     operation_name: nil,
     variables: %{},
     context: %{},


### PR DESCRIPTION
This PR fixes the new pipeline changes in 1.2 not respecting the adapter configured by `:absinthe, :adapter`.

Cheers to @russmatney for discovering the issue in our code base.