### PR TITLE
Update documentation type in Interface module

### DIFF
--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -23,7 +23,7 @@ defmodule Absinthe.Type.Interface do
     resolve_type fn
       %{age: _}, _ -> :person
       %{employee_count: _}, _ -> :business
-      _ -> :error
+      _ -> nil
     end
   end
 

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -21,8 +21,8 @@ defmodule Absinthe.Type.Interface do
   interface :named_entity do
     field :name, :string
     resolve_type fn
-      %{age: _}, _ -> {:ok, :person}
-      %{employee_count: _}, _ -> {:ok, :business}
+      %{age: _}, _ -> :person
+      %{employee_count: _}, _ -> :business
       _ -> :error
     end
   end


### PR DESCRIPTION
I was following the doc and was presented this error:

```elixir
(CaseClauseError) no case clause matching: {:ok, :confirmed_collaborator}
 (absinthe) lib/absinthe/type/interface.ex:96: Absinthe.Type.Interface.resolve_type/3
```

Changing this to the same signature as the `union`’s `resolve_type` function made it work.

🎉 