### PR TITLE
Support atoms for error messages

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -280,6 +280,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp split_error_value(error_value) when is_binary(error_value) do
     {[message: error_value], []}
   end
+  defp split_error_value(error_value) when is_atom(error_value) do
+    {[message: Atom.to_string(error_value)], []}
+  end
 
   # Introspection Field
   defp call_resolution_function(args, %{schema_node: %{name: "__" <> _}} = field, info, _) do

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -44,6 +44,8 @@ defmodule Things do
           {:error, [%{message: "Custom Error 1", code: 1}, %{message: "Custom Error 2", code: 2}]}
         %{type: :multiple_without_message}, _ ->
           {:error, [%{message: "Custom Error 1", code: 1}, %{code: 2}]}
+        %{type: :atom}, _ ->
+          {:error, [%{message: "foo"}]}
       end
     end
 


### PR DESCRIPTION
Sometimes you get atoms in {:error, message} and instead of
people handling the converation themselves it's better just
returning the string equivilant of the atom inline with what
json libraries like Poison do.

I'm not sure how to test this because I can't find any other tests
for this.

Also I could have an implementation that handles everything
either through to_string or inspect.