### PR TITLE
Use to_string for error messages

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -58,6 +58,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
       {:error, ["Simple message", [message: "A keyword list error", code: 1], %{message: "A map error"}]}
 
+  Generic handler for interoperability with errors from other libraries:
+      {:error, :foo}
+      {:error, 1.0}
+      {:error, 2}
+
   ## To activate a plugin
 
   `{:plugin, NameOfPluginModule, term}` to activate a plugin.

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -280,6 +280,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp split_error_value(error_value) when is_binary(error_value) do
     {[message: error_value], []}
   end
+  defp split_error_value(error_value) do
+    {[message: to_string(error_value)], []}
+  end
 
   # Introspection Field
   defp call_resolution_function(args, %{schema_node: %{name: "__" <> _}} = field, info, _) do

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -63,7 +63,7 @@ defmodule Absinthe.Type.Field do
   @typedoc """
   An error value is a simple error message, a custom error, or a list of either/both of them.
   """
-  @type error_value :: error_message | custom_error | [error_message | custom_error]
+  @type error_value :: error_message | custom_error | [error_message | custom_error] | serializable
 
   @typedoc """
   The configuration for a field.


### PR DESCRIPTION
Sometimes you get other types in {:error, value}, like atom and integers,
and instead of people handling the converation themselves it's better just
returning the string equivalent of the atom inline with what json libraries
like Poison do or any other type that can be a string.

An example would be if you are doing `with` in you body you get the error
message from the library you are using. In guardian case you could get:
`{:error, :token_expired}`