### PR TITLE
Don't clear accumulator when checking interfaces

### DIFF
--- a/lib/absinthe/schema/rule/object_must_implement_interfaces.ex
+++ b/lib/absinthe/schema/rule/object_must_implement_interfaces.ex
@@ -53,7 +53,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfaces do
     |> Enum.reduce([], fn
       %Type.Interface{} = iface_type, acc ->
         if Type.Interface.implements?(iface_type, type) do
-          []
+          acc
         else
           [report(type.__reference__.location, %{object: type.name, interface: iface_type.name}) | acc]
         end


### PR DESCRIPTION
Fixing a small mistake I noticed.  I think this fixes the bug in #211.