### PR TITLE
Add failing test for interface subtype

### DIFF
--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -295,6 +295,73 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"item" => %{"id" => "foo", "name" => "Foo"}}}}, result
   end
 
+  it "can query simple InterfaceSubtypeSchema" do
+    result = """
+    {
+      box {
+        item {
+          name
+          cost
+        }
+      }
+    }
+    """
+    |> run(Absinthe.InterfaceSubtypeSchema)
+    assert_result {:ok, %{data: %{"box" => %{"item" => %{"name" => "Computer", "cost" => 1000}}}}}, result
+  end
+
+  it "can query InterfaceSubtypeSchema treating box as HasItem" do
+    result = """
+    {
+      box {
+        ... on HasItem {
+          item {
+            name
+          }
+        }
+      }
+    }
+    """
+    |> run(Absinthe.InterfaceSubtypeSchema)
+    assert_result {:ok, %{data: %{"box" => %{"item" => %{"name" => "Computer"}}}}}, result
+  end
+
+  it "can query InterfaceSubtypeSchema treating box as HasItem and item as ValuedItem" do
+    result = """
+    {
+      box {
+        ... on HasItem {
+          item {
+            name
+            ... on ValuedItem {
+              cost
+            }
+          }
+        }
+      }
+    }
+    """
+    |> run(Absinthe.InterfaceSubtypeSchema)
+    assert_result {:ok, %{data: %{"box" => %{"item" => %{"name" => "Computer", "cost" => 1000}}}}}, result
+  end
+
+  it "rejects querying InterfaceSubtypeSchema treating box as HasItem asking for cost" do
+    result = """
+    {
+      box {
+        ... on HasItem {
+          item {
+            name
+            cost
+          }
+        }
+      }
+    }
+    """
+    |> run(Absinthe.InterfaceSubtypeSchema)
+    assert_result {:error, %{errors: [%{message: "Cannot query field \"cost\" on type \"ValuedItem\"."}]}}, result
+  end
+
   it "should wrap all lexer errors and return if not aborting to a phase" do
     query = """
     {

--- a/test/support/interface_subtype_schema.ex
+++ b/test/support/interface_subtype_schema.ex
@@ -1,0 +1,40 @@
+defmodule Absinthe.InterfaceSubtypeSchema do
+  use Absinthe.Schema
+
+  # Example data
+  @box %{
+    item: %{name: "Computer", cost: 1000}
+  }
+
+  query do
+
+    field :box,
+      type: :box,
+      args: [],
+      resolve: fn _, _ ->
+        {:ok, @box}
+      end
+  end
+
+  object :box do
+    field :item, :valued_item
+    interface :has_item
+    is_type_of fn _ -> true end
+  end
+
+  interface :has_item do
+    field :item, :item
+  end
+
+  object :valued_item do
+    field :name, :string
+    field :cost, :integer
+
+    interface :item
+    is_type_of fn _ -> true end
+  end
+
+  interface :item do
+    field :name, :string
+  end
+end


### PR DESCRIPTION
This shows that an implementor of an interface with a more specific field than expected will not compile. I've validated that `graphql-java` accepts this schema (and the documentation that this failure dumps asserts that it should be valid as well).

I don't know how to fix this, but I hope this failing test case will be helpful.