### PR TITLE
Fix Elixir 1.5 deprecation warnings

### DIFF
--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -59,12 +59,12 @@ defmodule Absinthe.Phase.Parse do
     end
   end
 
-  @spec format_raw_parse_error({integer, :absinthe_parser, [char_list]}) :: Phase.Error.t
+  @spec format_raw_parse_error({integer, :absinthe_parser, [charlist]}) :: Phase.Error.t
   defp format_raw_parse_error({line, :absinthe_parser, msgs}) do
     message = msgs |> Enum.map(&to_string/1) |> Enum.join("")
     %Phase.Error{message: message, locations: [%{line: line, column: 0}], phase: __MODULE__}
   end
-  @spec format_raw_parse_error({integer, :absinthe_lexer, {atom, char_list}}) :: Phase.Error.t
+  @spec format_raw_parse_error({integer, :absinthe_lexer, {atom, charlist}}) :: Phase.Error.t
   defp format_raw_parse_error({line, :absinthe_lexer, {problem, field}}) do
     message = "#{problem}: #{field}"
     %Phase.Error{message: message, locations: [%{line: line, column: 0}], phase: __MODULE__}

--- a/lib/absinthe/schema/error.ex
+++ b/lib/absinthe/schema/error.ex
@@ -22,11 +22,11 @@ defmodule Absinthe.Schema.Error do
 
   defp indent(text) do
     text
-    |> String.strip
+    |> String.trim
     |> String.split("\n")
     |> Enum.map(&"  #{&1}")
     |> Enum.join("\n")
-    |> String.lstrip
+    |> String.trim_leading
   end
 
 end

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -991,7 +991,7 @@ defmodule Absinthe.Schema.Notation do
     |> record_description!(text)
   end
 
-  defp reformat_description(text), do: String.strip(text)
+  defp reformat_description(text), do: String.trim(text)
 
   @doc false
   # Record a description in the current scope

--- a/lib/absinthe/schema/rule/field_imports_exist.ex
+++ b/lib/absinthe/schema/rule/field_imports_exist.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Schema.Rule.FieldImportsExist do
 
     Object #{inspect definition.identifier} imports fields from #{inspect ref} but
     #{inspect ref} does not exist in the schema!
-    """ |> String.strip
+    """ |> String.trim
 
     %{data: %{artifact: msg, value: ref}, location: %{file: definition.file, line: definition.line}, rule: __MODULE__}
   end

--- a/lib/absinthe/schema/rule/no_circular_field_imports.ex
+++ b/lib/absinthe/schema/rule/no_circular_field_imports.ex
@@ -38,7 +38,7 @@ defmodule Absinthe.Schema.Rule.NoCircularFieldImports do
             |> Enum.map(&"`#{&1}'")
             |> Enum.join(" => ")
 
-          msg = String.strip """
+          msg = String.trim """
           Field Import Cycle Error
 
           Field Import in object `#{definition.identifier}' `import_fields(#{inspect ref}) forms a cycle via: (#{deps})


### PR DESCRIPTION
When compiling an app with Absinthe on Elixir master, a couple of deprecation warnings popped up:

    ==> absinthe
    Compiling 4 files (.erl)
    Compiling 194 files (.ex)
    warning: String.strip/1 is deprecated, use String.trim/1
      lib/absinthe/schema/rule/no_circular_field_imports.ex:41

    warning: String.lstrip/1 is deprecated, use String.trim_leading/1
      lib/absinthe/schema/error.ex:29

    warning: String.strip/1 is deprecated, use String.trim/1
      lib/absinthe/schema/error.ex:25

    warning: String.strip/1 is deprecated, use String.trim/1
      lib/absinthe/schema/rule/field_imports_exist.ex:45

    warning: the char_list() type is deprecated, use charlist()
      lib/absinthe/phase/parse.ex:67

    warning: the char_list() type is deprecated, use charlist()
      lib/absinthe/phase/parse.ex:62

    warning: String.strip/1 is deprecated, use String.trim/1
      lib/absinthe/schema/notation.ex:994

    Generated absinthe app

This patch replaces all calls to the deprecated String functions (`strip/1`, `lstrip/1`) with their recommended alternatives (`trim/1` and `trim_leading/1`, respectively), and uses the `charlist()` type instead of `char_list()`.