### PR TITLE
Switched HandleError to HandleAuth

### DIFF
--- a/lib/absinthe/middleware.ex
+++ b/lib/absinthe/middleware.ex
@@ -200,7 +200,7 @@ defmodule Absinthe.Middleware do
   field :hello, :string do
     middleware Auth, some_option: 1
     resolve &get_the_string/2
-    middleware HandleAuth, :foo
+    middleware HandleError, :foo
   end
   ```
 


### PR DESCRIPTION
If I'm reading the example right I believe you meant the HandleAuth middleware would run after the Auth middleware.