### PR TITLE
Add fix for merging fragments on a list field returning more than 1 element

### DIFF
--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -81,11 +81,12 @@ defmodule Absinthe.Phase.Document.Result do
     Map.merge(left, right, &do_deep_resolve/3)
   end
 
-  defp do_deep_resolve(_key, [%{} = left], [%{} = right]) do
-    [do_deep_merge(right, left)]
-  end
   defp do_deep_resolve(_key, %{} = left, %{} = right) do
-    do_deep_merge(right, left)
+    do_deep_merge(left, right)
+  end
+  defp do_deep_resolve(key, [_|_] = left, [_|_] = right) do
+    Enum.zip(left, right)
+    |> Enum.map(fn {l, r} -> do_deep_resolve(key, l, r) end)
   end
   defp do_deep_resolve(_key, _left, right) do
    right

--- a/test/lib/absinthe/fragment_merge_test.exs
+++ b/test/lib/absinthe/fragment_merge_test.exs
@@ -16,7 +16,7 @@ defmodule Absinthe.FragmentMergeTest do
     query do
       field :viewer, :user do
         resolve fn _, _ ->
-          {:ok, %{todos: %{total_count: 1, completed_count: 2}}}
+          {:ok, %{todos: [%{total_count: 1, completed_count: 2}, %{total_count: 3, completed_count: 4}]}}
         end
       end
     end
@@ -43,7 +43,40 @@ defmodule Absinthe.FragmentMergeTest do
       }
     }
     """
-    assert {:ok, %{data: %{"viewer" => %{"todos" => [%{"totalCount" => 1, "completedCount" => 2}]}}}} == Absinthe.run(doc, Schema)
+    expected = %{"viewer" => %{"todos" => [
+      %{"totalCount" => 1, "completedCount" => 2},
+      %{"totalCount" => 3, "completedCount" => 4}
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
+  end
+
+  test "it deep merges duplicated fields properly" do
+    doc = """
+    {
+      viewer {
+        ...fragmentWithOtherField
+        ...fragmentWithOneField
+      }
+    }
+
+    fragment fragmentWithOneField on User {
+      todos {
+        totalCount,
+        completedCount
+      }
+    }
+
+    fragment fragmentWithOtherField on User {
+      todos {
+        completedCount
+      }
+    }
+    """
+    expected = %{"viewer" => %{"todos" => [
+      %{"totalCount" => 1, "completedCount" => 2},
+      %{"totalCount" => 3, "completedCount" => 4}
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
   end
 
   test "it deep merges fields properly different levels" do
@@ -69,6 +102,11 @@ defmodule Absinthe.FragmentMergeTest do
       }
     }
     """
-    assert {:ok, %{data: %{"viewer" => %{"todos" => [%{"totalCount" => 1, "completedCount" => 2}]}}}} == Absinthe.run(doc, Schema)
+    expected = %{"viewer" => %{"todos" => [
+      %{"totalCount" => 1, "completedCount" => 2},
+      %{"totalCount" => 3, "completedCount" => 4}
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
   end
+
 end

--- a/test/lib/absinthe/union_fragment_test.exs
+++ b/test/lib/absinthe/union_fragment_test.exs
@@ -146,4 +146,70 @@ defmodule Absinthe.UnionFragmentTest do
     assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
   end
 
+  test "it queries a heterogeneous list using fragments properly" do
+    doc = """
+    {
+      viewer {
+        objects {
+          ...fragmentWithUserField
+          ...fragmentWithOneTodoField
+          ...fragmentWithOtherTodoField
+        }
+      }
+    }
+
+    fragment fragmentWithUserField on User {
+      name
+    }
+
+    fragment fragmentWithOneTodoField on Todo {
+      name
+    }
+
+    fragment fragmentWithOtherTodoField on Todo {
+      completed
+    }
+    """
+    expected = %{"viewer" => %{"objects" => [
+      %{"name" => "foo"},
+      %{"name" => "do stuff", "completed" => false},
+      %{"name" => "bar"},
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
+  end
+
+  test "it merges fragments of a heterogeneous list properly" do
+    doc = """
+    {
+      viewer {
+        ...fragmentWithOneType
+        ...fragmentWithOtherType
+      }
+    }
+
+    fragment fragmentWithOneType on Viewer {
+      objects {
+        ... on User {
+          name
+        }
+      }
+    }
+
+    fragment fragmentWithOtherType on Viewer {
+      objects {
+        ... on Todo {
+          name
+          completed
+        }
+      }
+    }
+    """
+    expected = %{"viewer" => %{"objects" => [
+      %{"name" => "foo"},
+      %{"name" => "do stuff", "completed" => false},
+      %{"name" => "bar"},
+    ]}}
+    assert {:ok, %{data: expected}} == Absinthe.run(doc, Schema)
+  end
+
 end


### PR DESCRIPTION
The current implementation for fragment merging in the resolution step only matches on `[%{} = left], [%{} = right]` when lists of objects are found.

The PR correctly handles merging when multiple fragments are made over a list of objects field.