### PR TITLE
Add Absinthe.Pipeline.replace/3

### DIFF
--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -153,6 +153,23 @@ defmodule Absinthe.Pipeline do
     end
   end
 
+  @doc """
+  Replace a phase in a pipeline with another, using the same options.
+  """
+  @spec replace(t, Phase.t, Phase.t) :: t
+  def replace(pipeline, phase, replacement) do
+    Enum.map(pipeline, fn
+      candidate ->
+        case match_phase?(phase, candidate) do
+          true ->
+            {candidate_phase, opts} = phase_invocation(candidate)
+            {replacement, opts}
+          false ->
+            candidate
+        end
+    end)
+  end
+
   # Whether a phase configuration is for a given phase
   @spec match_phase?(Phase.t, phase_config_t) :: boolean
   defp match_phase?(phase, phase), do: true

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Type.Directive do
   * `:name` - The name of the directivee. Should be a lowercase `binary`. Set automatically.
   * `:description` - A nice description for introspection.
   * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/1`.
-  * `:locations` - A list of places the directives can be used (can be `:operation`, `:fragment`, `:field`).
+  * `:locations` - A list of places the directives can be used.
   * `:instruction` - A function that, given an argument, returns an instruction for the correct action to take
 
   The `:__reference__` key is for internal use.
@@ -26,10 +26,12 @@ defmodule Absinthe.Type.Directive do
     name: binary,
     description: binary,
     args: map,
-    locations: [atom],
+    locations: [location],
     expand: nil | ((Absinthe.Blueprint.node_t, map) -> {Absinthe.Blueprint.t, map}),
     instruction: ((map) -> atom), __reference__: Type.Reference.t
   }
+
+  @type location :: :query | :mutation | :field | :fragment_definition | :fragment_spread | :inline_fragment
 
   defstruct [
     name: nil,

--- a/test/lib/absinthe/pipeline_test.exs
+++ b/test/lib/absinthe/pipeline_test.exs
@@ -97,7 +97,7 @@ defmodule Absinthe.PipelineTest do
     end
   end
 
-  @pipeline [A, B, C, D, {E, []}, F]
+  @pipeline [A, B, C, D, {E, [name: "e"]}, F]
 
   describe ".before" do
 
@@ -120,8 +120,8 @@ defmodule Absinthe.PipelineTest do
     end
 
     it "inserts the phase before" do
-      assert [X, A, B, C, D, {E, []}, F] == Pipeline.insert_before(@pipeline, A, X)
-      assert [A, B, C, D, X, {E, []}, F] == Pipeline.insert_before(@pipeline, E, X)
+      assert [X, A, B, C, D, {E, [name: "e"]}, F] == Pipeline.insert_before(@pipeline, A, X)
+      assert [A, B, C, D, X, {E, [name: "e"]}, F] == Pipeline.insert_before(@pipeline, E, X)
     end
 
   end
@@ -134,7 +134,7 @@ defmodule Absinthe.PipelineTest do
 
     it "returns the phases upto the match" do
       assert [A, B, C] == Pipeline.upto(@pipeline, C)
-      assert [A, B, C, D, {E, []}] == Pipeline.upto(@pipeline, E)
+      assert [A, B, C, D, {E, [name: "e"]}] == Pipeline.upto(@pipeline, E)
     end
 
   end
@@ -142,8 +142,40 @@ defmodule Absinthe.PipelineTest do
   describe ".upto" do
 
     it "returns the pipeline without specified phase" do
-      assert [A, B, D, {E, []}, F] == Pipeline.without(@pipeline, C)
+      assert [A, B, D, {E, [name: "e"]}, F] == Pipeline.without(@pipeline, C)
       assert [A, B, C, D, F] == Pipeline.without(@pipeline, E)
+    end
+
+  end
+
+  describe ".replace" do
+
+    describe "when not found" do
+      it "returns the pipeline unchanged" do
+        assert @pipeline == Pipeline.replace(@pipeline, X, ABC)
+      end
+    end
+
+    describe "when found" do
+      describe "when the target has options" do
+        describe "when no replacement options are given" do
+          it "replaces the phase but reuses the options" do
+            assert [A, B, C, D, {X, [name: "e"]}, F] == Pipeline.replace(@pipeline, E, X)
+          end
+        end
+        describe "when replacement options are given" do
+          it "replaces the phase and uses the new options" do
+            assert [A, B, C, D, {X, [name: "Custom"]}, F] == Pipeline.replace(@pipeline, E, {X, [name: "Custom"]})
+            assert [A, B, C, D, {X, []}, F] == Pipeline.replace(@pipeline, E, {X, []})
+          end
+        end
+      end
+      describe "when the target has no options" do
+        it "simply replaces the phase" do
+          assert [A, B, C, X, {E, [name: "e"]}, F] == Pipeline.replace(@pipeline, D, X)
+          assert [A, B, C, {X, [name: "Custom Opt"]}, {E, [name: "e"]}, F] == Pipeline.replace(@pipeline, D, {X, [name: "Custom Opt"]})
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Adds `Absinthe.Pipeline.replace/3`(also cleans up some inaccuracies I saw in `Absinthe.Type.Directive`).

This is used for experimental features being implemented for absinthe_phoenix.