### PR TITLE
Phase.Document.Validation.SelectedCurrentOperation edge case

### DIFF
--- a/test/lib/absinthe/phase/document/validation/selected_current_operation_test.exs
+++ b/test/lib/absinthe/phase/document/validation/selected_current_operation_test.exs
@@ -45,6 +45,18 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperationTest do
       )
     end
 
+    it "fails when a single operation with wrong name is provided" do
+      assert_fails_rule(@rule,
+        """
+        query Foo {
+          name
+        }
+        """,
+        [operation_name: "Nothere"],
+        no_current_operation()
+      )
+    end
+
   end
 
   context "Not given an operation name" do


### PR DESCRIPTION
I added a test with a query that looks like it should fail the validation, but it passes. Not sure if it's a bug or somehow intended behavior, so I did not attempt to fix it until clarified. 