### PR TITLE
Improve generic example in docs of batch_fun

### DIFF
--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -82,7 +82,10 @@ defmodule Absinthe.Middleware.Batch do
 
   ```elixir
   def by_id(model, ids) do
-    Repo.al from m in model, where: m.id in ^ids
+    model
+    |> where([m], m.id in ^ids)
+    |> Repo.all()
+    |> Map.new(&{&1.id, &1})
   end
   ```
   It could also be used to set options unique to the execution of a particular


### PR DESCRIPTION
This brings the generic example of using `batch_fun` in line with the Ecto Best Practices guide. It had a typo and was missing the map step.

:)