### PR TITLE
Add Code of Conduct, derived from Elixir's.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Code of Conduct
+
+Contact: conduct@absinthe-graphql.org
+
+## Why have a Code of Conduct?
+
+As contributors and maintainers of this project, we are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+
+The goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about the Absinthe project effectively, productively, and respectfully, even in face of disagreements. The Code of Conduct also provides a mechanism for resolving conflicts in the community when they arise.
+
+## Our Values
+
+These are the values developers that participate in Absinthe project-related activities should aspire to:
+
+  * Be friendly and welcoming
+  * Be patient
+    * Remember that people have varying communication styles and that not everyone is using their native language. (Meaning and tone can be lost in translation.)
+  * Be thoughtful
+    * Productive communication requires effort. Think about how your words will be interpreted.
+    * Remember that sometimes it is best to refrain entirely from commenting.
+  * Be respectful
+    * In particular, respect differences of opinion. It is important that we resolve disagreements and differing views constructively.
+  * Avoid destructive behavior
+    * Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+    * Unconstructive criticism: don't merely decry the current state of affairs; offer (or at least solicit) suggestions as to how things may be improved.
+    * Snarking (pithy, unproductive, sniping comments).
+
+The following actions are explicitly forbidden:
+
+  * Insulting, demeaning, hateful, or threatening remarks.
+  * Discrimination based on age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+  * Bullying or systematic harassment.
+  * Unwelcome sexual advances.
+  * Incitement to any of these.
+
+## Where does the Code of Conduct apply?
+
+If you participate in or contribute to the Absinthe project ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
+
+Explicit enforcement of the Code of Conduct applies to the official mediums operated by the Absinthe project:
+
+* The official GitHub projects and code reviews.
+* The absinthe-graphql.org website and documentation.
+* The #absinthe-graphql Slack channel.
+
+Activities related to Absinthe (conference talks, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
+
+Project maintainers may remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing: conduct@absinthe-graphql.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. **All reports will be kept confidential**.
+
+**The goal of the Code of Conduct is to resolve conflicts in the most harmonious way possible**. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort. **Do not** post about the issue publicly or try to rally sentiment against a particular individual or group.
+
+## Acknowledgements
+
+This document was based on the Code of Conduct from the Elixir project, which is based on the Code of Conduct from the Go project with parts derived from Django's Code of Conduct, Rust's Code of Conduct, and the Contributor Covenant.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ The project is under constant improvement by a growing list of contributors,
 and your feedback is important. Please
 [join us](http://absinthe-graphql.org/community/)!
 
+Please remember that all interactions in our official spaces follow our [Code of
+Conduct](./CODE_OF_CONDUCT.md).
+
 ## Installation
 
 Install from [Hex.pm](https://hex.pm/packages/absinthe):


### PR DESCRIPTION
Completes #333.

Before merging, we just need to make sure that the `conduct@absinthe-graphql.org` email address is operational.