### PR TITLE
Fixes deprecation warnings from Elixir 1.5

### DIFF
--- a/lib/absinthe/phase/document/arguments/data.ex
+++ b/lib/absinthe/phase/document/arguments/data.ex
@@ -47,13 +47,9 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
     %{node | data: data_list}
   end
   def handle_node(%Input.Value{normalized: %Input.Object{fields: fields}} = node) do
-    data =
-      fields
-      |> Enum.filter_map(
-        &include_field?/1,
-        &{&1.schema_node.__reference__.identifier, &1.input_value.data}
-      )
-      |> Map.new
+    data = for field <- fields, include_field?(field), into: %{} do
+      {field.schema_node.__reference__.identifier, field.input_value.data}
+    end
 
     %{node | data: data}
   end

--- a/lib/absinthe/schema/rule/field_imports_exist.ex
+++ b/lib/absinthe/schema/rule/field_imports_exist.ex
@@ -39,7 +39,7 @@ defmodule Absinthe.Schema.Rule.FieldImportsExist do
   def explanation(%{data: %{artifact: msg}}) do
     """
       #{msg}
-    """ |> String.strip
+    """ |> String.trim
   end
 
   defp error(definition, ref) do

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Absinthe.Mixfile do
       {:benchfella, "~> 0.3.0", only: :dev},
       {:dialyze, "~> 0.2", only: :dev},
       {:phoenix_pubsub, ">= 0.0.0", only: :test},
-      {:mix_test_watch, "~> 0.4.0", only: [:test, :dev]}
+      {:mix_test_watch, "~> 0.4.1", only: [:test, :dev]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
-%{"benchfella": {:hex, :benchfella, "0.3.4", "41d2c017b361ece5225b5ba2e3b30ae53578c57c6ebc434417b4f1c2c94cf4f3", [:mix], [], "hexpm"},
-  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm"},
-  "fs": {:hex, :fs, "2.12.0", "ad631efacc9a5683c8eaa1b274e24fa64a1b8eb30747e9595b93bec7e492e25e", [:rebar3], [], "hexpm"},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.4.0", "7e44b681b0238999d4c39b5beed77b4ac45aef1c112a763aae414bdb5bc34523", [:mix], [{:fs, "~> 2.12", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
-  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"}}
+%{"benchfella": {:hex, :benchfella, "0.3.4", "41d2c017b361ece5225b5ba2e3b30ae53578c57c6ebc434417b4f1c2c94cf4f3", [:mix], []},
+  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], []},
+  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.4.1", "a98a84c795623f1ba020324f4354cf30e7120ba4dab65f9c2ae300f830a25f75", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], []}}


### PR DESCRIPTION
Fixes the following warnings that were emitted after updating to Elixir 1.5:

```
warning: String.strip/1 is deprecated, use String.trim/1
  lib/absinthe/schema/rule/field_imports_exist.ex:42

warning: Enum.filter_map/3 is deprecated, use Enum.filter/2 + Enum.map/2
or for comprehensions
  lib/absinthe/phase/document/arguments/data.ex:52
```