### PR TITLE
Add support for Decimal values

### DIFF
--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Type.Custom do
   - naive_datetime
   - date
   - time
-  - decimal (only if Decimal is available)
+  - decimal (only if [Decimal](https://hex.pm/packages/decimal) is available)
 
   Further description of these types can be found in the source code.
 

--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -7,6 +7,7 @@ defmodule Absinthe.Type.Custom do
   - naive_datetime
   - date
   - time
+  - decimal (only if Decimal is available)
 
   Further description of these types can be found in the source code.
 
@@ -56,6 +57,18 @@ defmodule Absinthe.Type.Custom do
     parse &parse_time/1
   end
 
+  if Code.ensure_loaded?(Decimal) do
+    scalar :decimal do
+      description """
+      The `Decimal` scalar type represents signed double-precision fractional
+      values parsed by the `Decimal` library.  The Decimal appears in a JSON
+      response as a string to preserve precision.
+      """
+      serialize &Decimal.to_string/1
+      parse &parse_decimal/1
+    end
+  end
+
   @spec parse_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, DateTime.t} | :error
   defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case DateTime.from_iso8601(value) do
@@ -99,5 +112,26 @@ defmodule Absinthe.Type.Custom do
   end
   defp parse_time(_) do
     :error
+  end
+
+  if Code.ensure_loaded?(Decimal) do
+    @spec parse_decimal(any) :: {:ok, Decimal.t} | :error
+    defp parse_decimal(%Absinthe.Blueprint.Input.String{value: value}) do
+      case Decimal.parse(value) do
+        {:ok, decimal} -> {:ok, decimal}
+        _ -> :error
+      end
+    end
+    defp parse_decimal(%Absinthe.Blueprint.Input.Float{value: value}) do
+      decimal = Decimal.new(value)
+      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
+    end
+    defp parse_decimal(%Absinthe.Blueprint.Input.Integer{value: value}) do
+      decimal = Decimal.new(value)
+      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
+    end
+    defp parse_decimal(_) do
+      :error
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule Absinthe.Mixfile do
       {:ex_doc, "~> 0.14", only: :dev},
       {:benchfella, "~> 0.3.0", only: :dev},
       {:dialyze, "~> 0.2", only: :dev},
+      {:decimal, "~> 1.0", optional: :true},
       {:phoenix_pubsub, ">= 0.0.0", only: :test},
       {:mix_test_watch, "~> 0.4.1", only: [:test, :dev]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"benchfella": {:hex, :benchfella, "0.3.4", "41d2c017b361ece5225b5ba2e3b30ae53578c57c6ebc434417b4f1c2c94cf4f3", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [], [], "hexpm"},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/lib/absinthe/custom_types_test.exs
+++ b/test/lib/absinthe/custom_types_test.exs
@@ -16,6 +16,7 @@ defmodule Absinthe.CustomTypesTest do
       naive_datetime: ~N[2017-01-27 20:31:55],
       date: ~D[2017-01-27],
       time: ~T[20:31:55],
+      decimal: Decimal.new("-3.49"),
     }
 
     query do
@@ -36,6 +37,7 @@ defmodule Absinthe.CustomTypesTest do
       field :naive_datetime, :naive_datetime
       field :date, :date
       field :time, :time
+      field :decimal, :decimal
     end
 
     object :result do
@@ -47,6 +49,7 @@ defmodule Absinthe.CustomTypesTest do
       field :naive_datetime, :naive_datetime
       field :date, :date
       field :time, :time
+      field :decimal, :decimal
     end
   end
 
@@ -162,6 +165,60 @@ defmodule Absinthe.CustomTypesTest do
       request = """
       mutation {
         custom_types_mutation(args: { time: "abc" }) {
+          message
+        }
+      }
+      """
+      assert {:ok, %{errors: _errors}} = run(request, Schema)
+    end
+  end
+
+  context "custom decimal type" do
+    it "can use decimal type in queries" do
+      result = "{ custom_types_query { decimal } }" |> run(Schema)
+      assert_result {:ok, %{data: %{"custom_types_query" =>
+      %{"decimal" => "-3.49"}}}}, result
+    end
+    it "can use decimal type as string in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { decimal: "-3.49" }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "can use decimal type as integer in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { decimal: 3 }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "can use decimal type as float in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { decimal: -3.49 }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "returns an error when decimal value cannot be parsed" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { decimal: "abc" }) {
           message
         }
       }

--- a/test/lib/absinthe/type/custom_test.exs
+++ b/test/lib/absinthe/type/custom_test.exs
@@ -21,6 +21,8 @@ defmodule Absinthe.Type.CustomTest do
   @naive_datetime ~N[2017-01-27 20:31:55]
   @date ~D[2017-01-27]
   @time ~T[20:31:55]
+  @decimal Decimal.new("-3.49")
+  @decimal_int Decimal.new("3")
 
   defp serialize(type, value) do
     TestSchema.__absinthe_type__(type)
@@ -140,6 +142,32 @@ defmodule Absinthe.Type.CustomTest do
       assert :error == parse(:time, %Input.String{value: "abc123"})
       assert :error == parse(:time, %Input.String{value: "01/25/2017 20:31:55"})
       assert :error == parse(:time, %Input.String{value: "2017-15-42T31:71:95Z"})
+    end
+  end
+
+  context ":decimal" do
+    it "serializes as a string" do
+      assert "-3.49" == serialize(:decimal, @decimal)
+      assert "3" == serialize(:decimal, @decimal_int)
+    end
+
+    it "can be parsed from a numeric string" do
+      assert {:ok, decimal} = parse(:decimal, %Input.String{value: "-3.49"})
+      assert Decimal.cmp(@decimal, decimal) == :eq
+    end
+
+    it "can be parsed from a float" do
+      assert {:ok, decimal} = parse(:decimal, %Input.Float{value: -3.49})
+      assert Decimal.cmp(@decimal, decimal) == :eq
+    end
+
+    it "can be parsed from an integer" do
+      assert {:ok, decimal} = parse(:decimal, %Input.Integer{value: 3})
+      assert Decimal.cmp(@decimal_int, decimal) == :eq
+    end
+
+    it "cannot be parsed from alphanumeric string" do
+      assert :error == parse(:decimal, %Input.String{value: "23.4 abc"})
     end
   end
 end


### PR DESCRIPTION
As requested, this PR adds :decimal as a custom type in Absinthe.

Decimal values are return in JSON as strings to maintain precision, and are parsed into Decimal structs using the [Decimal](https://hexdocs.pm/decimal/Decimal.html) library