### PR TITLE
Allow parsing Input.Null for custom types

### DIFF
--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -68,7 +68,7 @@ defmodule Absinthe.Type.Custom do
       parse &parse_decimal/1
     end
 
-    @spec parse_decimal(any) :: {:ok, Decimal.t} | :error
+    @spec parse_decimal(any) :: {:ok, Decimal.t} | {:ok, nil} | :error
     defp parse_decimal(%Absinthe.Blueprint.Input.String{value: value}) do
       case Decimal.parse(value) do
         {:ok, decimal} -> {:ok, decimal}
@@ -83,12 +83,15 @@ defmodule Absinthe.Type.Custom do
       decimal = Decimal.new(value)
       if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
     end
+    defp parse_decimal(%Absinthe.Blueprint.Input.Null{}) do
+      {:ok, nil}
+    end
     defp parse_decimal(_) do
       :error
     end
   end
 
-  @spec parse_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, DateTime.t} | :error
+  @spec parse_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, DateTime.t} | {:ok, nil} | :error
   defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, 0} -> {:ok, datetime}
@@ -96,38 +99,50 @@ defmodule Absinthe.Type.Custom do
       _error -> :error
     end
   end
+  defp parse_datetime(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
   defp parse_datetime(_) do
     :error
   end
 
-  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, NaiveDateTime.t} | :error
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, NaiveDateTime.t} |{:ok, nil} | :error
   defp parse_naive_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case NaiveDateTime.from_iso8601(value) do
       {:ok, naive_datetime} -> {:ok, naive_datetime}
       _error -> :error
     end
   end
+  defp parse_naive_datetime(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
   defp parse_naive_datetime(_) do
     :error
   end
 
-  @spec parse_date(Absinthe.Blueprint.Input.String.t) :: {:ok, Date.t} | :error
+  @spec parse_date(Absinthe.Blueprint.Input.String.t) :: {:ok, Date.t} | {:ok, nil} | :error
   defp parse_date(%Absinthe.Blueprint.Input.String{value: value}) do
     case Date.from_iso8601(value) do
       {:ok, date} -> {:ok, date}
       _error -> :error
     end
   end
+  defp parse_date(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
   defp parse_date(_) do
     :error
   end
 
-  @spec parse_time(Absinthe.Blueprint.Input.String.t) :: {:ok, Time.t} | :error
+  @spec parse_time(Absinthe.Blueprint.Input.String.t) :: {:ok, Time.t} | {:ok, nil} | :error
   defp parse_time(%Absinthe.Blueprint.Input.String{value: value}) do
     case Time.from_iso8601(value) do
       {:ok, time} -> {:ok, time}
       _error -> :error
     end
+  end
+  defp parse_time(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
   end
   defp parse_time(_) do
     :error

--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -68,7 +68,8 @@ defmodule Absinthe.Type.Custom do
       parse &parse_decimal/1
     end
 
-    @spec parse_decimal(any) :: {:ok, Decimal.t} | {:ok, nil} | :error
+    @spec parse_decimal(any) :: {:ok, Decimal.t} | :error
+    @spec parse_decimal(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
     defp parse_decimal(%Absinthe.Blueprint.Input.String{value: value}) do
       case Decimal.parse(value) do
         {:ok, decimal} -> {:ok, decimal}
@@ -91,7 +92,8 @@ defmodule Absinthe.Type.Custom do
     end
   end
 
-  @spec parse_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, DateTime.t} | {:ok, nil} | :error
+  @spec parse_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, DateTime.t} | :error
+  @spec parse_datetime(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
   defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case DateTime.from_iso8601(value) do
       {:ok, datetime, 0} -> {:ok, datetime}
@@ -106,7 +108,8 @@ defmodule Absinthe.Type.Custom do
     :error
   end
 
-  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, NaiveDateTime.t} |{:ok, nil} | :error
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t) :: {:ok, NaiveDateTime.t} | :error
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
   defp parse_naive_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case NaiveDateTime.from_iso8601(value) do
       {:ok, naive_datetime} -> {:ok, naive_datetime}
@@ -120,7 +123,8 @@ defmodule Absinthe.Type.Custom do
     :error
   end
 
-  @spec parse_date(Absinthe.Blueprint.Input.String.t) :: {:ok, Date.t} | {:ok, nil} | :error
+  @spec parse_date(Absinthe.Blueprint.Input.String.t) :: {:ok, Date.t} | :error
+  @spec parse_date(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
   defp parse_date(%Absinthe.Blueprint.Input.String{value: value}) do
     case Date.from_iso8601(value) do
       {:ok, date} -> {:ok, date}
@@ -134,7 +138,8 @@ defmodule Absinthe.Type.Custom do
     :error
   end
 
-  @spec parse_time(Absinthe.Blueprint.Input.String.t) :: {:ok, Time.t} | {:ok, nil} | :error
+  @spec parse_time(Absinthe.Blueprint.Input.String.t) :: {:ok, Time.t} | :error
+  @spec parse_time(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
   defp parse_time(%Absinthe.Blueprint.Input.String{value: value}) do
     case Time.from_iso8601(value) do
       {:ok, time} -> {:ok, time}

--- a/test/lib/absinthe/custom_types_test.exs
+++ b/test/lib/absinthe/custom_types_test.exs
@@ -71,6 +71,18 @@ defmodule Absinthe.CustomTypesTest do
       assert_result {:ok, %{data: %{"custom_types_mutation" =>
         %{"message" => "ok"}}}}, result
     end
+    it "can use null in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { datetime: null }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
     it "returns an error when datetime value cannot be parsed" do
       request = """
       mutation {
@@ -93,6 +105,18 @@ defmodule Absinthe.CustomTypesTest do
       request = """
       mutation {
         custom_types_mutation(args: { naive_datetime: "2017-01-27T20:31:55" }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "can use null in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { naive_datetime: null }) {
           message
         }
       }
@@ -131,6 +155,18 @@ defmodule Absinthe.CustomTypesTest do
       assert_result {:ok, %{data: %{"custom_types_mutation" =>
         %{"message" => "ok"}}}}, result
     end
+    it "can use null in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { date: null }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
     it "returns an error when date value cannot be parsed" do
       request = """
       mutation {
@@ -153,6 +189,18 @@ defmodule Absinthe.CustomTypesTest do
       request = """
       mutation {
         custom_types_mutation(args: { time: "20:31:55" }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "can use null in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { time: null }) {
           message
         }
       }
@@ -207,6 +255,18 @@ defmodule Absinthe.CustomTypesTest do
       request = """
       mutation {
         custom_types_mutation(args: { decimal: -3.49 }) {
+          message
+        }
+      }
+      """
+      result = run(request, Schema)
+      assert_result {:ok, %{data: %{"custom_types_mutation" =>
+        %{"message" => "ok"}}}}, result
+    end
+    it "can use null in input_object" do
+      request = """
+      mutation {
+        custom_types_mutation(args: { decimal: null }) {
           message
         }
       }


### PR DESCRIPTION
`Absinthe.Blueprint.Input.Null` got introduced in https://github.com/absinthe-graphql/absinthe/pull/198 but parsing fails for
custom types, because they didn't handle it.

This PR fixes this by matching for `Absinthe.Blueprint.Input.Null` as well.

Are there any other types that would need to handle this case? If so, I can update my PR.