### PR TITLE
Fix compile error when Decimal is not available

### DIFF
--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -64,31 +64,8 @@ defmodule Absinthe.Type.Custom do
       values parsed by the `Decimal` library.  The Decimal appears in a JSON
       response as a string to preserve precision.
       """
-      serialize &Decimal.to_string/1
-      parse &parse_decimal/1
-    end
-
-    @spec parse_decimal(any) :: {:ok, Decimal.t} | :error
-    @spec parse_decimal(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
-    defp parse_decimal(%Absinthe.Blueprint.Input.String{value: value}) do
-      case Decimal.parse(value) do
-        {:ok, decimal} -> {:ok, decimal}
-        _ -> :error
-      end
-    end
-    defp parse_decimal(%Absinthe.Blueprint.Input.Float{value: value}) do
-      decimal = Decimal.new(value)
-      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
-    end
-    defp parse_decimal(%Absinthe.Blueprint.Input.Integer{value: value}) do
-      decimal = Decimal.new(value)
-      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
-    end
-    defp parse_decimal(%Absinthe.Blueprint.Input.Null{}) do
-      {:ok, nil}
-    end
-    defp parse_decimal(_) do
-      :error
+      serialize &Absinthe.Type.Custom.Decimal.serialize/1
+      parse &Absinthe.Type.Custom.Decimal.parse/1
     end
   end
 

--- a/lib/absinthe/type/custom/decimal.ex
+++ b/lib/absinthe/type/custom/decimal.ex
@@ -1,0 +1,46 @@
+if Code.ensure_loaded?(Decimal) do
+
+  defmodule Absinthe.Type.Custom.Decimal do
+    @moduledoc false
+
+    defdelegate serialize(value), to: Decimal, as: :to_string
+
+    @spec parse(any) :: {:ok, Decimal.t} | :error
+    @spec parse(Absinthe.Blueprint.Input.Null.t) :: {:ok, nil}
+    def parse(%Absinthe.Blueprint.Input.String{value: value}) do
+      case Decimal.parse(value) do
+        {:ok, decimal} -> {:ok, decimal}
+        _ -> :error
+      end
+    end
+    def parse(%Absinthe.Blueprint.Input.Float{value: value}) do
+      decimal = Decimal.new(value)
+      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
+    end
+    def parse(%Absinthe.Blueprint.Input.Integer{value: value}) do
+      decimal = Decimal.new(value)
+      if Decimal.nan?(decimal), do: :error, else: {:ok, decimal}
+    end
+    def parse(%Absinthe.Blueprint.Input.Null{}) do
+      {:ok, nil}
+    end
+    def parse(_) do
+      :error
+    end
+
+  end
+
+else
+
+  defmodule Absinthe.Type.Custom.Decimal do
+    @moduledoc false
+
+    @spec parse(any) :: :error
+    def parse(_), do:  :error
+
+    @spec serialize(any) :: nil
+    def serialize(_), do: nil
+
+  end
+
+end


### PR DESCRIPTION
Resolves #383.

- Extract :decimal parse/serialize to separate module
- Wrap module in Code.ensure_loaded?/1 and provide stub

Due to the way that macro expansion works for the `parse` and
`serialize` macros, you can't `&` capture-reference a function that
isn't defined due to a `Code.ensure_loaded?/1`. These changes
write a stub module so that those functions can be found, even though
they're never used.