### PR TITLE
Fix `no function clause matching in sum_complexity` error

### DIFF
--- a/lib/absinthe/phase/document/complexity/analysis.ex
+++ b/lib/absinthe/phase/document/complexity/analysis.ex
@@ -119,6 +119,10 @@ defmodule Absinthe.Phase.Document.Complexity.Analysis do
     Enum.reduce(fields, 0, &sum_complexity/2)
   end
 
+  defp sum_complexity(%{complexity: complexity}, acc) when is_nil(complexity) do
+    @default_complexity + acc
+  end
+
   defp sum_complexity(%{complexity: complexity}, acc) when is_integer(complexity) do
     complexity + acc
   end


### PR DESCRIPTION
By default each field in a query will increase the complexity by 1