### PR TITLE
Fully qualify type names in Absinthe.Resolution.t

### DIFF
--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -27,15 +27,15 @@ defmodule Absinthe.Resolution do
     adapter: Absinthe.Adapter.t,
     context: map,
     root_value: any,
-    schema: Schema.t,
-    definition: Blueprint.node_t,
-    parent_type: Type.t,
+    schema: Absinthe.Schema.t,
+    definition: Absinthe.Blueprint.node_t,
+    parent_type: Absinthe.Type.t,
     source: any,
     state: field_state,
     acc: %{any => any},
     extensions: %{any => any},
     arguments: %{optional(atom) => any},
-    fragments: [Blueprint.Document.Fragment.Named.t],
+    fragments: [Absinthe.Blueprint.Document.Fragment.Named.t],
   }
 
   @enforce_keys [:adapter, :context, :root_value, :schema, :source]


### PR DESCRIPTION
In our application, dialyzer complains:

```
:0: Unknown type 'Elixir.Blueprint':node_t/0
:0: Unknown type 'Elixir.Blueprint.Document.Fragment.Named':t/0
:0: Unknown type 'Elixir.Schema':t/0
:0: Unknown type 'Elixir.Type':t/0
```

I tracked those warnings down to `Absinthe.Resolution.t` definition, this is the fix.