### PR TITLE
Failing test for complexity analysis of GraphiQL introspection query

### DIFF
--- a/test/lib/absinthe/phase/document/complexity_test.exs
+++ b/test/lib/absinthe/phase/document/complexity_test.exs
@@ -230,5 +230,31 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert errors == []
     end
 
+    it "handles GraphQL introspection" do
+      doc= """
+      query IntrospectionQuery {
+        __schema {
+          types {
+            ...FullType
+          }
+        }
+      }
+
+      fragment FullType on __Type {
+        fields {
+          args {
+            ...InputValue
+          }
+        }
+      }
+
+      fragment InputValue on __InputValue {
+        type { name }
+      }
+      """
+
+      assert {:ok, result, _} = run_phase(doc, operation_name: "IntrospectionQuery", variables: %{}, analyze_complexity: true)
+    end
+
   end
 end


### PR DESCRIPTION
[GraphiQL introspection query](https://github.com/graphql/graphiql/blob/dc4a561f796258c6e6773612279abccb76f10ee0/src/utility/introspectionQueries.js#L14) triggers error in Absinthe complexity analysis phase. That query is quite big, I cut some stuff out of it, and ended up with smaller one that still triggers the same error. Both queries run fine and return expected results with complexity analysis disabled.