### PR TITLE
Fix doc for absinthe.schema.json task

### DIFF
--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
 
   ## Usage
 
-      absinthe.schema.json [OPTIONS] [FILENAME]
+      absinthe.schema.json [FILENAME] [OPTIONS]
 
   ## Options
 


### PR DESCRIPTION
Filename is expected as the first argument. Fix doc to reflect the same.