### PR TITLE
Don't allow Reserved names as object identifiers

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -176,7 +176,12 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
-  defmacro object(identifier, attrs \\ [], [do: block]) do
+  @reserved_identifiers ~w(query mutation subscription)a
+  defmacro object(identifier, attrs \\ [], block)
+  defmacro object(identifier, _attrs, _block) when identifier in @reserved_identifiers do
+    raise Absinthe.Schema.Notation.Error, "Invalid schema notation: cannot create an `object` with reserved identifier `#{identifier}`"
+  end
+  defmacro object(identifier, attrs, [do: block]) do
     __CALLER__
     |> recordable!(:object, @placement[:object])
     |> record_object!(identifier, attrs, block)

--- a/test/lib/absinthe/phase/parse_test.exs
+++ b/test/lib/absinthe/phase/parse_test.exs
@@ -9,7 +9,7 @@ defmodule Absinthe.Phase.ParseTest do
     assert {:error, _} = run("{ user(id: 2 { name } }")
   end
 
-  @reserved ~w(query mutation fragment on implements interface union scalar enum input extend)
+  @reserved ~w(query mutation subscription fragment on implements interface union scalar enum input extend)
   it "can parse queries with arguments and variables that are 'reserved words'" do
     @reserved
     |> Enum.each(fn

--- a/test/lib/absinthe/schema/notation_test.exs
+++ b/test/lib/absinthe/schema/notation_test.exs
@@ -90,7 +90,7 @@ defmodule Absinthe.Schema.NotationTest do
     it "handles circular errors" do
       defmodule Circles do
         use Absinthe.Schema.Notation
-        
+
         object :foo do
           import_fields :bar
           field :name, :string
@@ -391,6 +391,20 @@ defmodule Absinthe.Schema.NotationTest do
         end
       end
       """, "Invalid schema notation: `object` must only be used toplevel"
+    end
+    it "cannot use reserved identifiers" do
+      assert_notation_error "ReservedIdentifierSubscription", """
+      object :subscription do
+      end
+      """, "Invalid schema notation: cannot create an `object` with reserved identifier `subscription`"
+      assert_notation_error "ReservedIdentifierQuery", """
+      object :query do
+      end
+      """, "Invalid schema notation: cannot create an `object` with reserved identifier `query`"
+      assert_notation_error "ReservedIdentifierMutation", """
+      object :mutation do
+      end
+      """, "Invalid schema notation: cannot create an `object` with reserved identifier `mutation`"
     end
   end
 


### PR DESCRIPTION
Re: https://github.com/absinthe-graphql/absinthe/issues/393

This PR raises an error when someone tries to define an object using a reserved `:identifier`.. (`:query`, `:mutation`, `:subscription`).

This currently leads to a fairly opaque error at runtime :(