### PR TITLE
Eager Default Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Status: RC
 - Enhancement: Subscriptions! See the Absinthe.Phoenix project for getting started info
 - Enhancement: Null literal support [as laid out in the October 2016 GraphQL Specification](http://facebook.github.io/graphql/#sec-Null-Value)
 - Enhancement: Errors now include path information. This path information can be accessed in resolvers via `Absinthe.Resolution.path/1`
+
+- Breaking Change: Default middleware applied eagerly. If you're changing the default resolver, you WILL need to consult: https://github.com/absinthe-graphql/absinthe/pull/403
 - Breaking Change: Errors returned from resolvers no longer say "In field #{field_name}:". The inclusion of the path information obviates the need for this data, and it makes error messages a lot easier to deal with on the front end.
 
 ## v1.3.2

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -75,6 +75,15 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp field_data(fields, errors, acc \\ [])
   defp field_data([], errors, acc), do: {Map.new(acc), errors}
+  defp field_data([%Absinthe.Resolution{} = res | _], _errors, _acc) do
+    raise """
+    Found unresolved resolution struct!
+
+    You probably forgot to run the resolution phase again.
+
+    #{inspect res}
+    """
+  end
   defp field_data([field | fields], errors, acc) do
     {value, errors} = data(field, errors)
     field_data(fields, errors, [{field_name(field.emitter), value} | acc])

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -381,17 +381,8 @@ defimpl Inspect, for: Absinthe.Resolution do
     inner =
       res
       |> Map.from_struct
-      |> Map.update!(:definition, fn
-        %{name: name} ->
-          name
-        _ ->
-          nil
-      end)
-      |> Map.update!(:parent_type, fn
-        %{identifier: identifier} ->
-          identifier
-        _ ->
-          nil
+      |> Map.update!(:fields_cache, fn _ ->
+        "#fieldscache<...>"
       end)
       |> Map.to_list
       |> Inspect.List.inspect(opts)

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -201,8 +201,8 @@ defmodule Absinthe.Schema do
 
       defp __do_absinthe_middleware__(middleware, field, object) do
         middleware
-        |> __MODULE__.middleware(field, object) # run field against user supplied function
         |> Absinthe.Schema.ensure_middleware(field, object) # if they forgot to add middleware set the default
+        |> __MODULE__.middleware(field, object) # run field against user supplied function
       end
 
       @doc false

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -236,6 +236,16 @@ defmodule Absinthe.Schema do
     end
   end
 
+  @doc """
+  List of Plugins to run before / after resolution.
+
+  Plugins are modules that implement the `Absinthe.Plugin` behaviour. These modules
+  have the opportunity to run callbacks before and after the resolution of the entire
+  document, and have access to the resolution accumulator.
+
+  Plugins must be specified by the schema, so that Absinthe can make sure they are
+  all given a chance to run prior to resolution.
+  """
   @callback plugins() :: [Absinthe.Plugin.t]
 
   @doc false

--- a/test/lib/absinthe/execution/default_resolver_test.exs
+++ b/test/lib/absinthe/execution/default_resolver_test.exs
@@ -32,7 +32,7 @@ defmodule Absinthe.Execution.DefaultResolverTest do
         field :bar, :string
       end
 
-      def middleware([], %{name: name, identifier: identifier}, _) do
+      def middleware([{Absinthe.Middleware.MapGet, _}], %{name: name, identifier: identifier}, _) do
         middleware_spec = Absinthe.Resolution.resolver_spec(fn parent, _, _ ->
           case parent do
             %{^name => value} -> {:ok, value}


### PR DESCRIPTION
Although a small change, this will affect anyone who is currently doing stuff to change the default middleware, so it's worth an explanation.

## Right Now

The way things work right now is that the default middleware is applied "lazily". What this means is if you have a simple field like:

```elixir
object :user 
  field :name, :string
end
```

then when it is passed to the `def middleware` callback on a schema, the middleware provided is an empty list

```elixir
def middleware(middleware, %{identifier: :name}, %{identifier: :user}) do
  middleware |> IO.inspect #=> []
end
```

The nice thing about this is that it makes it easy to pattern match for the "no middleware supplied" situation, you can just look for `[]`. 

The problem though is that if you want to add a simple tracing middleware that runs on every field for example, the "obvious" way is to just do:

```elixir
def middleware(middleware, _field, _object) do
  [ Tracer | middleware]
end
```

Aaand we just broke our `field :name, :string` field, and all others like it. No longer does it come back from `def middleware` as `[]` and thus our lazy default isn't applied.

This has tripped up a reasonable number of people, and I think violates the common sense of what having a default value means. It also makes it hard for users to answer the question "when I don't specify middleware on a field, what middleware ultimately runs". This seems like the place they could do it, but instead they get `[]`

## Proposed solution.

I want to make the default eager. This means:

```elixir
def middleware(middleware, %{identifier: :name}, %{identifier: :user}) do
  middleware |> IO.inspect #=> [{Absinthe.Middleware.MapGet, :name}]
end
```

Every field will have at least one middleware specified, and the `def middleware` callback has full access to it. Conceptually, it's a lot simpler than the current approach, in that there isn't some hidden action after the fact.

Changing the default is a bit more work now, because you have to explicitly match against the Absinthe default now to put something else in its place. However it isn't crazy difficult, and moreover a helper function could be reasonably added to make it even easier.

This _is_ a breaking change for anyone doing something to set different default middleware right now, but I'm confident that it could be a one line fix. This may also affect third party libraries.

@bruce @lauraannwilliams 