### PR TITLE
Setup Dialyxir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
 language: elixir
+
 elixir:
   - 1.4.5
   - 1.5.1
+
 notifications:
   recipients:
     - bruce.williams@cargosense.com
     - ben.wilson@cargosense.com
+
 otp_release:
   - 19.2
   - 20.0
-script: "MIX_ENV=test mix local.hex --force && MIX_ENV=test mix do deps.get, test"
+
+cache:
+  directories:
+    - _build
+    - deps
+
+env:
+  - MIX_ENV=test
+
+install:
+  - mix local.hex --force
+  - mix local.rebar --force
+  - mix do deps.get, compile
+
+script:
+  - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ install:
 
 script:
   - mix test
+  - mix dialyzer

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Absinthe.Mixfile do
       {:ex_spec, "~> 2.0.0", only: :test},
       {:ex_doc, "~> 0.14", only: :dev},
       {:benchfella, "~> 0.3.0", only: :dev},
-      {:dialyze, "~> 0.2", only: :dev},
+      {:dialyxir, "~> 0.5", only: :dev},
       {:decimal, "~> 1.0", optional: :true},
       {:phoenix_pubsub, ">= 0.0.0", only: :test},
       {:mix_test_watch, "~> 0.4.1", only: [:test, :dev]}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"benchfella": {:hex, :benchfella, "0.3.4", "41d2c017b361ece5225b5ba2e3b30ae53578c57c6ebc434417b4f1c2c94cf4f3", [:mix], [], "hexpm"},
   "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [], [], "hexpm"},
-  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm"},


### PR DESCRIPTION
Welcome to a broken build!

This sets up dialyxir to run on in Travis. You'll see a lot of errors. Some of them are actual errors.

I also had to modify Travis. We now cache the `_build` and `deps` folders so that we don't have to always redownload and rebuild everything.