### PR TITLE
Use Macro.to_string for non-atom type modules

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1216,7 +1216,7 @@ defmodule Absinthe.Schema.Notation do
   end
   defp do_import_types(type_module, _) do
     raise ArgumentError, """
-    #{type_module} is not a module
+    `#{Macro.to_string(type_module)}` is not a module
 
     This macro must be given a literal module name or a macro which expands to a
     literal module name. Variables are not supported at this time.


### PR DESCRIPTION
Previously, the following code:

    for schema <- [PostSchema, UserSchema, AppSchema] do
      import_types Module.concat(MyApp, schema)
    end

Would generate the following error:

    ** (Protocol.UndefinedError) protocol String.Chars not implemented
    for {{:., [line: 9], [{:__aliases__, [counter: 0, line: 9],
    [:Module]}, :concat]}, [line: 9], [{:__aliases__, [counter: 0,u
    line: 9], [:MyApp]}, {:schema, [line: 9], nil}]}

It now generates:

    ** (ArgumentError) `Module.concat(VoicelayerGraphQL, schema)` is not
    a module

    This macro must be given a literal module name or a macro which
    expands to a literal module name. Variables are not supported at this
    time.