### PR TITLE
Rename Blueprint.Document.Resolution to Blueprint.Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Status: RC
 - Enhancement: Errors now include path information. This path information can be accessed in resolvers via `Absinthe.Resolution.path/1`
 
 - Breaking Change: Default middleware applied eagerly. If you're changing the default resolver, you WILL need to consult: https://github.com/absinthe-graphql/absinthe/pull/403
+- Breaking Change: Plugins receive an `%Absinthe.Blueprint.Execution{}` struct instead of the bare accumulator. This makes it possible for plugins to set or operate on context values.
 - Breaking Change: Errors returned from resolvers no longer say "In field #{field_name}:". The inclusion of the path information obviates the need for this data, and it makes error messages a lot easier to deal with on the front end.
+
+- Internal Change: `Absinthe.Blueprint.Document.Resolution` => `Absinthe.Blueprint.Execution`
 
 ## v1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,47 @@
 ## v1.4.0
 Status: RC
 
-- Enhancement: Subscriptions! See the Absinthe.Phoenix project for getting started info
+- Enhancement: Subscriptions! See the Absinthe.Phoenix project for getting started info.
 - Enhancement: Null literal support [as laid out in the October 2016 GraphQL Specification](http://facebook.github.io/graphql/#sec-Null-Value)
 - Enhancement: Errors now include path information. This path information can be accessed in resolvers via `Absinthe.Resolution.path/1`
 
 - Breaking Change: Default middleware applied eagerly. If you're changing the default resolver, you WILL need to consult: https://github.com/absinthe-graphql/absinthe/pull/403
-- Breaking Change: Plugins receive an `%Absinthe.Blueprint.Execution{}` struct instead of the bare accumulator. This makes it possible for plugins to set or operate on context values.
+
+- Breaking Change: Plugins receive an `%Absinthe.Blueprint.Execution{}` struct instead of the bare accumulator. This makes it possible for plugins to set or operate on context values. Upgrade you plugins! Change this:
+  ```
+  def before_resolution(acc) do
+    acc = # doing stuff to the acc here
+  end
+  def after_resolution(acc) do
+    acc = # doing stuff to the acc here
+  end
+  def pipeline(pipeline, acc) do
+    case acc do
+      # checking on the acc here
+    end
+  end
+  ```
+  to
+  ```
+  def before_resolution(%{acc: acc} = exec) do
+    acc = # doing stuff to the acc here
+    %{exec | acc: acc}
+  end
+  def after_resolution(%{acc: acc} = exec) do
+    acc = # doing stuff to the acc here
+    %{exec | acc: acc}
+  end
+  def pipeline(pipeline, exec) do
+    case exec.acc do
+      # checking on the acc here
+    end
+  end
+  ```
+  The reason for this is that you can also access the `context` within the `exec` value. When using something like DataLoader, it's important to have easy to the context
+
 - Breaking Change: Errors returned from resolvers no longer say "In field #{field_name}:". The inclusion of the path information obviates the need for this data, and it makes error messages a lot easier to deal with on the front end.
 
-- Internal Change: `Absinthe.Blueprint.Document.Resolution` => `Absinthe.Blueprint.Execution`
+- Internal Change: `Absinthe.Blueprint.Document.Resolution` => `Absinthe.Blueprint.Execution`. See https://github.com/absinthe-graphql/absinthe/pull/409 for details.
 
 ## v1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Status: RC
 - Enhancement: Subscriptions! See the Absinthe.Phoenix project for getting started info
 - Enhancement: Null literal support [as laid out in the October 2016 GraphQL Specification](http://facebook.github.io/graphql/#sec-Null-Value)
 - Enhancement: Errors now include path information. This path information can be accessed in resolvers via `Absinthe.Resolution.path/1`
+
+- Breaking Change: Default middleware applied eagerly. If you're changing the default resolver, you WILL need to consult: https://github.com/absinthe-graphql/absinthe/pull/403
 - Breaking Change: Errors returned from resolvers no longer say "In field #{field_name}:". The inclusion of the path information obviates the need for this data, and it makes error messages a lot easier to deal with on the front end.
 
 ## v1.3.2

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Blueprint do
     flags: %{},
     errors: [],
     input: nil,
-    resolution: %Blueprint.Execution{},
+    execution: %Blueprint.Execution{},
     result: %{},
   ]
 
@@ -36,7 +36,7 @@ defmodule Absinthe.Blueprint do
     # Added by phases
     errors: [Absinthe.Phase.Error.t],
     flags: flags_t,
-    resolution: Blueprint.Document.Resolution.t,
+    execution: Blueprint.Execution.t,
     result: result_t,
   }
 

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Blueprint do
     flags: %{},
     errors: [],
     input: nil,
-    resolution: %Blueprint.Document.Resolution{},
+    resolution: %Blueprint.Execution{},
     result: %{},
   ]
 

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -1,6 +1,32 @@
 defmodule Absinthe.Blueprint.Execution do
 
-  @moduledoc false
+  @moduledoc """
+  Blueprint Execution Data
+
+  The `%Absinthe.Blueprint.Execution{}` struct holds on to the core values that
+  drive a document's execution.
+
+  Here's how the execution flow works. Given a document like:
+  ```
+  {
+    posts {
+      title
+      author { name }
+    }
+  }
+  ```
+
+  After all the validation happens, and we're actually going to execute this document,
+  an `%Execution{}` struct is created. This struct is passed to each plugin's
+  `before_resolution` callback, so that plugins can set initial values in the accumulator
+  or context.
+
+  Then the resolution phase walks the document until it hits the `posts` field.
+  To resolve the posts field, an `%Absinthe.Resolution{}` struct is created from
+  the `%Execution{}` struct. This resolution struct powers the normal middleware
+  resolution process. When a field has resolved, the `:acc`, `:context`, and `:field_cache`
+  values within the resolution struct are pulled out and used to update the execution.
+  """
 
   alias Absinthe.Phase
 

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -1,9 +1,8 @@
-defmodule Absinthe.Blueprint.Document.Resolution do
+defmodule Absinthe.Blueprint.Execution do
 
   @moduledoc false
 
   alias Absinthe.Phase
-  alias __MODULE__
 
   @type acc :: map
 
@@ -17,17 +16,17 @@ defmodule Absinthe.Blueprint.Document.Resolution do
 
   @type t :: %__MODULE__ {
     validation_errors: [Phase.Error.t],
-    result: nil | Resolution.Object.t,
+    result: nil | Result.Object.t,
     acc: acc,
   }
 
   @type node_t ::
-      Resolution.Object
-    | Resolution.List
-    | Resolution.Leaf
+      Result.Object
+    | Result.List
+    | Result.Leaf
 
   def get_result(%__MODULE__{result: nil}, operation, root_value) do
-    %Absinthe.Blueprint.Document.Resolution.Object{
+    %Absinthe.Blueprint.Result.Object{
       root_value: root_value,
       emitter: operation,
     }

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -7,6 +7,11 @@ defmodule Absinthe.Blueprint.Execution do
   @type acc :: map
 
   defstruct [
+    :adapter,
+    :root_value,
+    :schema,
+    fragments: %{},
+    fields_cache: %{},
     validation_errors: [],
     result: nil,
     acc: %{},
@@ -25,7 +30,24 @@ defmodule Absinthe.Blueprint.Execution do
     | Result.List
     | Result.Leaf
 
-  def get_result(%__MODULE__{result: nil}, operation, root_value) do
+  def get(%{execution: %{result: nil} = exec} = bp_root, operation) do
+    result = %Absinthe.Blueprint.Result.Object{
+      root_value: exec.root_value,
+      emitter: operation,
+    }
+
+    %{exec |
+      result: result,
+      adapter: bp_root.adapter,
+      schema: bp_root.schema,
+      fragments: Map.new(bp_root.fragments, &{&1.name, &1})
+    }
+  end
+  def get(%{execution: exec}, _) do
+    exec
+  end
+
+  def get_result(%__MODULE__{result: nil, root_value: root_value}, operation) do
     %Absinthe.Blueprint.Result.Object{
       root_value: root_value,
       emitter: operation,

--- a/lib/absinthe/blueprint/result/leaf.ex
+++ b/lib/absinthe/blueprint/result/leaf.ex
@@ -1,14 +1,13 @@
-defmodule Absinthe.Blueprint.Document.Resolution.Object do
+defmodule Absinthe.Blueprint.Result.Leaf do
 
   @moduledoc false
 
   alias Absinthe.{Blueprint, Phase}
 
-  @enforce_keys [:emitter, :root_value]
+  @enforce_keys [:emitter, :value]
   defstruct [
-    :root_value,
     :emitter,
-    :fields,
+    :value,
     errors: [],
     flags: %{},
     extensions: %{},
@@ -16,7 +15,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.Object do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    fields: [Blueprint.Document.Resolution.node_t],
+    value: Blueprint.Document.Resolution.node_t,
     errors: [Phase.Error.t],
     flags: Blueprint.flags_t,
     extensions: %{any => any},

--- a/lib/absinthe/blueprint/result/list.ex
+++ b/lib/absinthe/blueprint/result/list.ex
@@ -1,13 +1,13 @@
-defmodule Absinthe.Blueprint.Document.Resolution.Leaf do
+defmodule Absinthe.Blueprint.Result.List do
 
   @moduledoc false
 
   alias Absinthe.{Blueprint, Phase}
 
-  @enforce_keys [:emitter, :value]
+  @enforce_keys [:emitter, :values]
   defstruct [
     :emitter,
-    :value,
+    :values,
     errors: [],
     flags: %{},
     extensions: %{},
@@ -15,7 +15,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.Leaf do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    value: Blueprint.Document.Resolution.node_t,
+    values: [Blueprint.Document.Resolution.node_t],
     errors: [Phase.Error.t],
     flags: Blueprint.flags_t,
     extensions: %{any => any},

--- a/lib/absinthe/blueprint/result/object.ex
+++ b/lib/absinthe/blueprint/result/object.ex
@@ -1,13 +1,14 @@
-defmodule Absinthe.Blueprint.Document.Resolution.List do
+defmodule Absinthe.Blueprint.Result.Object do
 
   @moduledoc false
 
   alias Absinthe.{Blueprint, Phase}
 
-  @enforce_keys [:emitter, :values]
+  @enforce_keys [:emitter, :root_value]
   defstruct [
+    :root_value,
     :emitter,
-    :values,
+    :fields,
     errors: [],
     flags: %{},
     extensions: %{},
@@ -15,7 +16,7 @@ defmodule Absinthe.Blueprint.Document.Resolution.List do
 
   @type t :: %__MODULE__{
     emitter: Blueprint.Document.Field.t,
-    values: [Blueprint.Document.Resolution.node_t],
+    fields: [Blueprint.Document.Resolution.node_t],
     errors: [Phase.Error.t],
     flags: Blueprint.flags_t,
     extensions: %{any => any},

--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -80,11 +80,11 @@ defmodule Absinthe.Middleware.Async do
   # We must set the flag to false because if a previous resolution iteration
   # set it to true it needs to go back to false now. It will be set
   # back to true if any field uses this plugin again.
-  def before_resolution(acc) do
-    Map.put(acc, __MODULE__, false)
+  def before_resolution(exec) do
+    put_in(exec.acc[__MODULE__], false)
   end
   # Nothing to do after resolution for this plugin, so we no-op
-  def after_resolution(acc), do: acc
+  def after_resolution(exec), do: exec
 
   # If the flag is set we need to do another resolution phase.
   # otherwise, we do not

--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -88,8 +88,8 @@ defmodule Absinthe.Middleware.Async do
 
   # If the flag is set we need to do another resolution phase.
   # otherwise, we do not
-  def pipeline(pipeline, acc) do
-    case acc do
+  def pipeline(pipeline, exec) do
+    case exec.acc do
       %{__MODULE__ => true} ->
         [Absinthe.Phase.Document.Execution.Resolution | pipeline]
       _ ->

--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -95,12 +95,12 @@ defmodule Absinthe.Middleware.Batch do
 
   @type post_batch_fun :: (term -> Absinthe.Type.Field.result)
 
-  def before_resolution(acc) do
-    case acc do
+  def before_resolution(exec) do
+    case exec.acc do
       %{__MODULE__ => _} ->
-        put_in(acc[__MODULE__][:input], [])
+        put_in(exec.acc[__MODULE__][:input], [])
       _ ->
-        Map.put(acc, __MODULE__, %{input: [], output: %{}})
+        put_in(exec.acc[__MODULE__], %{input: [], output: %{}})
     end
   end
 
@@ -128,9 +128,9 @@ defmodule Absinthe.Middleware.Batch do
     |> Absinthe.Resolution.put_result(post_batch_fun.(batch_data_for_fun))
   end
 
-  def after_resolution(acc) do
-    output = do_batching(acc[__MODULE__][:input])
-    put_in(acc[__MODULE__][:output], output)
+  def after_resolution(exec) do
+    output = do_batching(exec.acc[__MODULE__][:input])
+    put_in(exec.acc[__MODULE__][:output], output)
   end
 
   defp do_batching(input) do

--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -156,8 +156,8 @@ defmodule Absinthe.Middleware.Batch do
 
   # If the flag is set we need to do another resolution phase.
   # otherwise, we do not
-  def pipeline(pipeline, acc) do
-    case acc[__MODULE__][:input] do
+  def pipeline(pipeline, exec) do
+    case exec.acc[__MODULE__][:input] do
       [_|_] ->
         [Absinthe.Phase.Document.Execution.Resolution | pipeline]
       _ ->

--- a/lib/absinthe/phase/blueprint.ex
+++ b/lib/absinthe/phase/blueprint.ex
@@ -10,11 +10,11 @@ defmodule Absinthe.Phase.Blueprint do
     input = blueprint.input
     blueprint = Blueprint.Draft.convert(input, blueprint)
 
-    context = Map.merge(blueprint.resolution.context, options[:context] || %{})
-    blueprint = put_in(blueprint.resolution.context, context)
+    context = Map.merge(blueprint.execution.context, options[:context] || %{})
+    blueprint = put_in(blueprint.execution.context, context)
 
-    root_value = Map.merge(blueprint.resolution.root_value, options[:root_value] || %{})
-    blueprint = put_in(blueprint.resolution.root_value, root_value)
+    root_value = Map.merge(blueprint.execution.root_value, options[:root_value] || %{})
+    blueprint = put_in(blueprint.execution.root_value, root_value)
 
     {:ok, blueprint}
   end

--- a/lib/absinthe/phase/document/complexity/result.ex
+++ b/lib/absinthe/phase/document/complexity/result.ex
@@ -18,7 +18,7 @@ defmodule Absinthe.Phase.Document.Complexity.Result do
     {operation, errors} = Blueprint.prewalk(operation, [], fun)
 
     blueprint = Blueprint.update_current(input, fn(_) -> operation end)
-    blueprint = put_in(blueprint.resolution.validation_errors, errors)
+    blueprint = put_in(blueprint.execution.validation_errors, errors)
 
     case {errors, Map.new(options)} do
       {[], _} ->

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -28,7 +28,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
     if Keyword.get(options, :plugin_callbacks, true) do
       bp_root.schema.plugins()
-      |> Absinthe.Plugin.pipeline(execution.acc)
+      |> Absinthe.Plugin.pipeline(execution)
       |> case do
         [] ->
           {:ok, blueprint}

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -41,24 +41,18 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp perform_resolution(bp_root, operation, options) do
-    root_value = bp_root.execution.root_value
-
-    info   = build_info(bp_root, root_value)
-    acc    = bp_root.execution.acc
-    result = bp_root.execution |> Execution.get_result(operation, root_value)
+    exec = Execution.get(bp_root, operation)
 
     plugins = bp_root.schema.plugins()
     run_callbacks? = Keyword.get(options, :plugin_callbacks, true)
 
-    acc = plugins |> run_callbacks(:before_resolution, acc, run_callbacks?)
+    exec = plugins |> run_callbacks(:before_resolution, exec, run_callbacks?)
 
-    info = %{info | acc: acc}
+    {result, exec} = walk_result(exec.result, operation, operation.schema_node, exec, [operation])
 
-    {result, info} = walk_result(result, operation, operation.schema_node, info, [operation])
+    exec = plugins |> run_callbacks(:after_resolution, exec, run_callbacks?)
 
-    acc = plugins |> run_callbacks(:after_resolution, info.acc, run_callbacks?)
-
-    Execution.update(bp_root.execution, result, info.context, acc)
+    %{exec | result: result}
   end
 
   defp run_callbacks(plugins, callback, acc, true) do
@@ -66,65 +60,53 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
   defp run_callbacks(_, _, acc, _ ), do: acc
 
-  defp build_info(bp_root, root_value) do
-    context = bp_root.execution.context
-
-    %Absinthe.Resolution{
-      adapter: bp_root.adapter,
-      context: context,
-      root_value: root_value,
-      schema: bp_root.schema,
-      source: root_value,
-      fragments: Map.new(bp_root.fragments, &{&1.name, &1}),
-    }
-  end
-
   @doc """
   This function walks through any existing results. If no results are found at a
   given node, it will call the requisite function to expand and build those results
   """
-  def walk_result(%{fields: nil} = result, bp_node, _schema_type, info, path) do
-    {fields, info} = resolve_fields(bp_node, info, result.root_value, path)
-    {%{result | fields: fields}, info}
+  def walk_result(%{fields: nil} = result, bp_node, _schema_type, exec, path) do
+    {fields, exec} = resolve_fields(bp_node, exec, result.root_value, path)
+    {%{result | fields: fields}, exec}
   end
-  def walk_result(%{fields: fields} = result, bp_node, schema_type, info, path) do
-    {fields, info} = walk_results(fields, bp_node, schema_type, info, [0 | path], [])
+  def walk_result(%{fields: fields} = result, bp_node, schema_type, exec, path) do
+    {fields, exec} = walk_results(fields, bp_node, schema_type, exec, [0 | path], [])
 
-    {%{result | fields: fields}, info}
+    {%{result | fields: fields}, exec}
   end
-  def walk_result(%Result.Leaf{} = result, _, _, info, _) do
-    {result, info}
+  def walk_result(%Result.Leaf{} = result, _, _, exec, _) do
+    {result, exec}
   end
-  def walk_result(%{values: values} = result, bp_node, schema_type, info, path) do
-    {values, info} = walk_results(values, bp_node, schema_type, info, [0 | path], [])
-    {%{result | values: values}, info}
+  def walk_result(%{values: values} = result, bp_node, schema_type, exec, path) do
+    {values, exec} = walk_results(values, bp_node, schema_type, exec, [0 | path], [])
+    {%{result | values: values}, exec}
   end
-  def walk_result(%Absinthe.Resolution{} = res, _bp_node, _schema_type, info, _path) do
-    do_resolve_field(%{res | acc: info.acc}, info, res.source, res.path)
+  def walk_result(%Absinthe.Resolution{} = res, _bp_node, _schema_type, exec, _path) do
+    res = update_persisted_fields(res, exec)
+    do_resolve_field(res, exec, res.source, res.path)
   end
 
   # walk list results
-  defp walk_results([value | values], bp_node, inner_type, info, [i | sub_path] = path, acc) do
-    {result, info} = walk_result(value, bp_node, inner_type, info, path)
-    walk_results(values, bp_node, inner_type, info, [i + 1 | sub_path], [result | acc])
+  defp walk_results([value | values], bp_node, inner_type, exec, [i | sub_path] = path, acc) do
+    {result, exec} = walk_result(value, bp_node, inner_type, exec, path)
+    walk_results(values, bp_node, inner_type, exec, [i + 1 | sub_path], [result | acc])
   end
-  defp walk_results([], _, _, info, _, acc), do: {:lists.reverse(acc), info}
+  defp walk_results([], _, _, exec, _, acc), do: {:lists.reverse(acc), exec}
 
-  defp resolve_fields(parent, info, source, path) do
+  defp resolve_fields(parent, exec, source, path) do
     parent
     # parent is the parent field, we need to get the return type of that field
     |> get_return_type
     # that return type could be an interface or union, so let's make it concrete
-    |> get_concrete_type(source, info)
+    |> get_concrete_type(source, exec)
     |> case do
       nil ->
-        {[], info}
+        {[], exec}
       parent_type ->
-        {fields, fields_cache} = Absinthe.Resolution.Projector.project(parent.selections, parent_type, path, info.fields_cache, info)
+        {fields, fields_cache} = Absinthe.Resolution.Projector.project(parent.selections, parent_type, path, exec.fields_cache, exec)
 
-        info = %{info | fields_cache: fields_cache}
+        exec = %{exec | fields_cache: fields_cache}
 
-        do_resolve_fields(fields, info, source, parent_type, path, [])
+        do_resolve_fields(fields, exec, source, parent_type, path, [])
     end
   end
 
@@ -136,38 +118,40 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
   defp get_return_type(type), do: type
 
-  defp get_concrete_type(%Type.Union{} = parent_type, source, info) do
-    Type.Union.resolve_type(parent_type, source, info)
+  defp get_concrete_type(%Type.Union{} = parent_type, source, exec) do
+    Type.Union.resolve_type(parent_type, source, exec)
   end
-  defp get_concrete_type(%Type.Interface{} = parent_type, source, info) do
-    Type.Interface.resolve_type(parent_type, source, info)
+  defp get_concrete_type(%Type.Interface{} = parent_type, source, exec) do
+    Type.Interface.resolve_type(parent_type, source, exec)
   end
-  defp get_concrete_type(parent_type, _source, _info) do
+  defp get_concrete_type(parent_type, _source, _exec) do
     parent_type
   end
 
-  defp do_resolve_fields([field | fields], info, source, parent_type, path, acc) do
-    {result, info} = resolve_field(field, info, source, parent_type, [field | path])
-    do_resolve_fields(fields, info, source, parent_type, path, [result | acc])
+  defp do_resolve_fields([field | fields], exec, source, parent_type, path, acc) do
+    {result, exec} = resolve_field(field, exec, source, parent_type, [field | path])
+    do_resolve_fields(fields, exec, source, parent_type, path, [result | acc])
   end
-  defp do_resolve_fields([], info, _, _, _, acc), do: {:lists.reverse(acc), info}
+  defp do_resolve_fields([], exec, _, _, _, acc), do: {:lists.reverse(acc), exec}
 
-  def resolve_field(field, info, source, parent_type, path) do
-    info
+  def resolve_field(field, exec, source, parent_type, path) do
+    exec
     |> build_resolution_struct(field, source, parent_type, path)
-    |> do_resolve_field(info, source, path)
+    |> do_resolve_field(exec, source, path)
   end
 
   # bp_field needs to have a concrete schema node, AKA no unions or interfaces
-  defp do_resolve_field(res, info, source, path) do
+  defp do_resolve_field(res, exec, source, path) do
     res
     |> reduce_resolution
     |> case do
       %{state: :resolved} = res ->
-        build_result(res, info, source, path)
+        exec = update_persisted_fields(exec, res)
+        build_result(res, exec, source, path)
 
-      %{state: :suspended, acc: acc} = res ->
-        {res, %{info | acc: acc}}
+      %{state: :suspended} = res ->
+        exec = update_persisted_fields(exec, res)
+        {res, exec}
 
       final_res ->
         raise """
@@ -178,15 +162,21 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     end
   end
 
-  defp build_resolution_struct(info, bp_field, source, parent_type, path) do
-    %{info |
+
+  defp update_persisted_fields(dest, %{acc: acc, context: context, fields_cache: cache}) do
+    %{dest | acc: acc, context: context, fields_cache: cache}
+  end
+
+  defp build_resolution_struct(exec, bp_field, source, parent_type, path) do
+    common = Map.take(exec, [:adapter, :context, :acc, :root_value, :schema, :fragments, :fields_cache])
+    %Absinthe.Resolution{
       path: path,
       source: source,
       parent_type: parent_type,
       middleware: bp_field.schema_node.middleware,
       definition: bp_field,
       arguments: bp_field.argument_data,
-    }
+    } |> Map.merge(common)
   end
 
   defp reduce_resolution(%{middleware: []} = res), do: res
@@ -212,36 +202,31 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     fun.(res, [])
   end
 
-  defp build_result(%{errors: []} = res, info, _source, path) do
+  defp build_result(%{errors: []} = res, exec, _source, path) do
     %{
       value: result,
-      context: context,
-      acc: acc,
       definition: bp_field,
       extensions: extensions
     } = res
 
-    full_type = Type.expand(bp_field.schema_node.type, info.schema)
+    full_type = Type.expand(bp_field.schema_node.type, exec.schema)
 
     bp_field = put_in(bp_field.schema_node.type, full_type)
-
-    info = %{info | context: context, acc: acc}
 
     result = result |> to_result(bp_field, full_type)
 
     %{result | extensions: extensions}
-    |> walk_result(bp_field, full_type, info, path)
+    |> walk_result(bp_field, full_type, exec, path)
   end
-  defp build_result(%{errors: errors} = res, info, source, path) do
-    build_error_result({:error, errors}, errors, res.acc, res.definition, info, source, path)
+  defp build_result(%{errors: errors} = res, exec, source, path) do
+    build_error_result({:error, errors}, errors, res.definition, exec, source, path)
   end
 
-  defp build_error_result(original_value, error_values, acc, bp_field, info, source, path) do
-    info = %{info | acc: acc}
-    full_type = Type.expand(bp_field.schema_node.type, info.schema)
+  defp build_error_result(original_value, error_values, bp_field, exec, source, path) do
+    full_type = Type.expand(bp_field.schema_node.type, exec.schema)
     result = to_result(nil, bp_field, full_type)
     result = Enum.reduce(Enum.reverse(error_values), result, &put_result_error_value(&1, &2, original_value, bp_field, source, path))
-    {result, info}
+    {result, exec}
   end
 
   defp put_result_error_value(error_value, result, original_value, bp_field, source, path) do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -4,7 +4,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   # Runs resolution functions in a blueprint.
   #
-  # Blueprint results are placed under `blueprint.result.resolution`. This is
+  # Blueprint results are placed under `blueprint.result.execution`. This is
   # because the results form basically a new tree from the original blueprint.
 
   alias Absinthe.{Blueprint, Type, Phase}
@@ -22,13 +22,13 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp resolve_current(bp_root, operation, options) do
-    resolution = perform_resolution(bp_root, operation, options)
+    execution = perform_resolution(bp_root, operation, options)
 
-    blueprint = %{bp_root | resolution: resolution}
+    blueprint = %{bp_root | execution: execution}
 
     if Keyword.get(options, :plugin_callbacks, true) do
       bp_root.schema.plugins()
-      |> Absinthe.Plugin.pipeline(resolution.acc)
+      |> Absinthe.Plugin.pipeline(execution.acc)
       |> case do
         [] ->
           {:ok, blueprint}
@@ -41,11 +41,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp perform_resolution(bp_root, operation, options) do
-    root_value = bp_root.resolution.root_value
+    root_value = bp_root.execution.root_value
 
     info   = build_info(bp_root, root_value)
-    acc    = bp_root.resolution.acc
-    result = bp_root.resolution |> Execution.get_result(operation, root_value)
+    acc    = bp_root.execution.acc
+    result = bp_root.execution |> Execution.get_result(operation, root_value)
 
     plugins = bp_root.schema.plugins()
     run_callbacks? = Keyword.get(options, :plugin_callbacks, true)
@@ -58,7 +58,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
     acc = plugins |> run_callbacks(:after_resolution, info.acc, run_callbacks?)
 
-    Execution.update(bp_root.resolution, result, info.context, acc)
+    Execution.update(bp_root.execution, result, info.context, acc)
   end
 
   defp run_callbacks(plugins, callback, acc, true) do
@@ -67,7 +67,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp run_callbacks(_, _, acc, _ ), do: acc
 
   defp build_info(bp_root, root_value) do
-    context = bp_root.resolution.context
+    context = bp_root.execution.context
 
     %Absinthe.Resolution{
       adapter: bp_root.adapter,

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Phase.Document.Result do
   end
 
   defp process(blueprint) do
-    result = case blueprint.resolution do
+    result = case blueprint.execution do
       %{validation_errors: [], result: nil} ->
         :execution_failed
       %{validation_errors: [], result: result} ->

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -75,6 +75,15 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp field_data(fields, errors, acc \\ [])
   defp field_data([], errors, acc), do: {Map.new(acc), errors}
+  defp field_data([%Absinthe.Resolution{} = res | _], _errors, _acc) do
+    raise """
+    Found unresolved resolution struct!
+
+    You probably forgot to run the resolution phase again.
+
+    #{inspect res}
+    """
+  end
   defp field_data([field | fields], errors, acc) do
     {value, errors} = data(field, errors)
     field_data(fields, errors, [{field_name(field.emitter), value} | acc])

--- a/lib/absinthe/phase/document/validation/result.ex
+++ b/lib/absinthe/phase/document/validation/result.ex
@@ -18,7 +18,7 @@ defmodule Absinthe.Phase.Document.Validation.Result do
   @spec do_run(Blueprint.t, %{result_phase: Phase.t, jump_phases: boolean}) :: Phase.result_t
   def do_run(input, %{result_phase: abort_phase, jump_phases: jump}) do
     {input, {errors, invalid}} = Blueprint.prewalk(input, {[], false}, &handle_node/2)
-    result = put_in(input.resolution.validation_errors, errors)
+    result = put_in(input.execution.validation_errors, errors)
     case {errors, invalid, jump} do
       {[], false, _} ->
         {:ok, result}

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -26,7 +26,7 @@ defmodule Absinthe.Phase.Parse do
   end
 
   defp add_validation_error(bp, error) do
-    put_in(bp.resolution.validation_errors, [error])
+    put_in(bp.execution.validation_errors, [error])
   end
 
   def handle_error(blueprint, %{jump_phases: true, result_phase: abort_phase}) do

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -16,7 +16,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
   end
 
   def do_subscription(%{type: :subscription} = op, blueprint, options) do
-    context = blueprint.resolution.context
+    context = blueprint.execution.context
     pubsub = ensure_pubsub!(context)
 
     hash = :erlang.phash2(blueprint)
@@ -30,7 +30,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     else
       {:error, error} ->
 
-        blueprint = update_in(blueprint.resolution.validation_errors, &[error | &1])
+        blueprint = update_in(blueprint.execution.validation_errors, &[error | &1])
 
         error_pipeline = [
           {Phase.Document.Result, options},

--- a/lib/absinthe/plugin.ex
+++ b/lib/absinthe/plugin.ex
@@ -47,9 +47,9 @@ defmodule Absinthe.Plugin do
   end
 
   @doc false
-  def pipeline(plugins, resolution_acc) do
+  def pipeline(plugins, exec) do
     Enum.reduce(plugins, [], fn plugin, pipeline ->
-      plugin.pipeline(pipeline, resolution_acc)
+      plugin.pipeline(pipeline, exec)
     end)
     |> Enum.dedup
     |> List.flatten

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -8,7 +8,8 @@ defmodule Absinthe.Resolution do
   """
 
   @typedoc """
-  Information about the current resolution.
+  Information about the current resolution. It is created by adding field specific
+  information to the more general `%Absinthe.Blueprint.Execution{}` struct.
 
   ## Contents
   - `:adapter` - The adapter used for any name conversions.

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -38,7 +38,6 @@ defmodule Absinthe.Resolution do
     fragments: [Absinthe.Blueprint.Document.Fragment.Named.t],
   }
 
-  @enforce_keys [:adapter, :context, :root_value, :schema, :source]
   defstruct [
     :value,
     :adapter,

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -381,17 +381,8 @@ defimpl Inspect, for: Absinthe.Resolution do
     inner =
       res
       |> Map.from_struct
-      |> Map.update!(:definition, fn
-        %{name: name} ->
-          name
-        _ ->
-          nil
-      end)
-      |> Map.update!(:parent_type, fn
-        %{identifier: identifier} ->
-          identifier
-        _ ->
-          nil
+      |> Map.update!(:fields_cache, fn _ ->
+        "#fieldscache<...>"
       end)
       |> Map.to_list
       |> Inspect.List.inspect(opts)

--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Resolution.Projector do
   the various type conditions that come along with fragments / inline fragments,
   field merging, and other wondeful stuff like that.
   """
-  def project(selections, %{identifier: identifier} = parent_type, path, cache, info) do
+  def project(selections, %{identifier: identifier} = parent_type, path, cache, exec) do
     path_names = for %{name: name, alias: alias} <- path, name, do: alias || name
     key = {identifier, path_names}
 
@@ -23,7 +23,7 @@ defmodule Absinthe.Resolution.Projector do
       _ ->
         fields =
           selections
-          |> collect(parent_type, info)
+          |> collect(parent_type, exec)
           |> rectify_order
 
         {fields, Map.put(cache, key, fields)}

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -201,8 +201,8 @@ defmodule Absinthe.Schema do
 
       defp __do_absinthe_middleware__(middleware, field, object) do
         middleware
-        |> __MODULE__.middleware(field, object) # run field against user supplied function
         |> Absinthe.Schema.ensure_middleware(field, object) # if they forgot to add middleware set the default
+        |> __MODULE__.middleware(field, object) # run field against user supplied function
       end
 
       @doc false

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -236,6 +236,16 @@ defmodule Absinthe.Schema do
     end
   end
 
+  @doc """
+  List of Plugins to run before / after resolution.
+
+  Plugins are modules that implement the `Absinthe.Plugin` behaviour. These modules
+  have the opportunity to run callbacks before and after the resolution of the entire
+  document, and have access to the resolution accumulator.
+
+  Plugins must be specified by the schema, so that Absinthe can make sure they are
+  all given a chance to run prior to resolution.
+  """
   @callback plugins() :: [Absinthe.Plugin.t]
 
   @doc false

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Subscription.Local do
   def publish_mutation(pubsub, mutation_result, subscribed_fields) do
     for {field, key_strategy} <- subscribed_fields,
     {topic, doc} <- get_docs(pubsub, field, mutation_result, key_strategy) do
-      doc = put_in(doc.resolution.root_value, mutation_result)
+      doc = put_in(doc.execution.root_value, mutation_result)
 
       pipeline = [
         Absinthe.Phase.Document.Execution.Resolution,

--- a/test/lib/absinthe/execution/default_resolver_test.exs
+++ b/test/lib/absinthe/execution/default_resolver_test.exs
@@ -32,7 +32,7 @@ defmodule Absinthe.Execution.DefaultResolverTest do
         field :bar, :string
       end
 
-      def middleware([], %{name: name, identifier: identifier}, _) do
+      def middleware([{Absinthe.Middleware.MapGet, _}], %{name: name, identifier: identifier}, _) do
         middleware_spec = Absinthe.Resolution.resolver_spec(fn parent, _, _ ->
           case parent do
             %{^name => value} -> {:ok, value}

--- a/test/lib/absinthe/extensions_test.exs
+++ b/test/lib/absinthe/extensions_test.exs
@@ -22,7 +22,7 @@ defmodule Absinthe.ExtensionsTest do
   defmodule MyPhase do
     # rolls up the extensions data into a top level result
     def run(blueprint, _) do
-      extensions = get_ext(blueprint.resolution.result.fields)
+      extensions = get_ext(blueprint.execution.result.fields)
       result = Map.put(blueprint.result, :extensions, extensions)
       {:ok, %{blueprint | result: result}}
     end

--- a/test/lib/absinthe/phase/document/complexity_test.exs
+++ b/test/lib/absinthe/phase/document/complexity_test.exs
@@ -31,10 +31,10 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
 
     union :search_result do
       types [:foo, :quux]
-      
+
       resolve_type fn
         :foo, _ -> :foo
-        :quux, _ -> :quux 
+        :quux, _ -> :quux
       end
     end
 
@@ -80,7 +80,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert {:ok, result, _} = run_phase(doc, operation_name: "UnionComplexity", variables: %{})
       op = result.operations |> Enum.find(&(&1.name == "UnionComplexity"))
       assert op.complexity == 2
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
     end
 
@@ -96,7 +96,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert {:ok, result, _} = run_phase(doc, operation_name: "ComplexityArg", variables: %{})
       op = result.operations |> Enum.find(&(&1.name == "ComplexityArg"))
       assert op.complexity == 8
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
     end
 
@@ -113,7 +113,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert {:ok, result, _} = run_phase(doc, operation_name: "ComplexityVar", variables: %{"limit" => 5})
       op = result.operations |> Enum.find(&(&1.name == "ComplexityVar"))
       assert op.complexity == 15
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
     end
 
@@ -130,13 +130,13 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert {:ok, result, _} = run_phase(doc, operation_name: "ContextComplexity", variables: %{}, context: %{current_user: true})
       op = result.operations |> Enum.find(&(&1.name == "ContextComplexity"))
       assert op.complexity == 3
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
 
       assert {:ok, result, _} = run_phase(doc, operation_name: "ContextComplexity", variables: %{})
       op = result.operations |> Enum.find(&(&1.name == "ContextComplexity"))
       assert op.complexity == 13
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
 
     end
@@ -187,7 +187,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       op = result.operations |> Enum.find(&(&1.name == "ComplexityDiscount"))
       assert op.complexity == 99
 
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
     end
 
@@ -201,7 +201,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       """
 
       assert {:error, result, _} = run_phase(doc, operation_name: "ComplexityError", variables: %{}, max_complexity: 5)
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == [
         "Field fooComplexity is too complex: complexity is 6 and maximum is 5",
         "Operation ComplexityError is too complex: complexity is 6 and maximum is 5"
@@ -221,7 +221,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       """
 
       assert {:error, result, _} = run_phase(doc, operation_name: "ComplexityNested", variables: %{}, max_complexity: 4)
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == [
         "Field nestedComplexity is too complex: complexity is 5 and maximum is 4",
         "Operation ComplexityNested is too complex: complexity is 5 and maximum is 4"
@@ -238,7 +238,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       """
 
       assert {:error, result, _} = run_phase(doc, operation_name: nil, variables: %{}, max_complexity: 100)
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == [
         "Field fooComplexity is too complex: complexity is 105 and maximum is 100",
         "Operation is too complex: complexity is 105 and maximum is 100"
@@ -257,7 +257,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
       assert {:ok, result, _} = run_phase(doc, operation_name: "ComplexitySkip", variables: %{}, max_complexity: 1, analyze_complexity: false)
       op = result.operations |> Enum.find(&(&1.name == "ComplexitySkip"))
       assert op.complexity == nil
-      errors = result.resolution.validation_errors |> Enum.map(&(&1.message))
+      errors = result.execution.validation_errors |> Enum.map(&(&1.message))
       assert errors == []
     end
 

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -313,7 +313,7 @@ defmodule AbsintheTest do
     assert {:error, bp} = Absinthe.Phase.Parse.run(query, jump_phases: false)
     assert [%Absinthe.Phase.Error{extra: %{},
               locations: [%{column: 0, line: 2}], message: "illegal: -w",
-              phase: Absinthe.Phase.Parse}] == bp.resolution.validation_errors
+              phase: Absinthe.Phase.Parse}] == bp.execution.validation_errors
   end
 
   it "should resolve using enums" do


### PR DESCRIPTION
This solves some long standing confusion caused by overloading the term "resolution". By switching this name we can talk clearly about "executing a document" and "resolving a field". This execution struct tracks the progress of the execution progress, and the Resolution struct is used on each field to resolve it.

The resolution struct shares some important values in common with the execution struct, and this PR also makes sure that all three of those: `acc`, `context`, and `fields_cache` are readily available within plugins.