### PR TITLE
Use enum name instead of value in default value when instrospecting

### DIFF
--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -279,6 +279,8 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
         _, %{schema: schema, source: %{default_value: value, type: type}} ->
           case Absinthe.Schema.lookup_type(schema, type, unwrap: true) do
+            %Absinthe.Type.Enum{values_by_internal_value: values} ->
+              {:ok, values[value].name}
             %{serialize: serializer} ->
               {:ok, inspect serializer.(value)}
             _ ->

--- a/test/lib/absinthe/introspection_test.exs
+++ b/test/lib/absinthe/introspection_test.exs
@@ -139,6 +139,50 @@ defmodule Absinthe.IntrospectionTest do
       ] == values |> Enum.sort_by(&(&1["name"]))
     end
 
+    it "when used as the defaultValue of an argument" do
+      result = """
+      {
+        __schema {
+          queryType {
+            fields {
+              name
+              type {
+                name
+              }
+              args {
+                name
+                defaultValue
+              }
+            }
+          }
+        }
+      }
+      """
+      |> run(ColorSchema)
+      assert {:ok, %{data: %{"__schema" => %{"queryType" => %{"fields" => fields}}}}} = result
+      assert [
+        %{"name" => "info", "args" => [%{"name" => "channel", "defaultValue" => "RED"}]}
+      ] = fields
+    end
+
+    it "when used as the default value of an input object" do
+      result = """
+      {
+        __type(name: "ChannelInput") {
+          name
+          inputFields {
+            name
+            defaultValue
+          }
+        }
+      }
+      """
+      |> run(ColorSchema)
+      assert {:ok, %{data: %{"__type" => %{"name" => "ChannelInput", "inputFields" => input_fields}}}} = result
+      assert [
+        %{"name" => "channel", "defaultValue" => "RED"}
+      ] = input_fields
+    end
   end
 
   context "introspection of an input object type" do

--- a/test/support/color_schema.ex
+++ b/test/support/color_schema.ex
@@ -20,7 +20,7 @@ defmodule ColorSchema do
     field :info,
       type: :channel_info,
       args: [
-        channel: [type: non_null(:channel)],
+        channel: [type: non_null(:channel), default_value: :r],
       ],
       resolve: fn
         %{channel: channel}, _ ->
@@ -49,6 +49,10 @@ defmodule ColorSchema do
 
     field :name, :string
     field :value, :integer
+  end
+
+  input_object :channel_input do
+    field :channel, :channel, default_value: :r
   end
 
 end


### PR DESCRIPTION
https://github.com/absinthe-graphql/absinthe/issues/412

This changes the `__InputValue` to use the enum name instead of its value when the `default value` is an enum type.