### PR TITLE
Limit types listed by introspection to used types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v1.4.0
 Status: RC
 
+- Bug Fix: Ensured types that aren't used by the schema's root types aren't reported by introspection
+- Internal Change: Added `Absinthe.Schema.used_types`, `Absinthe.Schema.introspection_types/1`, and `Type.introspection?/1`
+
 - Enhancement: Subscriptions! See the Absinthe.Phoenix project for getting started info.
 - Enhancement: Null literal support [as laid out in the October 2016 GraphQL Specification](http://facebook.github.io/graphql/#sec-Null-Value)
 - Enhancement: Errors now include path information. This path information can be accessed in resolvers via `Absinthe.Resolution.path/1`

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -536,6 +536,16 @@ defmodule Absinthe.Schema do
   end
 
   @doc """
+  Get all introspection types
+  """
+  @spec introspection_types(t) :: [Type.t]
+  def introspection_types(schema) do
+    schema
+    |> Schema.types
+    |> Enum.filter(&Type.introspection?/1)
+  end
+
+  @doc """
   Get all concrete types for union, interface, or object
   """
   @spec concrete_types(t, Type.t) :: [Type.t]
@@ -550,6 +560,18 @@ defmodule Absinthe.Schema do
   end
   def concrete_types(_, type) do
     [type]
+  end
+
+  @doc """
+  Get all types that are used by an operation
+  """
+  @spec used_types(t) :: [Type.t]
+  def used_types(schema) do
+    [:query, :mutation, :subscription]
+    |> Enum.map(&lookup_type(schema, &1))
+    |> Enum.filter(&(!is_nil(&1)))
+    |> Enum.flat_map(&Type.referenced_types(&1, schema))
+    |> Enum.uniq
   end
 
   @doc """

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -9,7 +9,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :types, list_of(:__type) do
       resolve fn
         _, %{schema: schema} ->
-          {:ok, Absinthe.Schema.types(schema)}
+          {:ok, Absinthe.Schema.used_types(schema) ++ Absinthe.Schema.introspection_types(schema)}
       end
     end
 

--- a/test/lib/absinthe/introspection_test.exs
+++ b/test/lib/absinthe/introspection_test.exs
@@ -45,7 +45,7 @@ defmodule Absinthe.IntrospectionTest do
         ContactSchema
       )
       names = types |> Enum.map(&(&1["name"])) |> Enum.sort
-      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult Name NamedEntity RootMutationType RootQueryType RootSubscriptionType __Schema __Directive __DirectiveLocation __EnumValue __Field __InputValue __Type) |> Enum.sort
+      expected = ~w(Int String Boolean Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType RootSubscriptionType __Schema __Directive __DirectiveLocation __EnumValue __Field __InputValue __Type) |> Enum.sort
       assert expected == names
     end
 

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -160,6 +160,26 @@ defmodule Absinthe.SchemaTest do
 
   end
 
+  context "used_types" do
+    it "does not contain introspection types" do
+      assert !Enum.any?(
+        Schema.used_types(ThirdSchema),
+        &Type.introspection?/1
+      )
+    end
+  end
+
+  context "introspection_types" do
+    it "is not empty" do
+      assert !Enum.empty?(Schema.introspection_types(ThirdSchema))
+    end
+    it "are introspection types" do
+      assert Enum.all?(
+        Schema.introspection_types(ThirdSchema),
+        &Type.introspection?/1
+      )
+    end
+  end
 
   context "root fields" do
 

--- a/test/support/contact_schema.ex
+++ b/test/support/contact_schema.ex
@@ -131,6 +131,10 @@ defmodule ContactSchema do
 
   object :contact do
     field :entity, :named_entity
+    import_fields :contact_method
+  end
+
+  object :contact_method do
     field :phone_number, :string
     field :address, :string
   end
@@ -143,6 +147,10 @@ defmodule ContactSchema do
       _ ->
         :error
     end
+  end
+
+  object :unused do
+    field :an_unused_field, :string
   end
 
 end


### PR DESCRIPTION
Limits the types that are returned by introspection queries to those types that are used by the schema (plus introspection types).

This also adds some handy helper functions:

- `Absinthe.Schema.introspection_types/1`
- `Absinthe.Schema.used_types/1`
- `Absinthe.Type.introspection?/1`

Resolves #392.