### PR TITLE
Rename input object test and fix test failures

### DIFF
--- a/test/lib/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
+++ b/test/lib/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
@@ -9,8 +9,8 @@ defmodule Absinthe.Schema.Rule.InputOuputTypesCorrectlyPlacedTest do
     it "is enforced with input types on arguments" do
       assert_schema_error("invalid_input_types",
                           [
-                            %{rule: Rule.InputsMustBeInputTypes, data: %{argument: :invalid_arg, struct: Absinthe.Type.Object, type: :user}},
-                            %{rule: Rule.InputsMustBeInputTypes, data: %{field: :blah, parent: Absinthe.Type.Object, struct: Absinthe.Type.InputObject, type: :input}},
+                            %{rule: Rule.InputOuputTypesCorrectlyPlaced, data: %{argument: :invalid_arg, struct: Absinthe.Type.Object, type: :user}},
+                            %{rule: Rule.InputOuputTypesCorrectlyPlaced, data: %{field: :blah, parent: Absinthe.Type.Object, struct: Absinthe.Type.InputObject, type: :input}},
                           ]
       )
     end


### PR DESCRIPTION
The test file was missing the `_test` suffix and therefore was not included by `mix test` .

The rule was renamed at one point and never tested because of the naming issue, so fixed that too.

Just a note about the Rule tests, they are rather awkward to debug when they fail, so happy to raise a separate issue/PR for this. (I'm fixing something else related and this was just something I happened to stumble across as I dug into the code).