### PR TITLE
Don't clobber the contents of the result

### DIFF
--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -9,7 +9,8 @@ defmodule Absinthe.Phase.Document.Result do
 
   @spec run(Blueprint.t | Phase.Error.t, Keyword.t) :: {:ok, map}
   def run(%Blueprint{} = bp, _options \\ []) do
-    {:ok, %{bp | result: process(bp)}}
+    result = Map.merge(bp.result, process(bp))
+    {:ok, %{bp | result: result}}
   end
 
   defp process(blueprint) do

--- a/lib/absinthe/plugin.ex
+++ b/lib/absinthe/plugin.ex
@@ -15,7 +15,7 @@ defmodule Absinthe.Plugin do
   NOTE: This function is given the full accumulator. Namespacing is suggested to
   avoid conflicts.
   """
-  @callback before_resolution(resolution_acc :: Document.Resolution.acc) :: Document.Resolution.acc
+  @callback before_resolution(execution :: Document.Execution.t) :: Document.Execution.t
 
   @doc """
   callback to do something with the resolution accumulator after
@@ -24,7 +24,7 @@ defmodule Absinthe.Plugin do
   NOTE: This function is given the full accumulator. Namespacing is suggested to
   avoid conflicts.
   """
-  @callback after_resolution(resolution_acc :: Document.Resolution.acc) :: Document.Resolution.acc
+  @callback after_resolution(execution :: Document.Execution.t) :: Document.Execution.t
 
   @doc """
   callback used to specify additional phases to run.
@@ -36,7 +36,7 @@ defmodule Absinthe.Plugin do
   NOTE: This function is given the whole pipeline to be inserted after the current
   phase completes.
   """
-  @callback pipeline(next_pipeline :: Absinthe.Pipeline.t, resolution_acc :: map) :: Absinthe.Pipeline.t
+  @callback pipeline(next_pipeline :: Absinthe.Pipeline.t, execution :: Document.Execution.t) :: Absinthe.Pipeline.t
 
 
   @doc """

--- a/test/lib/absinthe/extensions_test.exs
+++ b/test/lib/absinthe/extensions_test.exs
@@ -44,4 +44,17 @@ defmodule Absinthe.ExtensionsTest do
 
     assert bp.result == %{data: %{"foo" => "hello world"}, extensions: %{foo: 1}}
   end
+
+  it "Result phase doesn't clober the extensions" do
+    doc = "{foo}"
+
+    pipeline =
+      Schema
+      |> Absinthe.Pipeline.for_document()
+      |> Absinthe.Pipeline.insert_before(Absinthe.Phase.Document.Result, MyPhase)
+
+    assert {:ok, bp, _} = Absinthe.Pipeline.run(doc, pipeline)
+
+    assert bp.result == %{data: %{"foo" => "hello world"}, extensions: %{foo: 1}}
+  end
 end


### PR DESCRIPTION
When generating the final `result`, we don't want to clobber anything that was previously added. Specifically, we may have added an `extensions` key, which is to be included in the final response.

I tweaked the `extensions_test` to validate that this woks as expected...

@benwilson512 