### PR TITLE
Return a better error message when the default type for an enum is no…

### DIFF
--- a/lib/absinthe/schema/rule.ex
+++ b/lib/absinthe/schema/rule.ex
@@ -32,6 +32,7 @@ defmodule Absinthe.Schema.Rule do
     Rule.ObjectMustImplementInterfaces,
     Rule.InterfacesMustResolveTypes,
     Rule.InputOuputTypesCorrectlyPlaced,
+    Rule.DefaultEnumValuePresent,
   ]
 
   @spec check(Absinthe.Schema.t) :: [Absinthe.Schema.Error.detail_t]

--- a/lib/absinthe/schema/rule/default_enum_value_present.ex
+++ b/lib/absinthe/schema/rule/default_enum_value_present.ex
@@ -1,0 +1,56 @@
+defmodule Absinthe.Schema.Rule.DefaultEnumValuePresent do
+  use Absinthe.Schema.Rule
+
+  alias Absinthe.{Schema, Type}
+  require IEx
+
+  @moduledoc false
+
+  def explanation(%{data: %{default_value: default_value, type: type, value_list: value_list}}) do
+    """
+    The default_value for an enum must be present in the enum values.
+
+    Could not use default value of "#{default_value}" for #{inspect type}.
+
+    Valid values are:
+    #{value_list}
+    """
+  end
+
+  def check(schema) do
+    Schema.types(schema)
+    |> Enum.flat_map(&check_type(schema, &1))
+  end
+
+  defp check_type(schema, %Type.Object{fields: fields}) when not is_nil(fields) do
+    Enum.flat_map(fields, &check_field(schema, &1))
+  end
+  defp check_type(_schema, _type), do: []
+
+  defp check_field(schema, {_name, %{args: args}}) when not is_nil(args) do
+    Enum.flat_map(args, &check_args(schema, &1))
+  end
+  defp check_field(_schema, _type), do: []
+
+  defp check_args(schema, {_name, %{default_value: default_value, type: type}}) when not is_nil(default_value) do
+    type = Schema.lookup_type(schema, type)
+    check_default_value_present(default_value, type)
+  end
+  defp check_args(_schema, _args), do: []
+
+  defp check_default_value_present(default_value, %Type.Enum{} = type) do
+    values = Enum.map(type.values, &(elem(&1, 1).value))
+    value_list = Enum.map(values, &("\n * #{&1}"))
+    if not default_value in values do
+      detail = %{
+        value_list: value_list,
+        type: type.__reference__.identifier,
+        default_value: default_value
+      }
+      [report(type.__reference__.location, detail)]
+    else
+      []
+    end
+  end
+  defp check_default_value_present(_default_value, _type), do: []
+end

--- a/test/lib/absinthe/schema/rule/default_enum_value_present_test.exs
+++ b/test/lib/absinthe/schema/rule/default_enum_value_present_test.exs
@@ -1,0 +1,48 @@
+defmodule Absinthe.Schema.Rule.DefaultEnumValuePresentTest do
+  use Absinthe.Case, async: true
+  use SupportSchemas
+
+  context "rule" do
+    it "is enforced when the defaultValue is not in the enum" do
+      schema =
+        """
+        defmodule BadColorSchema do
+          use Absinthe.Schema
+
+          @names %{
+            r: "RED"
+          }
+
+          query do
+
+            field :info,
+            type: :channel_info,
+            args: [
+              channel: [type: non_null(:channel), default_value: :OTHER],
+            ],
+            resolve: fn
+              %{channel: channel}, _ ->
+              {:ok, %{name: @names[channel]}}
+            end
+
+          end
+
+          enum :channel do
+            value :red, as: :r
+            value :green, as: :g
+          end
+
+          object :channel_info do
+            field :name, :string
+          end
+        end
+        """
+
+      error = ~r/The default_value for an enum must be present in the enum values/
+
+      assert_raise(Absinthe.Schema.Error, error, fn ->
+        Code.eval_string(schema)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
…t present

Previously:

> ** (UndefinedFunctionError) function nil.name/0 is undefined or private
>     nil.name()
>     (absinthe) lib/absinthe/type/built_ins/introspection.ex:283:
>     anonymous fn/2 in Absinthe.Type.BuiltIns.Introspection.__absinthe_type__/1

Now:

> ** (RuntimeError) could not use default value of "other" for relation_type.
>
> Valid types are:
>
>  * friend
>  * family
>  * following