### PR TITLE
Issue and PR templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -24,7 +24,7 @@ If submitting a bug, please provide the following:
 ### Environment
 
 * Elixir version (elixir -v):
-* Absinthe version (mix deps; please list all Absinthe-related packages):
+* Absinthe version (mix deps | grep absinthe):
 * Client Framework and version (Relay, Apollo, etc):
 
 ### Expected behavior

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,5 @@
 <!--
+
 ### Precheck
 
 We're a small team and Absinthe is a big project, so please keep the

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,7 +7,7 @@ following in mind when submitting an issue:
 - For help and support, use:
   - Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
   - The Elixir Forum: https://elixirforum.com
-  - The documentation: https://hexdocs.pm/absinthe
+  - The documentation, to include guides: https://hexdocs.pm/absinthe
 - For new features, consider discussing the idea with us via Slack/Forum before submitting an issue
 - For bugs, do a quick search and make sure the bug has not yet been reported
 - Please try to ensure that your issue is related to the core Absinthe package and not one of the

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,46 @@
+<!--
+### Precheck
+
+We're a small team and Absinthe is a big project, so please keep the
+following in mind when submitting an issue:
+
+- For help and support, use:
+  - Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
+  - The Elixir Forum: https://elixirforum.com
+- For new features, consider discussing the idea with us via Slack/Forum before submitting an issue
+- For bugs, do a quick search and make sure the bug has not yet been reported
+- Please try to ensure that your issue is related to the core Absinthe package and not one of the
+  related packages. (We may ask you to move it, otherwise.)
+  - If it's Plug-related, you probably want `absinthe_plug`
+  - If it's Phoenix-related or about websockets, you probably want `absinthe_phoenix`
+- All checked? Be nice and have fun!
+-->
+
+<!-- START BUG TEMPLATE (Please delete the rest of this if you're not filing a bug.) -->
+
+If submitting a bug, please provide the following:
+
+### Environment
+
+* Elixir version (elixir -v):
+* Absinthe version (mix deps; please list all Absinthe-related packages):
+* Client Framework and version (Relay, Apollo, etc):
+
+### Expected behavior
+
+<!-- What did you expect to see? -->
+
+### Actual behavior
+
+<!--
+  Oh, oh. What happened?
+
+  Please include as much error information as you can.
+-->
+
+### Relevant Schema/Middleware Code
+
+<!--
+  Try to include any pertinent schema/middleware code that could
+  provide some context for the problem you're experiencing.
+-->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,6 +7,7 @@ following in mind when submitting an issue:
 - For help and support, use:
   - Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
   - The Elixir Forum: https://elixirforum.com
+  - The documentation: https://hexdocs.pm/absinthe
 - For new features, consider discussing the idea with us via Slack/Forum before submitting an issue
 - For bugs, do a quick search and make sure the bug has not yet been reported
 - Please try to ensure that your issue is related to the core Absinthe package and not one of the

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--
+
+### Precheck
+
+Thank you for submitting a pull request! Absinthe is a large
+project, and we really appreciate your help improving it.
+
+Please keep the following in mind as you submit your code; it
+will help us review, discuss, and merge your PR as quickly
+as possible.
+
+- Tests are good! Please include them if possible.
+- Documentation is good:
+  - Modules should have a `@moduledoc` (may be `false`)
+  - Public functions should have a `@doc` (may be `false`)
+  - Consider checking `/guides` for documentation that
+    needs to be updated
+- Specifications are good. Include `@spec` when possible.
+- Good Git history behavior is good. Don't rebase your PR branch,
+  and make small, focused commits. We generally squash commits on
+  merge for you, unless there is a reason not to (multiple committers
+  on a PR, etc).
+- Matching existing code style is good.
+
+We're happy to work with you, providing guidance and assistance
+where we can, collaborating with you to help your contribution become
+part of Absinthe. Thanks again!
+
+As always, feel free to reach out for questions/discussion via:
+
+- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
+- The Elixir Forum: https://elixirforum.com
+
+-->


### PR DESCRIPTION
We're getting to the volume now that it would be helpful to:

For Issues:
- Direct people to better sources of information for questions and support
- Remind them another package may be a better place to start
- Collect helpful environmental and schema information for bug reports

For PRs:
- Indicate helpful things to include that will shorten the review process, including tests, specs, and docs
- Remind them to match style
- Other things?

It should be simple, friendly, and quick to navigate