### PR TITLE
Add missing %Spread{} type when describing node

### DIFF
--- a/lib/absinthe/phase/document/complexity/result.ex
+++ b/lib/absinthe/phase/document/complexity/result.ex
@@ -67,4 +67,7 @@ defmodule Absinthe.Phase.Document.Complexity.Result do
   defp describe_node(%Blueprint.Document.Field{name: name}) do
     "Field #{name}"
   end
+  defp describe_node(%Blueprint.Document.Fragment.Spread{name: name}) do
+    "Spread #{name}"
+  end
 end


### PR DESCRIPTION
The spread is used in the introspection query. If the complexity of the
introspection query is too large then the following error will no longer
be raised:

> ** (exit) an exception was raised:
>     ** (FunctionClauseError) no function clause matching in
>     Absinthe.Phase.Document.Complexity.Result.describe_node/1

Two questions:

 1. Is the terminology of "Spread" correct or should it be something else? "Fragment Spread"?
 2. Do we even need this? Should the complexity analysis of introspection queries be set to 0 so that it never fails a complexity check?