### PR TITLE
Import batch/4

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Schema.Notation do
   defmacro __using__(opts \\ []) do
     import_opts = opts |> Keyword.put(:only, :macros)
     quote do
-      import Absinthe.Resolution.Helpers, only: [async: 1, batch: 3]
+      import Absinthe.Resolution.Helpers, only: [async: 1, batch: 4]
       import unquote(__MODULE__), unquote(import_opts)
       Module.register_attribute __MODULE__, :absinthe_definitions, accumulate: true
       Module.register_attribute(__MODULE__, :absinthe_descriptions, accumulate: true)


### PR DESCRIPTION
I noticed that I was enable to pass options to the batch function without importing batch/4 directly

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
