### PR TITLE
Bump dataloader version in ecto guide

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -150,7 +150,7 @@ make sure our schema knows it needs to run the dataloader.
 First however make sure to include the dataloader dependency in your application:
 
 ```elixir
-{:dataloader, "~> 0.1.0"}
+{:dataloader, "~> 1.0.0"}
 ```
 
 Latest install instructions found here: https://github.com/absinthe-graphql/dataloader


### PR DESCRIPTION
I noticed the ecto guide was using an older version of dataloader. This PR bumps it to 1.0.0.