### PR TITLE
Support for null values as nullable enum argument

### DIFF
--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -42,6 +42,9 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
         {:ok, val}
     end
   end
+  defp build_value(%Input.Null{}, %Type.Enum{}, _) do
+    {:ok, nil}
+  end
   defp build_value(normalized, %Type.Enum{} = schema_node, _) do
     case Type.Enum.parse(schema_node, normalized) do
       {:ok, %{value: value}} ->

--- a/test/lib/absinthe/execution/arguments_test.exs
+++ b/test/lib/absinthe/execution/arguments_test.exs
@@ -278,6 +278,13 @@ defmodule Absinthe.Execution.ArgumentsTest do
         """
         assert_result {:ok, %{data: %{"contact" => nil}}}, doc |> run(Schema)
       end
+
+      it "should pass nil as an argument to the resolver for enum types" do
+        doc = """
+        query GetContact($type:ContactType){ contact(type: $type) }
+        """
+        assert_result {:ok, %{data: %{"contact" => nil}}}, doc |> run(Schema, variables: %{"type" => nil})
+      end
     end
 
     context "enum types" do


### PR DESCRIPTION
## Issue

Nullable enum arg throws an error for null value.

### schema and query definition
```elixir
enum :post_type do
  value :a
  value :b
end

(...)
field :get_posts_by_type, :posts_result do
  arg :type, :post_type

  resolve (...)
end
```

### query
```javascript
getPostsByType(type: null) (...)
```

### result
```javascript
{
  "errors": [
    {
      "message": "Argument \"type\" has invalid value null.",
      "locations": [
        {
          "line": 2,
          "column": 0
        }
      ]
    }
  ]
}
```