### PR TITLE
Update Link to Absinthe Tutorial in Guide

### DIFF
--- a/guides/tutorial/start.md
+++ b/guides/tutorial/start.md
@@ -15,7 +15,7 @@ Before you start, it's a good idea to have some background into GraphQL in gener
  The tutorial expects you to have a properly set-up [Phoenix application](http://www.phoenixframework.org/docs/up-and-running) with <a href="https://hex.pm/packages/absinthe">absinthe</a> and <a href="https://hex.pm/packages/absinthe_plug">absinthe_plug</a> added to the dependencies.
 
 >  If you'd like to cheat, you can find the finished code for the tutorial
->  in the <a href="https://github.com/absinthe-graphql/absinthe_example">Absinthe Example</a>
+>  in the <a href="https://github.com/absinthe-graphql/absinthe_tutorial">Absinthe Example</a>
 >  project on GitHub.
 
 ## First Step


### PR DESCRIPTION
This resolves 
https://github.com/absinthe-graphql/absinthe_tutorial/issues/3
It's a simple update to the link to the repository in the tutorial documentation.