### PR TITLE
Absinthe.Blueprint.Input.Null: add alias for Absinthe.Blueprint

### DIFF
--- a/lib/absinthe/blueprint/input/null.ex
+++ b/lib/absinthe/blueprint/input/null.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Blueprint.Input.Null do
 
   @moduledoc false
 
-  alias Absinthe.{Phase}
+  alias Absinthe.{Blueprint, Phase}
 
   defstruct [
     :source_location,


### PR DESCRIPTION
This change adds an alias that is used in type definition, without it dialyzer complains about unknown types `Elixir.Blueprint.flags_t` and `elixir.Blueprint.Document.SourceLocation.t`.
