### PR TITLE
Block Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.5
+
+- Feature: Support for `"""`-quoted block strings, as defined in the GraphQL Specification (See facebook/graphql#397).
+
 ## v1.4.4
 
 - Bug Fix: fix where self referential interface type would cause infinite loop when introspecting.

--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -31,6 +31,11 @@ ExponentIndicator   = [eE]
 ExponentPart        = {ExponentIndicator}{Sign}?{Digit}+
 FloatValue          = {IntegerPart}{FractionalPart}|{IntegerPart}{ExponentPart}|{IntegerPart}{FractionalPart}{ExponentPart}
 
+% Block String Value
+EscapedBlockStringQuote = (\\""")
+BlockStringCharacter    = (\n|\t|\r|[^\x{0000}-\x{001F}]|{EscapedBlockStringQuote})
+BlockStringValue        = """{BlockStringCharacter}*"""
+
 % String Value
 HexDigit            = [0-9A-Fa-f]
 EscapedUnicode      = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
@@ -40,7 +45,6 @@ StringValue         = "{StringCharacter}*"
 
 % Boolean Value
 BooleanValue        = true|false
-
 
 % Reserved words
 ReservedWord        = query|mutation|subscription|fragment|on|implements|interface|union|scalar|enum|input|extend|type|directive|ON|null|schema
@@ -52,6 +56,7 @@ Rules.
 {ReservedWord}      : {token, {list_to_atom(TokenChars), TokenLine}}.
 {IntValue}          : {token, {int_value, TokenLine, TokenChars}}.
 {FloatValue}        : {token, {float_value, TokenLine, TokenChars}}.
+{BlockStringValue}  : {token, {block_string_value, TokenLine, TokenChars}}.
 {StringValue}       : {token, {string_value, TokenLine, TokenChars}}.
 {BooleanValue}      : {token, {boolean_value, TokenLine, TokenChars}}.
 {Name}              : {token, {name, TokenLine, TokenChars}}.

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -354,7 +354,7 @@ process_block_string([H | T], Acc) -> process_block_string(T, [H | Acc]).
 
 -spec block_string_value(string()) -> string().
 block_string_value(Value) ->
-  [FirstLine | Rest] = string:split(Value, "\n", all),
+  [FirstLine | Rest] = re:split(Value, "\n", [{return,list}]),
   Prefix = indentation_prefix(common_indent(Rest)),
   UnindentedLines = unindent(Rest, Prefix),
   Lines = trim_blank_lines([FirstLine | UnindentedLines]),

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -382,11 +382,19 @@ unindent(Lines, Prefix) ->
 unindent([], _Prefix, Result) ->
   lists:reverse(Result);
 unindent([H | T], Prefix, Result) ->
-  case string:prefix(H, Prefix) of
-    nomatch ->
-      unindent(T, Prefix, [H | Result]);
-    Unindented ->
-      unindent(T, Prefix, [Unindented | Result])
+  Processed = prefix(H, Prefix),
+  unindent(T, Prefix, [Processed | Result]).
+
+-spec prefix(string(), string()) -> string().
+prefix(Line, []) ->
+  Line;
+prefix(Line, Prefix) ->
+  Prefixed = lists:prefix(Prefix, Line),
+  if
+    Prefixed ->
+      string:substr(Line, length(Prefix) + 1);
+    true ->
+      Line
   end.
 
 -spec common_indent([string()]) -> non_neg_integer().

--- a/test/lib/absinthe/phase/parse/block_strings_test.exs
+++ b/test/lib/absinthe/phase/parse/block_strings_test.exs
@@ -2,21 +2,200 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
   use Absinthe.Case, async: true
 
   it "parses a query with a block string argument literal and no newlines" do
-    assert {:ok, _} = run(~s<{ post(title: "single", body: """text""") { name } }>)
+    assert {:ok, result} = run(~S<{ post(title: "single", body: """text""") { name } }>)
+    assert "text" == extract_body(result)
+  end
+
+  it "parses a query with a block string argument that contains a quote" do
+    assert {:ok, result} = run(~S<{ post(title: "single", body: """text "here""") { name } }>)
+    assert "text \"here" == extract_body(result)
+  end
+
+  it "parses a query with a block string argument that contains various escapes" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """unescaped \\n\\r\\b\\t\\f\\u1234""") { name } }>)
+    assert "unescaped \\n\\r\\b\\t\\f\\u1234" == extract_body(result)
+  end
+
+  it "parses a query with a block string argument that contains various slashes" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """slashes \\\\ \\/""") { name } }>)
+    assert "slashes \\\\ \\/" == extract_body(result)
+  end
+
+
+  @input [
+    "",
+    "    Hello,",
+    "      World!",
+    "",
+    "    Yours,",
+    "      GraphQL."
+  ]
+  @result [
+    "Hello,",
+    "  World!",
+    "",
+    "Yours,",
+    "  GraphQL."
+  ]
+  it "parses a query with a block string argument, removing uniform indentation from a string" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
+    assert lines(@result) == extract_body(result)
+  end
+
+  @input [
+    "",
+    "",
+    "    Hello,",
+    "      World!",
+    "",
+    "    Yours,",
+    "      GraphQL.",
+    "",
+    ""
+  ]
+  @result [
+    "Hello,",
+    "  World!",
+    "",
+    "Yours,",
+    "  GraphQL."
+  ]
+  it "parses a query with a block string argument, removing empty leading and trailing lines" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
+    assert lines(@result) == extract_body(result)
+  end
+
+  @input [
+    "  ",
+    "        ",
+    "    Hello,",
+    "      World!",
+    "",
+    "    Yours,",
+    "      GraphQL.",
+    "        ",
+    "  "
+  ]
+  @result [
+    "Hello,",
+    "  World!",
+    "",
+    "Yours,",
+    "  GraphQL."
+  ]
+  it "parses a query with a block string argument, removing blank leading and trailing lines" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
+    assert lines(@result) == extract_body(result)
+  end
+
+  @input [
+    "    Hello,",
+    "      World!",
+    "",
+    "    Yours,",
+    "      GraphQL."
+  ]
+  @result [
+    "    Hello,",
+    "  World!",
+    "",
+    "Yours,",
+    "  GraphQL."
+  ]
+  it "parses a query with a block string argument, retaining indentation from first line" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
+    assert lines(@result) == extract_body(result)
+  end
+
+  @input [
+    "               ",
+    "    Hello,     ",
+    "      World!   ",
+    "               ",
+    "    Yours,     ",
+    "      GraphQL. ",
+    "               "
+  ]
+  @result [
+    "Hello,     ",
+    "  World!   ",
+    "           ",
+    "Yours,     ",
+    "  GraphQL. "
+  ]
+  it "parses a query with a block string argument, not altering trailing spaces" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
+    assert lines(@result) == extract_body(result)
+  end
+
+  it "parses a query with a block string argument literal and carriage returns, normalizing" do
+    assert {:ok, result} = run(~s<{ post(title: "single", body: """text\nline\r\nanother""") { name } }>)
+    assert "text\nline\nanother" == extract_body(result)
+  end
+
+
+  it "parses a query with a block string argument literal with escaped triple quotes and no newlines" do
+    assert {:ok, result} = run(~S<{ post(title: "single", body: """text\""" """) { name } }>)
+    assert ~S<text""" > == extract_body(result)
   end
 
   it "parses a query with a block string argument literal and newlines" do
-    assert {:ok, _} = run(
+    assert {:ok, result} = run(
       ~s<{ post(title: "single", body: """
              text
       """) { name } }>)
+      assert "\n             text\n      " == extract_body(result)
   end
 
+  it "parses a query with a block string argument literal and escaped triple quotes and newlines" do
+    assert {:ok, result} = run(
+      ~S<{ post(title: "single", body: """
+             text\"""
+      """) { name } }>)
+    assert ~s<\n             text\"\"\"\n      > == extract_body(result)
+  end
+
+  it "returns an error for a bad byte" do
+    assert {:error, err} = run(~s<{ post(title: "single", body: """trying to escape a \u0000 byte""") { name } }>)
+    assert "syntax error" <> _ = extract_error_message(err)
+  end
+
+  defp extract_error_message(err) do
+    get_in(err,
+      [
+        Access.key(:execution),
+        Access.key(:validation_errors),
+        Access.at(0),
+        Access.key(:message)
+      ]
+    )
+  end
+
+  defp extract_body(value) do
+    get_in(value,
+      [
+        Access.key(:definitions),
+        Access.at(0),
+        Access.key(:selection_set),
+        Access.key(:selections),
+        Access.at(0),
+        Access.key(:arguments),
+        Access.at(1),
+        Access.key(:value),
+        Access.key(:value)
+      ]
+    )
+  end
 
   def run(input) do
     with {:ok, %{input: input}} <- Absinthe.Phase.Parse.run(input) do
       {:ok, input}
     end
+  end
+
+  defp lines(input) do
+    input
+    |> Enum.join("\n")
   end
 
 end

--- a/test/lib/absinthe/phase/parse/block_strings_test.exs
+++ b/test/lib/absinthe/phase/parse/block_strings_test.exs
@@ -147,12 +147,12 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert {:ok, result} = run(~S<query ($body: String = """text""") { post(title: "single", body: $body) { name } }>)
     assert "text" == get_in(result,
       [
-        Access.key(:definitions),
+        Access.key(:definitions, []),
         Access.at(0),
-        Access.key(:variable_definitions),
+        Access.key(:variable_definitions, %{}),
         Access.at(0),
-        Access.key(:default_value),
-        Access.key(:value)
+        Access.key(:default_value, %{}),
+        Access.key(:value, nil)
       ]
     )
   end
@@ -161,10 +161,10 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
   defp extract_error_message(err) do
     get_in(err,
       [
-        Access.key(:execution),
-        Access.key(:validation_errors),
+        Access.key(:execution, %{}),
+        Access.key(:validation_errors, []),
         Access.at(0),
-        Access.key(:message)
+        Access.key(:message, nil)
       ]
     )
   end

--- a/test/lib/absinthe/phase/parse/block_strings_test.exs
+++ b/test/lib/absinthe/phase/parse/block_strings_test.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Phase.Parse.BlockStringsTest do
   use Absinthe.Case, async: true
 
-  it "parses a query with a block string argument literal and no newlines" do
+  it "parses a query with a block string literal and no newlines" do
     assert {:ok, result} = run(~S<{ post(title: "single", body: """text""") { name } }>)
     assert "text" == extract_body(result)
   end
@@ -11,12 +11,12 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert "text \"here" == extract_body(result)
   end
 
-  it "parses a query with a block string argument that contains various escapes" do
+  it "parses a query with a block string literal that contains various escapes" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """unescaped \\n\\r\\b\\t\\f\\u1234""") { name } }>)
     assert "unescaped \\n\\r\\b\\t\\f\\u1234" == extract_body(result)
   end
 
-  it "parses a query with a block string argument that contains various slashes" do
+  it "parses a query with a block string literal that contains various slashes" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """slashes \\\\ \\/""") { name } }>)
     assert "slashes \\\\ \\/" == extract_body(result)
   end
@@ -37,7 +37,7 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     "Yours,",
     "  GraphQL."
   ]
-  it "parses a query with a block string argument, removing uniform indentation from a string" do
+  it "parses a query with a block string literal, removing uniform indentation from a string" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
     assert lines(@result) == extract_body(result)
   end
@@ -60,7 +60,7 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     "Yours,",
     "  GraphQL."
   ]
-  it "parses a query with a block string argument, removing empty leading and trailing lines" do
+  it "parses a query with a block string literal, removing empty leading and trailing lines" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
     assert lines(@result) == extract_body(result)
   end
@@ -83,7 +83,7 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     "Yours,",
     "  GraphQL."
   ]
-  it "parses a query with a block string argument, removing blank leading and trailing lines" do
+  it "parses a query with a block string literal, removing blank leading and trailing lines" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
     assert lines(@result) == extract_body(result)
   end
@@ -102,7 +102,7 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     "Yours,",
     "  GraphQL."
   ]
-  it "parses a query with a block string argument, retaining indentation from first line" do
+  it "parses a query with a block string literal, retaining indentation from first line" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
     assert lines(@result) == extract_body(result)
   end
@@ -123,42 +123,40 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     "Yours,     ",
     "  GraphQL. "
   ]
-  it "parses a query with a block string argument, not altering trailing spaces" do
+  it "parses a query with a block string literal, not altering trailing spaces" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """#{lines(@input)}""") { name } }>)
     assert lines(@result) == extract_body(result)
   end
 
-  it "parses a query with a block string argument literal and carriage returns, normalizing" do
+  it "parses a query with a block string literal and carriage returns, normalizing" do
     assert {:ok, result} = run(~s<{ post(title: "single", body: """text\nline\r\nanother""") { name } }>)
     assert "text\nline\nanother" == extract_body(result)
   end
 
-
-  it "parses a query with a block string argument literal with escaped triple quotes and no newlines" do
+  it "parses a query with a block string literal with escaped triple quotes and no newlines" do
     assert {:ok, result} = run(~S<{ post(title: "single", body: """text\""" """) { name } }>)
     assert ~S<text""" > == extract_body(result)
-  end
-
-  it "parses a query with a block string argument literal and newlines" do
-    assert {:ok, result} = run(
-      ~s<{ post(title: "single", body: """
-             text
-      """) { name } }>)
-      assert "\n             text\n      " == extract_body(result)
-  end
-
-  it "parses a query with a block string argument literal and escaped triple quotes and newlines" do
-    assert {:ok, result} = run(
-      ~S<{ post(title: "single", body: """
-             text\"""
-      """) { name } }>)
-    assert ~s<\n             text\"\"\"\n      > == extract_body(result)
   end
 
   it "returns an error for a bad byte" do
     assert {:error, err} = run(~s<{ post(title: "single", body: """trying to escape a \u0000 byte""") { name } }>)
     assert "syntax error" <> _ = extract_error_message(err)
   end
+
+  it "parses a query with a block string literal as a variable default" do
+    assert {:ok, result} = run(~S<query ($body: String = """text""") { post(title: "single", body: $body) { name } }>)
+    assert "text" == get_in(result,
+      [
+        Access.key(:definitions),
+        Access.at(0),
+        Access.key(:variable_definitions),
+        Access.at(0),
+        Access.key(:default_value),
+        Access.key(:value)
+      ]
+    )
+  end
+
 
   defp extract_error_message(err) do
     get_in(err,

--- a/test/lib/absinthe/phase/parse/block_strings_test.exs
+++ b/test/lib/absinthe/phase/parse/block_strings_test.exs
@@ -1,0 +1,22 @@
+defmodule Absinthe.Phase.Parse.BlockStringsTest do
+  use Absinthe.Case, async: true
+
+  it "parses a query with a block string argument literal and no newlines" do
+    assert {:ok, _} = run(~s<{ post(title: "single", body: """text""") { name } }>)
+  end
+
+  it "parses a query with a block string argument literal and newlines" do
+    assert {:ok, _} = run(
+      ~s<{ post(title: "single", body: """
+             text
+      """) { name } }>)
+  end
+
+
+  def run(input) do
+    with {:ok, %{input: input}} <- Absinthe.Phase.Parse.run(input) do
+      {:ok, input}
+    end
+  end
+
+end


### PR DESCRIPTION
Supports `"""`-delimited block strings, as defined in facebook/graphql#327, using the implementation in graphql/graphql-js#926 as a reference (omitting SDL `description` features slated for v1.5).

- [x] Lexer
- Parser
  - [x] Base support
  - [x] Escape handling
  - [x] Indentation handling
- [x] Tests