### PR TITLE
Add support for defining meta with keyword lists

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -709,10 +709,31 @@ defmodule Absinthe.Schema.Notation do
     |> record_private!(:meta, key, value)
   end
 
+  @doc """
+  Defines list of metadata's key/value pair for a custom type.
+  """
+  defmacro meta(keyword_list) do
+    __CALLER__
+    |> recordable!(:meta, @placement[:meta])
+    |> record_private!(:meta, keyword_list)
+  end
+
+  @doc false
+  # Record private values
+  def record_private!(env, raw_owner, raw_keyword_list) when is_list(raw_keyword_list) do
+    [owner, keyword_list] = Enum.map([raw_owner, raw_keyword_list], &Macro.expand(&1, env))
+    keyword_list
+    |> Enum.each(fn {k,v} -> do_record_private!(env, owner, k, v) end)
+  end
+
   @doc false
   # Record a private value
   def record_private!(env, raw_owner, raw_key, raw_value) do
     [owner, key, value] = Enum.map([raw_owner, raw_key, raw_value], &Macro.expand(&1, env))
+    do_record_private!(env, owner, key, value)
+  end
+
+  defp do_record_private!(env, owner, key, value) do
     new_attrs = Scope.current(env.module).attrs
     |> Keyword.put_new(:__private__, [])
     |> update_in([:__private__, owner], &List.wrap(&1))

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -344,6 +344,7 @@ defmodule Absinthe.SchemaTest do
 
     object :foo do
       meta :sql_table, "foos"
+      meta [cache: false, eager: true]
       field :bar, :string do
         meta :nice, "yup"
       end
@@ -384,10 +385,13 @@ defmodule Absinthe.SchemaTest do
 
   context "can add metadata to an object" do
 
+    @tag :wip
     it "sets object metadata" do
       foo = Schema.lookup_type(MetadataSchema, :foo)
-      assert %{__private__: [meta: [sql_table: "foos"]]} = foo
+      assert Keyword.equal?([sql_table: "foos", cache: false, eager: true], foo.__private__[:meta])
       assert Type.meta(foo, :sql_table) == "foos"
+      assert Type.meta(foo, :cache) == false
+      assert Type.meta(foo, :eager) == true
     end
 
     it "sets field metadata" do


### PR DESCRIPTION
I tried to add support to the field macro as well but could not make it work, not familiar enough with the inner working of the schema notation macro work.