### PR TITLE
Add waring in docs about third param of batch function

### DIFF
--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -90,6 +90,10 @@ defmodule Absinthe.Middleware.Batch do
   ```
   It could also be used to set options unique to the execution of a particular
   batching function.
+  
+  Be warned batch will be grouped by `{module, function, param}`, so you should not
+  use dynamically generated data in `param`. And you should keep `param` small, 
+  because it copied between processes (do not pass resolver info in it).
   """
   @type batch_fun :: {module, atom} | {module, atom, term}
 


### PR DESCRIPTION
Recently, I got bitten by passing whole resolution tree in this parameter, and received silently N+1 and drastically performance hit.