### PR TITLE
Absinthe.Schema: Fix middleware/3 typespec

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -241,7 +241,7 @@ defmodule Absinthe.Schema do
   all given a chance to run prior to resolution.
   """
   @callback plugins() :: [Absinthe.Plugin.t]
-  @callback middleware([Absinthe.Middleware.spec, ...], Type.Field.t, Type.Object.t) :: [Absinthe.Middleware.spec, ...]
+  @callback middleware([Absinthe.Middleware.spec, ...], Type.Field.t, Type.Object.t) :: [Absinthe.Middleware.spec]
   @callback context(map) :: map
 
   @doc false


### PR DESCRIPTION
This typespec causes a Dialyzer warning because `[]` is matched on in `__using__/1`. That match would never succeed if this callback always returned a non-empty list.
