### PR TITLE
Update result_selection_t typespec

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -30,7 +30,7 @@ defmodule Absinthe do
       | boolean
       | binary
       | atom
-      | result_selection_t
+      | [result_selection_t]
   }
 
   @type result_error_t ::


### PR DESCRIPTION
### Use Case

I received an error from dialyzer when running `List.last/1` on a value that I destructured from the result returned by `Absinthe.run/3`. To circumvent this, I used `Enum.fetch(.., -1)`, which was enough to allow dialyzer to move on. This felt hacky, so I decided to PR this typespec update, hoping that it would remove that false positive.

I'm unsure if `result_selection_t` was intended to be wrapped originally, or if I misinterpreted that. If I did, apologies, and I suppose it should be changed to:

```elixir
# ...
| result_selection_t
| [result_selection_t]
```

...but I couldn't imagine the benefit of the recursively defined type _unless_ that was the intent.