### PR TITLE
Schema: Remove match against `[]` to fix Dialyzer error

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -137,14 +137,6 @@ defmodule Absinthe.Schema do
         middleware
         |> Absinthe.Schema.__ensure_middleware__(field, object)
         |> __MODULE__.middleware(field, object) # run field against user supplied function
-        |> case do
-          [] ->
-            raise """
-            Middleware callback must return a non empty list of middleware!
-            """
-          middleware ->
-            middleware
-        end
       end
 
       @doc false


### PR DESCRIPTION
According to @benwilson512 in https://github.com/absinthe-graphql/absinthe/pull/468 this code is invalid.

Removing this `case` fixes the Dialyzer error:
```
lib/<app>/schema.ex:6: The pattern [] can never match the type [any(),...]
```