### PR TITLE
Add value/1 to formatter locals_without_parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -41,6 +41,7 @@
       trigger: 2,
       types: 1,
       union: 3,
+      value: 1,
       value: 2,
     ]
   ]


### PR DESCRIPTION
Adding `value/1` to the list, I think it's common to have Enum values w/o a description...

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
