### PR TITLE
Add /.elixir_ls to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /cover
 /deps
 /doc
+/.elixir_ls
 erl_crash.dump
 *.ez
 src/*.erl


### PR DESCRIPTION
[The Elixir Language Server](https://github.com/JakeBecker/elixir-ls) which powers great plugins for VS Code and Atom would generate some analysis files in ```.elixir_ls``` automatically. Would it be okay to add this directory to .gitignore file?