### PR TITLE
Docs: Add dataloader import line

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -137,6 +137,8 @@ what's actually happening behind the scenes.
 Using Dataloader is as simple as doing:
 
 ```elixir
+import Absinthe.Resolution.Helpers, only: [dataloader: 1]
+
 object :author do
   @desc "Author of the post"
   field :posts, list_of(:post), resolve: dataloader(Blog)


### PR DESCRIPTION
Otherwise the user will get a compilation error similar to:

   ** (CompileError) lib/my_app/graphql/types/community.ex:27: undefined function dataloader/1