### PR TITLE
Adding "generated" flag to quote to silence dialyzer warning

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -112,7 +112,7 @@ defmodule Absinthe.Schema do
   alias __MODULE__
 
   defmacro __using__(opts \\ []) do
-    quote do
+    quote(generated: true) do
       use Absinthe.Schema.Notation, unquote(opts)
       import unquote(__MODULE__), only: :macros
 


### PR DESCRIPTION
### Environment

* Elixir version (elixir -v): 
```
% elixir -v                                                                                                                                                      
Erlang/OTP 20 [erts-9.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.5.2
```
* Absinthe version (mix deps | grep absinthe): `1.4.7`
* Client Framework and version (Relay, Apollo, etc): n/a

### Expected behavior

dialyzer does not warn about middleware callback implementation that always returns a non-empty list.

### Actual behavior

Absinthe.Schema injects a function when used called `__do_absinthe_middleware__` which calls the middleware callback and then uses a case statement to match on the results. The first case in that case statement is a match on []. 

https://github.com/absinthe-graphql/absinthe/blob/5ae9ea2dd21e064efef6d7adc47d2b1de3b8175c/lib/absinthe/schema.ex#L139-L147

The problem is that dialyzer is smart enough to see that our middleware function is incapable of returning an empty list, and so it complains that that part of the case statement can never be reached and should be removed. Which generates the following warning:

```
lib/absinthe_dialyzer_warning.ex:2: The pattern [] can never match the type [any(),...]
```

The short term solution here (in case anyone else hits this issue) is to use this module attribute to silence the warning with:

```elixir
@dialyzer {:nowarn_function, __do_absinthe_middleware__: 3}
```

I think the *real* fix it to add the `generated: true` flag to to the `quote` options, which seems to get dialyzer to chill out. 

### Relevant Schema/Middleware Code

```elixir
defmodule AbsintheDialyzerWarning do
  use Absinthe.Schema
  # Uncomment the following line to silence the dialyzer warning
  # @dialyzer {:nowarn_function, __do_absinthe_middleware__: 3}

  object :person do
    field :name, :string
  end

  query do
    field :get_person, :person do
      resolve fn _, _ -> {:ok, %{name: "Trevor"}} end
    end
  end

  @impl Absinthe.Schema
  def middleware(middleware, _, _) do
    middleware ++ [PassThroughMiddleware]
  end
end

defmodule PassThroughMiddleware do
  @behaviour Absinthe.Middleware

  def call(res, _config) do
    res
  end
end
```

Here's a repo with the issue reproduced:
https://github.com/bundacia/absinthe_dialyzer_warning