### PR TITLE
Formatter is missing config for parenthesis

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -18,6 +18,7 @@
       field: 3,
       field: 4,
       import_fields: 2,
+      import_fields: 1,
       import_types: 1,
       input_object: 3,
       instruction: 1,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -29,6 +29,7 @@
       meta: 1,
       meta: 2,
       middleware: 2,
+      middleware: 1,
       object: 3,
       on: 1,
       parse: 1,


### PR DESCRIPTION
Hello guys, 

there is an issue with current `.formatter.exs`. In our project we have: 

```
[
  import_deps: [:absinthe]
]
```

but constructions, as follows, are not properly formatted: 

```elixir
    import_fields :slug_queries
    import_fields :label_queries
```

and 

```elixir
    middleware &build_payload/2
```

arguments are wrapped into parenthesis. Looks like we should be consistent and add proper values to config.