### PR TITLE
Adding handling for exceptions in resolver error status tuples

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -308,6 +308,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     end
   end
 
+  defp split_error_value(%{__exception__: true} = exception) do
+    {[message: Exception.message(exception)], []}
+  end
   defp split_error_value(error_value) when is_list(error_value) or is_map(error_value) do
     Keyword.split(Enum.to_list(error_value), [:message])
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,12 @@
-%{"benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
+%{
+  "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
   "dataloader": {:hex, :dataloader, "1.0.0", "d461598ddaa822d32bd7aca59f4b592fb6c8b21d74723d9ce9a5b8e32c301a4d", [:mix], [{:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
-  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [], [], "hexpm"},
+  "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.4.1", "a98a84c795623f1ba020324f4354cf30e7120ba4dab65f9c2ae300f830a25f75", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
-  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"}}
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
+}

--- a/test/lib/absinthe_test.exs
+++ b/test/lib/absinthe_test.exs
@@ -21,6 +21,11 @@ defmodule AbsintheTest do
     assert_result {:ok, %{data: %{"failingThing" => nil}, errors: [%{code: 1, message: "Custom Error 1", path: ["failingThing"]}, %{code: 2, message: "Custom Error 2", path: ["failingThing"]}]}}, run(query, Things)
   end
 
+  test "can return excpetion in a status tuple" do
+    query = "mutation { failingThing(type: STATUS_TUPLE_WITH_EXCEPTION) { name } }"
+    assert_result {:ok, %{data: %{"failingThing" => nil}, errors: [%{message: "Message", path: ["failingThing"]}]}}, run(query, Things)
+  end
+
   test "requires message in extended errors, when multiple errors are given" do
     query = "mutation { failingThing(type: MULTIPLE_WITHOUT_MESSAGE) { name } }"
     assert_raise Absinthe.ExecutionError, fn -> run(query, Things) end

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -17,6 +17,7 @@ defmodule Things do
     value :with_code
     value :without_message
     value :multiple_with_code
+    value :status_tuple_with_exception
     value :multiple_without_message
   end
 
@@ -46,6 +47,8 @@ defmodule Things do
           {:error, message: "Custom Error", code: 42}
         %{type: :without_message}, _ ->
           {:error, code: 42}
+        %{type: :status_tuple_with_exception}, _ ->
+          {:error, %RuntimeError{message: "Message"}}
         %{type: :multiple_with_code}, _ ->
           {:error, [%{message: "Custom Error 1", code: 1}, %{message: "Custom Error 2", code: 2}]}
         %{type: :multiple_without_message}, _ ->


### PR DESCRIPTION
If a resolver function returns an error status tuple where the second element is an elixir exception (eg. `{:error, %RuntimeError{}}`) instead of displaying this error in the graphql result you'll actually get the following type of error:

> ** (Protocol.UndefinedError) protocol Enumerable not implemented for %RuntimeError{message: "Error"}. This protocol is implemented for: Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream

While this probably isn't a super-common case, it seems counter-intuitive that an exception in this context would not work, and seems like something that would make sense to support.

For more background [see this blog post](https://tech.decisiv.com/handling-elixir-exceptions-in-absinthe-9656a9108c2d)

