### PR TITLE
update code formatting for easier usage

### DIFF
--- a/guides/introspection.md
+++ b/guides/introspection.md
@@ -16,8 +16,7 @@ Seeing the names of the types in the schema:
     }
   }
 }
-"""
-|> Absinthe.run(MyAppWeb.Schema)
+""" |> Absinthe.run(MyAppWeb.Schema)
 {:ok,
   %{data: %{
     "__schema" => %{
@@ -44,8 +43,7 @@ Getting the name of the queried type:
     __typename
   }
 }
-"""
-|> Absinthe.run(MyAppWeb.Schema)
+""" |> Absinthe.run(MyAppWeb.Schema)
 {:ok,
   %{data: %{
     "profile" => %{
@@ -71,8 +69,7 @@ Getting the name of the fields for a named type:
     }
   }
 }
-"""
-|> Absinthe.run(MyAppWeb.Schema)
+""" |> Absinthe.run(MyAppWeb.Schema)
 {:ok,
   %{data: %{
     "__type" => %{


### PR DESCRIPTION
first off: i know that this change is not in favor of `mix format` - the reason that i'm proposing it nevertheless is a usability easy for any users how are new to the project and try to copy & paste code from the website .. because, if you go with an existing code block from https://hexdocs.pm/absinthe/introspection.html:

```
"""
{
  __schema {
    types {
      name
    }
  }
}
"""
|> Absinthe.run(MyAppWeb.Schema)
```

and try to execute it in your iex shell .. it will bark:

```
iex(3)> """
...(3)> {
...(3)>   __schema {
...(3)>     types {
...(3)>       name
...(3)>     }
...(3)>   }
...(3)> }
...(3)> """
"{\n  __schema {\n    types {\n      name\n    }\n  }\n}\n"
iex(4)> |> Absinthe.run(MyAppWeb.Schema)
** (SyntaxError) iex:4: syntax error before: '|>'
```

which is absolutely clear from a reporting perspective .. a line break is a line break and ending the previous context - but it's annoying for a user to copy & paste this block into his editor .. remove the line break and give it another shot.

so WDYT?