### PR TITLE
update doc block sample: make id a non-null argument

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -43,9 +43,9 @@ defmodule Absinthe.Schema do
     field :item, :item do
 
       @desc "The ID of the item"
-      arg :id, type: :id
+      arg :id, type: non_null(:id)
 
-      resolve fn _, %{id: id}, _ ->
+      resolve fn %{id: id}, _ ->
         {:ok, Map.get(@fake_db, id)}
       end
     end

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -45,7 +45,7 @@ defmodule Absinthe.Schema do
       @desc "The ID of the item"
       arg :id, type: :id
 
-      resolve fn %{id: id}, _ ->
+      resolve fn _, %{id: id}, _ ->
         {:ok, Map.get(@fake_db, id)}
       end
     end


### PR DESCRIPTION
otherwise elixir will complain about `no function clause matching in anonymous fn/2` where the passed arguments look like: `fn(%{}, %{id: "foo"}, #Absinthe.Resolution<...>)`