### PR TITLE
Dataloader bug, regression test

### DIFF
--- a/lib/absinthe/middleware/dataloader.ex
+++ b/lib/absinthe/middleware/dataloader.ex
@@ -13,9 +13,7 @@ if Code.ensure_loaded?(Dataloader) do
     end
 
     def call(%{state: :unresolved} = resolution, {loader, callback}) do
-      previous_loader_state = resolution.context.loader
-
-      if previous_loader_state == loader || !Dataloader.pending_batches?(loader) do
+      if !Dataloader.pending_batches?(loader) do
         get_result(resolution, callback)
       else
         %{


### PR DESCRIPTION
Hereby the regression test

*note:* this small change to Dataloader.KV needs to be merged to make it testable using Dataloader.KV: https://github.com/absinthe-graphql/dataloader/pull/23.

