### PR TITLE
Add log_mode config to allow for single-line request logging

### DIFF
--- a/test/absinthe/logger_test.exs
+++ b/test/absinthe/logger_test.exs
@@ -1,6 +1,8 @@
 defmodule Absinthe.LoggerTest do
   use Absinthe.Case, async: true
 
+  import ExUnit.CaptureLog
+
   describe "Absinthe.Logger.filter_variables/1" do
     @value "abcd"
     @variables %{"token" => @value, "password" => @value, "alsoUnsafe" => @value}
@@ -52,6 +54,14 @@ defmodule Absinthe.LoggerTest do
     @document %{}
     test "given something else, is inspected" do
       assert "%{}" == Absinthe.Logger.document(@document)
+    end
+  end
+
+  describe "Absinthe.Logger.log_run/1" do
+    test "logs all expected information on multiple lines" do
+      assert capture_log(fn ->
+        Absinthe.Logger.log_run(:info, {"query ()", "foo", "bar", [foo: :bar]})
+      end) =~ "ABSINTHE schema=\"foo\" variables=%{}\n---\nquery ()\n---\n"
     end
   end
 end


### PR DESCRIPTION
This adds a configuration which allows developers to switch the
(potentially verbose) full graphql query into a single line. The idea is
that this allows for more compact logging in production environments,
which is specifically useful for log aggregation tools

---

I've added a test which covers the current state of the logger output, but not one for the alternate configuration. The main reason is that I'm not sure about best way to do that when it depends on an `Application.get_env` call - if there's a nice way of doing that I'm all ears :smile:.  It was useful to write the code against (as I switched the config to `single_line` locally to prove it out) and provides a regression which is why I left it in.

I'm also not 100% convinced on my use of the default `:multi_line` atom, as it's not actually used... Would this be better if the config option was something like `multi_line` and was a boolean?

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
