### PR TITLE
make sure type module is compiled before importing types

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1263,7 +1263,7 @@ defmodule Absinthe.Schema.Notation do
     for {_, _, leaf} <- modules_ast_list do
       type_module = Module.concat([root_module_with_alias | leaf])
 
-      if Code.ensure_loaded?(type_module) do
+      if Code.ensure_compiled?(type_module) do
         do_import_types(type_module, env)
       else
         raise ArgumentError, "module #{type_module} is not available"


### PR DESCRIPTION
Code.ensure_loaded?/1 is not strict enough check because modules in the
same application are compiled in parallel, and modules that are not
compiled yet are unavailable for load (Code.ensure_loaded?/1 will return
false in that case)

Fixes #533 
I couldn't come up with any way to test this, let me know if you have an idea :).
