### PR TITLE
make sure import_type always create compile-time dependency

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1241,7 +1241,7 @@ defmodule Absinthe.Schema.Notation do
   ```
   import_types MyApp.Schema.Types
 
-  import_types MyApp.Schema.Types.{TypesA, TypesB}
+  import_types MyApp.Schema.Types.{TypesA, TypesB, SubTypes.TypesC}
   ```
   """
   defmacro import_types(type_module_ast) do
@@ -1255,13 +1255,10 @@ defmodule Absinthe.Schema.Notation do
   end
 
   defp do_import_types({{:., _, [root_ast, :{}]}, _, modules_ast_list}, env) do
-    {:__aliases__, _, root} = root_ast
+    {:__aliases__, meta, root} = root_ast
 
-    root_module = Module.concat(root)
-    root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module_with_alias | leaf])
+    for {_, _, leaves} <- modules_ast_list do
+      type_module = Macro.expand({:__aliases__, meta, root ++ leaves}, env)
 
       if Code.ensure_loaded?(type_module) do
         do_import_types(type_module, env)

--- a/test/absinthe/type/import_types_test.exs
+++ b/test/absinthe/type/import_types_test.exs
@@ -23,5 +23,9 @@ defmodule Absinthe.Type.ImportTypesTest do
       assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :contact_method)
       assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :contact_kind)
     end
+
+    test "works with an alias, {} and scoped reference" do
+      assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :avatar)
+    end
   end
 end

--- a/test/support/fixtures/dynamic/import_types.ex
+++ b/test/support/fixtures/dynamic/import_types.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Fixtures.ImportTypes do
     object :employee do
       field :id, non_null(:id)
       field :name, :string
+      field :avatar, :avatar
       field :weekly_schedules, list_of(:weekly_schedule)
     end
   end
@@ -68,6 +69,16 @@ defmodule Absinthe.Fixtures.ImportTypes do
     end
   end
 
+  defmodule Shared.AvatarTypes do
+    use Absinthe.Schema.Notation
+
+    object :avatar do
+      field :height, non_null(:integer)
+      field :width, non_null(:integer)
+      field :url, non_null(:string)
+    end
+  end
+
   defmodule Schema do
     use Absinthe.Schema
 
@@ -76,7 +87,7 @@ defmodule Absinthe.Fixtures.ImportTypes do
 
     alias Absinthe.Fixtures.ImportTypes
     import_types ImportTypes.ScheduleTypes
-    import_types ImportTypes.{ProfileTypes, AuthTypes}
+    import_types ImportTypes.{ProfileTypes, AuthTypes, Shared.AvatarTypes}
 
     query do
       field :orders, list_of(:order)


### PR DESCRIPTION
do this by running Macro.expand on an alias AST node, which should be
equivalent of referencing module on subject module scope

compile-time dependency will always recompile root schema when
child schema is changed, and we need this to run schema validations on
every change

Fixes #535 
Again, I'm not sure how to test this in a suite, let me know if you have an idea.

UPD: added a small test to ensure scoped references are processed correctly inside {}