### PR TITLE
Introduce phase for adding document context

### DIFF
--- a/lib/absinthe/phase/blueprint.ex
+++ b/lib/absinthe/phase/blueprint.ex
@@ -6,15 +6,9 @@ defmodule Absinthe.Phase.Blueprint do
   alias Absinthe.Blueprint
 
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
-  def run(blueprint, options \\ []) do
+  def run(blueprint, _options \\ []) do
     input = blueprint.input
     blueprint = Blueprint.Draft.convert(input, blueprint)
-
-    context = Map.merge(blueprint.execution.context, options[:context] || %{})
-    blueprint = put_in(blueprint.execution.context, context)
-
-    root_value = Map.merge(blueprint.execution.root_value, options[:root_value] || %{})
-    blueprint = put_in(blueprint.execution.root_value, root_value)
 
     {:ok, blueprint}
   end

--- a/lib/absinthe/phase/document/context.ex
+++ b/lib/absinthe/phase/document/context.ex
@@ -1,0 +1,17 @@
+defmodule Absinthe.Phase.Document.Context do
+  @moduledoc "Pass on context and root value to document."
+
+  use Absinthe.Phase
+  alias Absinthe.Blueprint
+
+  @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(blueprint, options \\ []) do
+    context = Map.merge(blueprint.execution.context, options[:context] || %{})
+    blueprint = put_in(blueprint.execution.context, context)
+
+    root_value = Map.merge(blueprint.execution.root_value, options[:root_value] || %{})
+    blueprint = put_in(blueprint.execution.root_value, root_value)
+
+    {:ok, blueprint}
+  end
+end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -64,6 +64,7 @@ defmodule Absinthe.Pipeline do
       Phase.Document.Validation.UniqueOperationNames,
       Phase.Document.Validation.UniqueVariableNames,
       # Apply Input
+      {Phase.Document.Context, options},
       {Phase.Document.Variables, options},
       Phase.Document.Validation.ProvidedNonNullVariables,
       Phase.Document.Arguments.Normalize,

--- a/test/absinthe/phase/document/context_test.exs
+++ b/test/absinthe/phase/document/context_test.exs
@@ -1,0 +1,90 @@
+defmodule Absinthe.Phase.Document.ContextTest do
+  use Absinthe.Case, async: true
+
+  alias Absinthe.Pipeline
+
+  @context %{user: "Foo"}
+  @root %{version: "0.0.1"}
+
+  @compilation_pipeline Absinthe.Pipeline.for_document(nil, jump_phases: false)
+                        |> Absinthe.Pipeline.before(Absinthe.Phase.Document.Variables)
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+
+    query do
+      field :user, :string do
+        resolve(fn _root_value,
+                   _args,
+                   %{
+                     context: %{
+                       user: user
+                     }
+                   } ->
+          {:ok, user}
+        end)
+      end
+
+      field :version, :string do
+        resolve(fn root_value, _args, _res ->
+          {:ok, root_value.version}
+        end)
+      end
+    end
+  end
+
+  describe "when context contains some value" do
+    test "it is available during execution" do
+      result =
+        """
+          query GetUser {
+            user
+          }
+        """
+        |> compile()
+        |> execute()
+
+      assert result == %{data: %{"user" => "Foo"}}
+    end
+  end
+
+  describe "when root-value is set" do
+    test "it is available during execution" do
+      result =
+        """
+          query GetVersion {
+            version
+          }
+        """
+        |> compile()
+        |> execute()
+
+      assert result == %{data: %{"version" => @root.version}}
+    end
+  end
+
+  defp compile(query) do
+    {:ok, blueprint, _} = Pipeline.run(query, @compilation_pipeline)
+    blueprint
+  end
+
+  defp execute(blueprint) do
+    pipeline =
+      Absinthe.Pipeline.for_document(
+        TestSchema,
+        context: @context,
+        root_value: @root
+      )
+
+    start_phase =
+      case List.last(@compilation_pipeline) do
+        {mod, _} -> mod
+        mod -> mod
+      end
+
+    execution_pipeline = Absinthe.Pipeline.from(pipeline, start_phase)
+
+    {:ok, doc, _} = Pipeline.run(blueprint, execution_pipeline)
+    doc.result
+  end
+end


### PR DESCRIPTION
Some context values like the current logged in user-id are not available
during compilation phases of the document pipeline. So, add another
phase after all compilation phases to grab context values and put them in
blueprint execution context. This is needed when documents are
pre-compiled and are executed later when the context (like current
logged-in userID) values are actually available.

fixes #539
