### PR TITLE
Support Exception.t in `split_error_value/1`

### DIFF
--- a/guides/errors.md
+++ b/guides/errors.md
@@ -8,6 +8,7 @@ One or more errors for a field can be returned in a single `{:error, error_value
 
 `error_value` can be:
 - A simple error message string.
+- An `Exception.t`.
 - A map containing `:message` key, plus any additional serializable metadata.
 - A keyword list containing a `:message` key, plus any additional serializable metadata.
 - A list containing multiple of any/all of these.

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -347,6 +347,13 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     end
   end
 
+  defp split_error_value(%{__exception__: true} = error_value) do
+    error_value
+    |> Map.from_struct()
+    |> Map.delete(:__exception__)
+    |> split_error_value()
+  end
+
   defp split_error_value(error_value) when is_list(error_value) or is_map(error_value) do
     Keyword.split(Enum.to_list(error_value), [:message])
   end


### PR DESCRIPTION
This adds support for handling `Exception.t` types as returned errors. I think this is a reasonable type to support given that some libraries return them as errors.

Ideally a protocol would be supported for translating various types into the structure Absinthe expects but that felt like too large of a change for this PR.