### PR TITLE
Showing off the bug with integer value in identifier

### DIFF
--- a/test/absinthe/execution/default_resolver_test.exs
+++ b/test/absinthe/execution/default_resolver_test.exs
@@ -26,12 +26,13 @@ defmodule Absinthe.Execution.DefaultResolverTest do
 
       query do
         field :field_1, :integer
+        field :field2, :integer
       end
     end
 
     test "should resolve" do
-      assert {:ok, %{data: %{"field1" => "test"}}} ==
-               Absinthe.run("{ field1 }", Schema, root_value: %{field_1: "test"})
+      assert {:ok, %{data: %{"field1" => "test", "field2" => "test"}}} ==
+               Absinthe.run("{ field1 field2 }", Schema, root_value: %{field_1: "test", field2: "test"})
     end
   end
 

--- a/test/absinthe/execution/default_resolver_test.exs
+++ b/test/absinthe/execution/default_resolver_test.exs
@@ -20,6 +20,21 @@ defmodule Absinthe.Execution.DefaultResolverTest do
     end
   end
 
+  describe "with integer value in field identifier" do
+    defmodule Schema do
+      use Absinthe.Schema
+
+      query do
+        field :field_1, :integer
+      end
+    end
+
+    test "should resolve" do
+      assert {:ok, %{data: %{"field1" => "test"}}} ==
+               Absinthe.run("{ field1 }", Schema, root_value: %{field_1: "test"})
+    end
+  end
+
   describe "with a custom default resolver defined" do
     defmodule CustomSchema do
       use Absinthe.Schema


### PR DESCRIPTION
Hey, guys. Thanks for awesome work on Absinthe!

Recently I stumbled upon a stealthy bug when field with identifier like `field_1` (integer after underscore) is not allowed to be queried. This thing also prevents subscriptions from publishing any data if such a field is requested.

Note the second field `field2` which resolves fine or not throwing errors at least.

I tried to narrow down and fix the issue by myself but I don't have much time to really dig into Absinthe 
codebase. :(