### PR TITLE
Subscription: Add child_spec/1 hook

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -38,6 +38,14 @@ defmodule Absinthe.Subscription do
   """
   defdelegate start_link(pubsub), to: Subscription.Supervisor
 
+  def child_spec(pubsub) do
+    %{
+      id: __MODULE__,
+      start: {Subscription.Supervisor, :start_link, [pubsub]},
+      type: :supervisor
+    }
+  end
+
   @type subscription_field_spec :: {atom, term | (term -> term)}
 
   @doc """


### PR DESCRIPTION
Allows `Absinthe.Subscription` to be started using the new child spec form from Elixir 1.5: https://hexdocs.pm/elixir/1.6.5/Supervisor.html#module-child_spec-1