### PR TITLE
Support `import_fields` for `interface`s

### DIFF
--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -74,10 +74,15 @@ defmodule Absinthe.Type.Interface do
             identifier: nil,
             resolve_type: nil,
             __private__: [],
-            __reference__: nil
+            __reference__: nil,
+            field_imports: []
 
   def build(%{attrs: attrs}) do
-    fields = Type.Field.build(attrs[:fields] || [])
+    fields =
+      (attrs[:fields] || [])
+      |> Type.Field.build()
+      |> Type.Object.handle_imports(attrs[:field_imports])
+
     attrs = Keyword.put(attrs, :fields, fields)
 
     quote do

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -46,6 +46,36 @@ defmodule Absinthe.Schema.NotationTest do
       assert [:email, :name] = fields |> Map.keys() |> Enum.sort()
     end
 
+    test "works for interfaces" do
+      defmodule InterfaceFoo do
+        use Absinthe.Schema
+
+        query do
+          # Query type must exist
+        end
+
+        object :cool_fields do
+          field :name, :string
+        end
+
+        interface :foo do
+          import_fields :cool_fields
+          resolve_type fn _, _ -> :real_foo end
+        end
+
+        object :real_foo do
+          interface :foo
+          import_fields :cool_fields
+        end
+      end
+
+      interface_fields = InterfaceFoo.__absinthe_type__(:foo).fields
+      assert [:name] = interface_fields |> Map.keys() |> Enum.sort()
+
+      object_fields = InterfaceFoo.__absinthe_type__(:real_foo).fields
+      assert [:name] = object_fields |> Map.keys() |> Enum.sort()
+    end
+
     test "can work transitively" do
       defmodule Bar do
         use Absinthe.Schema


### PR DESCRIPTION
Howdy! I noticed that the docs say that `interface` supports `import_fields`, but it seems to be missing. I put this together to implement support for this mirroring how it's done with the other types..

Let me know if we need to do anything more than this!