### PR TITLE
Update Adapter documentation to not refer to configuration

### DIFF
--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -17,14 +17,9 @@ defmodule Absinthe.Adapter do
     modifications. (Note at the current time this does not support introspection
     if you're using camelized conventions).
 
-  To set an adapter, you can set an application configuration value:
+  To set an adapter, you pass a configuration option at runtime:
 
-  ```
-  config :absinthe,
-    adapter: YourApp.Adapter.TheAdapterName
-  ```
-
-  Or, you can provide it as an option to `Absinthe.run/3`:
+  For `Absinthe.run/3`:
 
   ```
   Absinthe.run(
@@ -33,6 +28,24 @@ defmodule Absinthe.Adapter do
     adapter: YourApp.Adapter.TheAdapterName
   )
   ```
+
+  For `Absinthe.Plug`:
+
+  ```
+  forward "/api",
+    to: Absinthe.Plug,
+    init_opts: [schema: MyAppWeb.Schema, adapter: YourApp.Adapter.TheAdapterName]
+  ```
+
+  For GraphiQL:
+
+  ```
+  forward "/graphiql",
+    to: Absinthe.Plug.GraphiQL,
+    init_opts: [schema: MyAppWeb.Schema, adapter: YourApp.Adapter.TheAdapterName]
+  ```
+
+  Check `Absinthe.Plug` for full documentation on using the Plugs
 
   Notably, this means you're able to switch adapters on case-by-case basis.
   In a Phoenix application, this means you could even support using different


### PR DESCRIPTION
The configuration does not appear to be read so instead just document how to set the adapter configuration.

Note: I think the [Absinthe.Plug](https://hexdocs.pm/absinthe_plug/Absinthe.Plug.html) documentation for Phoenix is incorrect. For me instead of:

```
forward "/graphiql",
  to: Absinthe.Plug.GraphiQL,
  init_opts: [
    schema: MyAppWeb.Schema,
    interface: :simple
  ]
```

What works for me is:

```
  forward "/graphiql", Absinthe.Plug.GraphiQL,
    [schema: MyAppWeb.Schema, adapter: YourApp.Adapter.TheAdapterName]
```

Should we use that style here as well? (I may be misunderstanding something about `forward` with plug vs Phoenix)

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
