### PR TITLE
Add an Absinthe.Adapter.Underscore adapter

### DIFF
--- a/guides/adapters.md
+++ b/guides/adapters.md
@@ -13,6 +13,11 @@ Absinthe ships with two adapters:
   for incoming query documents and outgoing results. This is the default as of v0.3,
   and it is _highly_ recommended that it's the adapter you use, as introspection
   currently makes certain assumptions about how to return results.
+* `Absinthe.Adapter.Underscore`, which is similar to the `LanguageConventions`
+  adapter but converts all incoming identifiers to underscores and does not
+  modify outgoing identifiers (since those are already expected to be
+  underscores). Unlike `Absinthe.Adapter.Passthrough` this does not break
+  introspection.
 * `Absinthe.Adapter.Passthrough`, which is a no-op adapter and makes no
   modifications.
 

--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -13,6 +13,11 @@ defmodule Absinthe.Adapter do
   * `Absinthe.Adapter.LanguageConventions`, which expects schemas to be defined
     in `snake_case` (the standard Elixir convention), translating to/from `camelCase`
     for incoming query documents and outgoing results. (This is the default as of v0.3.)
+  * `Absinthe.Adapter.Underscore`, which is similar to the `LanguageConventions`
+    adapter but converts all incoming identifiers to underscores and does not
+    modify outgoing identifiers (since those are already expected to be
+    underscores). Unlike `Absinthe.Adapter.Passthrough` this does not break
+    introspection.
   * `Absinthe.Adapter.Passthrough`, which is a no-op adapter and makes no
     modifications. (Note at the current time this does not support introspection
     if you're using camelized conventions).

--- a/lib/absinthe/adapter/underscore.ex
+++ b/lib/absinthe/adapter/underscore.ex
@@ -1,0 +1,27 @@
+defmodule Absinthe.Adapter.Underscore do
+  @moduledoc """
+  Underscores external input and leaves external input alone. Unlike the
+  `Absinthe.Adapter.Passthrough` this does not break introspection (because
+  introspection relies on underscoring incoming introspection queries which we
+  still do).
+  """
+
+  use Absinthe.Adapter
+
+  def to_internal_name(nil, _role) do
+    nil
+  end
+
+  def to_internal_name("__" <> camelized_name, role) do
+    "__" <> to_internal_name(camelized_name, role)
+  end
+
+  def to_internal_name(camelized_name, _role) do
+    camelized_name
+    |> Macro.underscore()
+  end
+
+  def to_external_name(name, _role) do
+    name
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -159,7 +159,8 @@ defmodule Absinthe.Mixfile do
       "Document Adapters": [
         Absinthe.Adapter,
         Absinthe.Adapter.LanguageConventions,
-        Absinthe.Adapter.Passthrough
+        Absinthe.Adapter.Passthrough,
+        Absinthe.Adapter.Underscore
       ],
       Execution: [
         Absinthe.Blueprint,


### PR DESCRIPTION
It is similar to the `Absinthe.Adapter.LanguageConventions` adapter but converts all incoming identifiers to underscores and does not modify outgoing identifiers (since those are already expected to be underscores). Unlike `Absinthe.Adapter.Passthrough` it does not break introspection.

If this has a chance of being merged than I gladly work on some tests for this adapter. If not maybe I could add this adapter to the wiki somewhere?