### PR TITLE
Default MapGet middleware should ignore already resolved fields

### DIFF
--- a/lib/absinthe/middleware/map_get.ex
+++ b/lib/absinthe/middleware/map_get.ex
@@ -1,6 +1,11 @@
 defmodule Absinthe.Middleware.MapGet do
   @moduledoc """
-  This is the default middleware.
+  This is the default middleware. It assumes the the object it receives is a map
+  and uses `Map.get/2` to get the value for this field. If this field is already
+  marked as resolved, then this middleware does not touch it.
+
+  If you want to replace this middleware you should use
+  `Absinthe.Schema.replace_default/4`
   """
 
   @behaviour Absinthe.Middleware

--- a/lib/absinthe/middleware/map_get.ex
+++ b/lib/absinthe/middleware/map_get.ex
@@ -5,7 +5,9 @@ defmodule Absinthe.Middleware.MapGet do
 
   @behaviour Absinthe.Middleware
 
-  def call(%{source: source} = res, key) do
+  def call(%{state: :unresolved, source: source} = res, key) do
     %{res | state: :resolved, value: Map.get(source, key)}
   end
+
+  def call(res, _key), do: res
 end


### PR DESCRIPTION
Similar to the default resolve middleware `Absinthe.Middleware.MapGet` should ignore already resolved fields instead of over-writing their values.