### PR TITLE
Add missing definition of Absinthe.Blueprint.Input.RawValue.t()

### DIFF
--- a/lib/absinthe/blueprint/input/raw_value.ex
+++ b/lib/absinthe/blueprint/input/raw_value.ex
@@ -5,4 +5,8 @@ defmodule Absinthe.Blueprint.Input.RawValue do
   defstruct [
     :content
   ]
+
+  @type t :: %__MODULE__{
+          content: Absinthe.Blueprint.Input.t()
+        }
 end


### PR DESCRIPTION
`Absinthe.Blueprint.Input.Value.t()`[ refers to](https://github.com/absinthe-graphql/absinthe/blob/5600d03a0c9daa493a869910a6e2be3689082d35/lib/absinthe/blueprint/input/value.ex#L30) `Absinthe.Blueprint.Input.RawValue.t()`, whis is not defined.

This change defines that missing type.

