### PR TITLE
Fixes escape character sequences that are not on the last attributes

### DIFF
--- a/src/absinthe_lexer.xrl
+++ b/src/absinthe_lexer.xrl
@@ -40,7 +40,7 @@ BlockStringValue        = """{BlockStringCharacter}*"""
 HexDigit            = [0-9A-Fa-f]
 EscapedUnicode      = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
 EscapedCharacter    = ["\\\/bfnrt]
-StringCharacter     = ([^\"{_LineTerminator}]|\\{EscapedUnicode}|\\{EscapedCharacter})
+StringCharacter     = ([^\\"{_LineTerminator}]|\\{EscapedUnicode}|\\{EscapedCharacter})
 StringValue         = "{StringCharacter}*"
 
 % Boolean Value

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -27,6 +27,37 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert "slashes \\\\ \\/" == extract_body(result)
   end
 
+  test "parses attributes when there are escapes" do
+    assert {:ok, result}  = run(
+      ~s<{ post(title: "title", body: "body\\\\") { name } }>
+    )
+    assert "body\\" == extract_body(result)
+
+    assert {:ok, result}  = run(
+      ~s<{ post(title: "title\\\\", body: "body") { name } }>
+    )
+    assert "body" == extract_body(result)
+  end
+
+  test "paarse attributes where there are escapes on multiple lines" do
+    assert {:ok, result}  = run(
+      ~s<{ post(
+        title: "title",
+        body: "body\\\\"
+      ) { name } }>
+    )
+    assert "body\\" == extract_body(result)
+
+    assert {:ok, result}  = run(
+      ~s<{ post(
+        title: "title\\\\",
+        body: "body"
+      ) { name } }>
+    )
+    assert "body" == extract_body(result)
+  end
+
+
   @input [
     "",
     "    Hello,",

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -39,7 +39,7 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert "body" == extract_body(result)
   end
 
-  test "paarse attributes where there are escapes on multiple lines" do
+  test "parse attributes where there are escapes on multiple lines" do
     assert {:ok, result}  = run(
       ~s<{ post(
         title: "title",


### PR DESCRIPTION
Fixes #588 

When running with attributes that have escape characters and
on the same line the order of the attributes matters for the outcome. If
the slashes appear in the last attribute, then everything parses
successfully. If the property appears earlier in the list, then an error
is returned instead.

The error:

~~~elixir
  validation_errors: [
    %Absinthe.Phase.Error{
      extra: %{},
      locations: [%{column: 0, line: 1}],
      message: "illegal: \") { name } }",
      path: [],
      phase: Absinthe.Phase.Parse
    }
  ]
~~~

This change allows the attributes to come in any order.

Amos King @adkron <amos@binarynoggin.com>