### PR TITLE
Document dataloader helper callback option

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -165,6 +165,13 @@ defmodule Absinthe.Resolution.Helpers do
       field :organization, :organization do
         resolve dataloader(Accounts, :organization, use_parent: false)
       end
+
+      field(:account_active, non_null(:boolean), resolve: dataloader(
+          Accounts, :account, callback: fn account, _parent, _args ->
+            {:ok, account.active}
+          end
+        )
+      )
     end
     ```
 
@@ -196,6 +203,10 @@ defmodule Absinthe.Resolution.Helpers do
     - `:args` default: `%{}`. Any arguments you want to always pass into the
     `Dataloader.load/4` call. Resolver arguments are merged into this value and,
     in the event of a conflict, the resolver arguments win.
+    - `:callback` default: `default_callback/3`. Callback that is run with result
+    of dataloader. It receives the result as the first argument, and the parent
+    and args as second and third. Can be used to e.g. compute fields on the return
+    value of the loader. Should return an ok or error tuple.
     - `:use_parent` default: `true`. This option affects whether or not the `dataloader/2`
     helper will use any pre-existing value on the parent. IE if you return
     `%{author: %User{...}}` from a blog post the helper will by default simply use


### PR DESCRIPTION
Documents the callback option for the dataloader helper. Also included an example to illustrate its use.
