### PR TITLE
Fixes in mix absinthe.schema.json json-codec and pretty options

### DIFF
--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -73,22 +73,22 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
   end
 
   defp find_json(opts) do
-    case Keyword.get(opts, :json_codec, Poison) do
-      module when is_atom(module) ->
-        %{module: module, opts: codec_opts(module, opts)}
+    json_codec_opt = Keyword.get(opts, :json_codec, @default_codec_name)
+    module = String.to_atom("Elixir." <> json_codec_opt)
 
-      other ->
-        other
-    end
+    %{module: module, opts: codec_opts(module, opts)}
   end
 
-  defp codec_opts(Poison, opts) do
-    [pretty: Keyword.get(opts, :pretty, false)]
+  defp codec_opts(codec, opts) when codec in [Poison, Jason] do
+    codec_pretty_opt(Keyword.get(opts, :pretty, "false"))
   end
 
   defp codec_opts(_, _) do
     []
   end
+
+  defp codec_pretty_opt("true"), do: [pretty: true]
+  defp codec_pretty_opt(_), do: []
 
   defp find_schema(opts) do
     case Keyword.get(opts, :schema, Application.get_env(:absinthe, :schema)) do


### PR DESCRIPTION
When trying to generate the schema with the Jason codec using:

```
mix absinthe.schema.json --json-codec Jason
```

Got the exception:
```
* creating .
** (ArgumentError) you attempted to apply :module on "Jason". If you are using apply/3, make sure the module is an atom. If you are using the dot syntax, such as map.field or module.function, make sure the left side of the dot is an atom or a map
    :erlang.apply("Jason", :module, [])
    (absinthe) lib/mix/tasks/absinthe.schema.json.ex:67: Mix.Tasks.Absinthe.Schema.Json.run/1
```

Basically this PR makes sure the JSON codec option received as a string is converted to an Elixir atom.
Also the `pretty` option has to be converted to a boolean, previously it was passed to the JSON encoder as a string.
