### PR TITLE
Add closing parenthesis for example function

### DIFF
--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -23,7 +23,7 @@ defmodule Absinthe.Middleware.Async do
     resolve fn _, _, _ ->
       task = Task.async(fn ->
         {:ok, long_time_consuming_function()}
-      end
+      end)
       {:middleware, #{__MODULE__}, task}
     end
   end


### PR DESCRIPTION
Example code was missing closing parenthesis in anonymous function