### PR TITLE
Add missing typespec for RawValue

### DIFF
--- a/lib/absinthe/blueprint/input/raw_value.ex
+++ b/lib/absinthe/blueprint/input/raw_value.ex
@@ -5,4 +5,8 @@ defmodule Absinthe.Blueprint.Input.RawValue do
   defstruct [
     :content
   ]
+
+  @type t :: %__MODULE__{
+          content: any()
+        }
 end


### PR DESCRIPTION
We switched from v1.4.11 to v1.4.13 and stumbled upon dialyzer error. 

```
:0:unknown_type
Unknown type: Absinthe.Blueprint.Input.RawValue.t/0.
```

`Absinthe.Blueprint.Input.RawValue.t()` is actually [used](https://github.com/absinthe-graphql/absinthe/blob/4c16232a40d06dcb7979464159b36a9f03a1ff2e/lib/absinthe/blueprint/input/value.ex#L30) in one place, but not defined. This PR fixes the problem.
