### PR TITLE
Modify lexer and parser to support parsing kitchen-sink and schema-kitchen-sink fixtures

### DIFF
--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -194,9 +194,15 @@ DirectiveDefinition -> 'directive' '@' Name 'on' DirectiveDefinitionLocations Di
 DirectiveDefinition -> 'directive' '@' Name ArgumentsDefinition 'on' DirectiveDefinitionLocations Directives :
   build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'arguments' => '$4', 'directives' => '$7', 'locations' =>'$6'}, extract_location('$1')).
 
+SchemaDefinition -> 'schema' : build_ast_node('SchemaDefinition', #{}, extract_location('$1')).
+SchemaDefinition -> 'schema' Directives : build_ast_node('SchemaDefinition', #{'directives' => '$2'}, extract_location('$1')).
 SchemaDefinition -> 'schema' '{' FieldDefinitionList '}' : build_ast_node('SchemaDefinition', #{'fields' => '$3'}, extract_location('$1')).
 SchemaDefinition -> 'schema' Directives '{' FieldDefinitionList '}' : build_ast_node('SchemaDefinition', #{'directives' => '$2', 'fields' => '$4'}, extract_location('$1')).
 
+ObjectTypeDefinition -> 'type' Name :
+  build_ast_node('ObjectTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$1')).
+ObjectTypeDefinition -> 'type' Name Directives :
+  build_ast_node('ObjectTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$1')).
 ObjectTypeDefinition -> 'type' Name '{' FieldDefinitionList '}' :
   build_ast_node('ObjectTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, extract_location('$1')).
 ObjectTypeDefinition -> 'type' Name Directives '{' FieldDefinitionList '}' :
@@ -235,11 +241,19 @@ InputValueDefinition -> Name ':' Type Directives : build_ast_node('InputValueDef
 InputValueDefinition -> Name ':' Type DefaultValue : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3', 'default_value' => '$4'}, extract_location('$1')).
 InputValueDefinition -> Name ':' Type DefaultValue Directives : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3', 'default_value' => '$4', 'directives' => '$5'}, extract_location('$1')).
 
+InterfaceTypeDefinition -> 'interface' Name :
+  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$1')).
+InterfaceTypeDefinition -> 'interface' Name Directives :
+  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$1')).
 InterfaceTypeDefinition -> 'interface' Name '{' FieldDefinitionList '}' :
-  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'},extract_location('$1')).
+  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, extract_location('$1')).
 InterfaceTypeDefinition -> 'interface' Name Directives '{' FieldDefinitionList '}' :
   build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3', 'fields' => '$5'}, extract_location('$1')).
 
+UnionTypeDefinition -> 'union' Name :
+  build_ast_node('UnionTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$1')).
+UnionTypeDefinition -> 'union' Name Directives :
+  build_ast_node('UnionTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$1')).
 UnionTypeDefinition -> 'union' Name '=' UnionMembers :
   build_ast_node('UnionTypeDefinition', #{'name' => extract_binary('$2'), 'types' => '$4'}, extract_location('$1')).
 UnionTypeDefinition -> 'union' Name Directives '=' UnionMembers :
@@ -247,10 +261,15 @@ UnionTypeDefinition -> 'union' Name Directives '=' UnionMembers :
 
 UnionMembers -> NamedType : ['$1'].
 UnionMembers -> NamedType '|' UnionMembers : ['$1'|'$3'].
+UnionMembers -> '|' NamedType '|' UnionMembers : ['$2'|'$4'].
 
 ScalarTypeDefinition -> 'scalar' Name : build_ast_node('ScalarTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$2')).
 ScalarTypeDefinition -> 'scalar' Name Directives : build_ast_node('ScalarTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$2')).
 
+EnumTypeDefinition -> 'enum' Name :
+  build_ast_node('EnumTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$2')).
+EnumTypeDefinition -> 'enum' Name Directives :
+  build_ast_node('EnumTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$2')).
 EnumTypeDefinition -> 'enum' Name '{' EnumValueDefinitionList '}':
   build_ast_node('EnumTypeDefinition', #{'name' => extract_binary('$2'), 'values' => '$4'}, extract_location('$2')).
 EnumTypeDefinition -> 'enum' Name Directives '{' EnumValueDefinitionList '}':
@@ -264,20 +283,36 @@ EnumValueDefinitionList -> DescriptionDefinition EnumValueDefinition EnumValueDe
 
 DirectiveDefinitionLocations -> Name : [extract_binary('$1')].
 DirectiveDefinitionLocations -> Name '|' DirectiveDefinitionLocations : [extract_binary('$1')|'$3'].
+DirectiveDefinitionLocations -> '|' Name '|' DirectiveDefinitionLocations : [extract_binary('$2')|'$4'].
 
 EnumValueDefinition -> EnumValue : build_ast_node('EnumValueDefinition', #{'value' => extract_binary('$1')}, extract_location('$1')).
 EnumValueDefinition -> EnumValue Directives : build_ast_node('EnumValueDefinition', #{'value' => extract_binary('$1'), 'directives' => '$2'}, extract_location('$1')).
 
-
+InputObjectTypeDefinition -> 'input' Name :
+  build_ast_node('InputObjectTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$2')).
+InputObjectTypeDefinition -> 'input' Name Directives :
+  build_ast_node('InputObjectTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3'}, extract_location('$2')).
 InputObjectTypeDefinition -> 'input' Name '{' InputValueDefinitionList '}' :
   build_ast_node('InputObjectTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, extract_location('$2')).
 InputObjectTypeDefinition -> 'input' Name Directives '{' InputValueDefinitionList '}' :
   build_ast_node('InputObjectTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3', 'fields' => '$5'}, extract_location('$2')).
 
-
+TypeExtensionDefinition -> 'extend' EnumTypeDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
+TypeExtensionDefinition -> 'extend' InputObjectTypeDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
+TypeExtensionDefinition -> 'extend' InterfaceTypeDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
 TypeExtensionDefinition -> 'extend' ObjectTypeDefinition :
   build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
+TypeExtensionDefinition -> 'extend' ScalarTypeDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
+TypeExtensionDefinition -> 'extend' SchemaDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
+TypeExtensionDefinition -> 'extend' UnionTypeDefinition :
+  build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, extract_location('$1')).
 
+Expect 10.
 
 Erlang code.
 
@@ -297,7 +332,6 @@ extract_child_location(#{loc := #{'line' := Line, 'column' := Column}}) ->
 extract_child_location(_) ->
   #{'line' => nil, 'column' => nil}.
 
-
 % Value-level Utilities
 
 extract_atom({Value, _Loc}) ->
@@ -311,7 +345,6 @@ extract_binary({Token, _Loc}) ->
 
 extract_binary({_Token, _Loc, Value}) ->
   list_to_binary(Value).
-
 
 % AST Generation
 
@@ -358,7 +391,6 @@ process_string([H | T], Acc) ->
 
 hexlist_to_utf8_binary(HexList) ->
   unicode:characters_to_binary([httpd_util:hexlist_to_integer(HexList)]).
-
 
 % Block String
 
@@ -460,18 +492,15 @@ leading_whitespace([_H | _T], N) ->
 is_blank(BlockStringValue) ->
     leading_whitespace(BlockStringValue) == length(BlockStringValue).
 
-
 % Integer
 
 extract_integer({_Token, _Loc, Value}) ->
   {Int, []} = string:to_integer(Value), Int.
 
-
 % Float
 
 extract_float({_Token, _Loc, Value}) ->
   {Float, []} = string:to_float(Value), Float.
-
 
 % Boolean
 
@@ -479,4 +508,3 @@ extract_boolean({_Token, _Loc, "true"}) ->
   true;
 extract_boolean({_Token, _Loc, "false"}) ->
   false.
-

--- a/test/absinthe/phase/parse/language_test.exs
+++ b/test/absinthe/phase/parse/language_test.exs
@@ -1,0 +1,25 @@
+defmodule Absinthe.Phase.Parse.LanguageTest do
+  use Absinthe.Case, async: true
+
+  @moduletag :parser
+
+  test "parses kitchen-sink.graphql" do
+    filename = Path.join(__DIR__, "../../../support/fixtures/language/kitchen-sink.graphql")
+    input = File.read!(filename)
+    assert {:ok, _} = run(input)
+  end
+
+  test "parses schema-kitchen-sink.graphql" do
+    filename =
+      Path.join(__DIR__, "../../../support/fixtures/language/schema-kitchen-sink.graphql")
+
+    input = File.read!(filename)
+    assert {:ok, _} = run(input)
+  end
+
+  def run(input) do
+    with {:ok, %{input: input}} <- Absinthe.Phase.Parse.run(input) do
+      {:ok, input}
+    end
+  end
+end

--- a/test/support/fixtures/language/kitchen-sink.graphql
+++ b/test/support/fixtures/language/kitchen-sink.graphql
@@ -1,0 +1,59 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+query queryName($foo: ComplexType, $site: Site = MOBILE) {
+  whoever123is: node(id: [123, 456]) {
+    id ,
+    ... on User @defer {
+      field2 {
+        id ,
+        alias: field1(first:10, after:$foo,) @include(if: $foo) {
+          id,
+          ...frag
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory {
+  like(story: 123) @defer {
+    story {
+      id
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend {
+  foo(size: $size, bar: $b, obj: {key: "value", block: """
+
+      block string uses \"""
+
+  """})
+}
+
+{
+  unnamed(truthy: true, falsey: false, nullish: null),
+  query
+}

--- a/test/support/fixtures/language/schema-kitchen-sink.graphql
+++ b/test/support/fixtures/language/schema-kitchen-sink.graphql
@@ -1,0 +1,131 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+"""
+This is a description
+of the `Foo` type.
+"""
+type Foo implements Bar & Baz {
+  one: Type
+  """
+  This is a description of the `two` field.
+  """
+  two(
+    """
+    This is a description of the `argument` argument.
+    """
+    argument: InputType!
+  ): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+  seven(argument: Int = null): Type
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+type UndefinedType
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+interface UndefinedInterface
+
+extend interface Bar {
+  two(argument: InputType!): Type
+}
+
+extend interface Bar @onInterface
+
+union Feed = Story | Article | Advert
+
+union AnnotatedUnion @onUnion = A | B
+
+union AnnotatedUnionTwo @onUnion = | A | B
+
+union UndefinedUnion
+
+extend union Feed = Photo | Video
+
+extend union Feed @onUnion
+
+scalar CustomScalar
+
+scalar AnnotatedScalar @onScalar
+
+extend scalar CustomScalar @onScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+enum UndefinedEnum
+
+extend enum Site {
+  VR
+}
+
+extend enum Site @onEnum
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+input AnnotatedInput @onInputObject {
+  annotatedField: Type @onField
+}
+
+input UndefinedInput
+
+extend input InputType {
+  other: Float = 1.23e4
+}
+
+extend input InputType @onInputObject
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!)
+  on FIELD
+   | FRAGMENT_SPREAD
+   | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on
+  | FIELD
+  | FRAGMENT_SPREAD
+  | INLINE_FRAGMENT
+
+extend schema @onSchema
+
+extend schema @onSchema {
+  subscription: SubscriptionType
+}


### PR DESCRIPTION
This pull request adds tests for parsing the fixtures [`kitchen-sink.graphql`](https://github.com/graphql/graphql-js/blob/v14.0.2/src/language/__tests__/kitchen-sink.graphql) and [`schema-kitchen-sink.graphql`](https://github.com/graphql/graphql-js/blob/v14.0.2/src/language/__tests__/schema-kitchen-sink.graphql) as used in [graphql/graphql-js](https://github.com/graphql/graphql-js).

**Update 2018-12-04:** The tests now pass after rebasing against master.

## Overview of Changes

- `Absinthe.Lexer`
  - Ignore Ampersand (`&`) in the same way that Comma (`,`) is ignored.

     _Reasoning:_
     
     The [June 2018 GraphQL spec](https://facebook.github.io/graphql/June2018/#sec-Objects) specifies that multiple interfaces on an object type are separated by a `&`: `type O implements I1 & I2`
     
     This change came after many implementations out there have already started using a `,` to specify multiple interfaces: `type O implements I1, I2`
     
     By ignoring `&` and `,`, the lexer can handle both non-standard and standard forms.
     
  - Remove `BooleanValue` and instead treat booleans as if they were reserved words by traversing on `boolean_value_or_name_or_reserved_word`.
  
     _Reasoning:_
     
     Try parsing the following document using the old and new lexer:
     
     ```graphql
     query AnnoyingQuery($truetype: Font, $falsetto: Boolean = false, $nullify: Boolean = null) {
       annoying(truetype: $truetype, falsetto: $falsetto, nullify: $nullify)
     }
     ```

     You will find that the old lexer parses it correctly while the new one attempts to treat things like `$falsetto` as `false`.
     
     There may be a better way to handle this, but I noticed that `null` was being handled roughly the same way and didn't show the same symptoms.

- `:absinthe_parser`
  - Support "undefined style" definitions.

     _Example:_

     ```graphql
     enum UndefinedEnum
     enum UndefinedEnum @onType
     input UndefinedInputObject
     input UndefinedInputObject @onType
     interface UndefinedInterface
     interface UndefinedInterface @onType
     schema
     schema @onType
     type UndefinedObject
     type UndefinedObject @onType
     union UndefinedUnion
     union UndefinedUnion @onType
     ```

     _Reasoning:_

     All of that in order to support `extend` as seen below.

  - Support `extend` definitions.

     _Example:_

     ```graphql
     extend enum UndefinedEnum = VALUE
     extend input UndefinedInputObject { key: Int }
     extend interface UndefinedInterface { key: Int }
     extend schema { subscription: RootSubscriptionType }
     extend type UndefinedObject { key: Int }
     extend union UndefinedUnion = AnotherType
     ```
     
     _Reasoning:_
     
     Because almost everything is now extensible according to [the spec](https://facebook.github.io/graphql/June2018/#sec-Type-System-Extensions).  Directives aren't extensible, for now.

  - Support Pipe (`|`) prefixed members of directives and unions.

     _Example:_

     ```graphql
     directive @foo on FIELD | FRAGMENT_SPREAD
     directive @bar on
       | FIELD
       | FRAGMENT_SPREAD

     union Foo = A | B
     union Bar =
       | A
       | B
     ```

  - Added [`Expect 10`](https://github.com/potatosalad/absinthe/blob/3c6a844f27e6982f6e105e3cb904fe6126cdf9fb/src/absinthe_parser.yrl#L315) to the parser to suppress 10 shift/reduce conflicts.

     _Reasoning:_

     As a result of going from:

     ```erlang
     EnumTypeDefinition -> 'enum' Name '{' EnumValueDefinitionList '}' : '...'.
     EnumTypeDefinition -> 'enum' Name Directives '{' EnumValueDefinitionList '}' : '...'.
     ```

     To the more ambiguous:

     ```erlang
     EnumTypeDefinition -> 'enum' Name : '...'.
     EnumTypeDefinition -> 'enum' Name Directives : '...'.
     EnumTypeDefinition -> 'enum' Name '{' EnumValueDefinitionList '}' : '...'.
     EnumTypeDefinition -> 'enum' Name Directives '{' EnumValueDefinitionList '}' : '...'.
     ```

     On compilation, `yecc` will warn about the shift/reduce ambiguity (10 in total).  There may be some way to remove the warnings, but from [what I read](http://erlang.org/doc/man/yecc.html), you can simply tell `yecc` to ignore the known ambiguity and only warn if the number changes.

     From the docs:

     > The optional expect declaration can be placed anywhere before the last optional section with Erlang code. It is used for suppressing the warning about conflicts that is ordinarily given if the grammar is ambiguous. An example:
     >
     > ```erlang
     > Expect 2.
     > ```
     >
     > The warning is given if the number of shift/reduce conflicts differs from 2, or if there are reduce/reduce conflicts.
