### PR TITLE
Subscriptions - multiple topic support

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -126,6 +126,9 @@ subscription do
     # subscription {
     #   commentAdded(repoName: "elixir-lang/elixir") { content }
     # }
+    #
+    # If needed, you can also provide a list of topics:
+    #   {:ok, topic: ["absinthe-graphql/absinthe", "elixir-lang/elixir"]}
     config fn args, _ ->
       {:ok, topic: args.repo_name}
     end

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -31,7 +31,9 @@ defmodule Absinthe.Schema.Notation do
   @doc """
   Configure a subscription field.
 
-  ## Example
+  The returned topic can be single topic, or a list of topics
+
+  ## Examples
 
   ```elixir
   config fn args, %{context: context} ->
@@ -40,6 +42,14 @@ defmodule Absinthe.Schema.Notation do
     else
       {:error, "unauthorized"}
     end
+  end
+  ```
+
+  Alternatively can provide a list of topics:
+
+  ```elixir
+  config fn _, _ ->
+    {:ok, topic: ["topic_one", "topic_two", "topic_three"]}
   end
   ```
 


### PR DESCRIPTION
Adds support for specifying multiple topics when configuring a subscription field.

The function provided to `config` can now return either a single topic, or a list of topics, for example:

```elixir
subscription do
  field :some_field, :string do
    config fn _, _ ->
      {:ok, topic: ["topic_1", "topic_2", "topic_3"]}
    end
  end
end
```

Thanks to @benwilson512 for pointing me in the right direction!