### PR TITLE
Support :path option to import_sdl

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -18,6 +18,8 @@ locals_without_parens = [
   import_fields: 2,
   import_fields: 1,
   import_types: 1,
+  import_sdl: 1,
+  import_sdl: 2,
   input_object: 3,
   interface: 1,
   interface: 3,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1137,9 +1137,14 @@ defmodule Absinthe.Schema.Notation do
 
   TODO: Example for dynamic loading during init
   """
-  defmacro import_sdl(embedded \\ nil, opts \\ []) do
+  defmacro import_sdl(opts) when is_list(opts) do
     __CALLER__
-    |> do_import_sdl(embedded, opts)
+    |> do_import_sdl(nil, opts)
+  end
+
+  defmacro import_sdl(sdl, opts \\ []) when is_binary(sdl) do
+    __CALLER__
+    |> do_import_sdl(sdl, opts)
   end
 
   defmacro values(values) do
@@ -1459,7 +1464,7 @@ defmodule Absinthe.Schema.Notation do
     with {:ok, path} <- Keyword.fetch(opts, :path),
          sdl <- File.read!(path) do
       Module.put_attribute(env.module, :external_resource, path)
-      do_import_types(env, sdl, Keyword.delete(opts, :path))
+      do_import_sdl(env, sdl, Keyword.delete(opts, :path))
     else
       :error ->
         raise Absinthe.Schema.Notation.Error,

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -30,35 +30,26 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
   end
 
   test "parses attributes when there are escapes" do
-    assert {:ok, result}  = run(
-      ~s<{ post(title: "title", body: "body\\\\") { name } }>
-    )
+    assert {:ok, result} = run(~s<{ post(title: "title", body: "body\\\\") { name } }>)
     assert "body\\" == extract_body(result)
 
-    assert {:ok, result}  = run(
-      ~s<{ post(title: "title\\\\", body: "body") { name } }>
-    )
+    assert {:ok, result} = run(~s<{ post(title: "title\\\\", body: "body") { name } }>)
     assert "body" == extract_body(result)
   end
 
   test "parse attributes where there are escapes on multiple lines" do
-    assert {:ok, result}  = run(
-      ~s<{ post(
+    assert {:ok, result} = run(~s<{ post(
         title: "title",
         body: "body\\\\"
-      ) { name } }>
-    )
+      ) { name } }>)
     assert "body\\" == extract_body(result)
 
-    assert {:ok, result}  = run(
-      ~s<{ post(
+    assert {:ok, result} = run(~s<{ post(
         title: "title\\\\",
         body: "body"
-      ) { name } }>
-    )
+      ) { name } }>)
     assert "body" == extract_body(result)
   end
-
 
   @input [
     "",

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -8,32 +8,22 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
   defmodule Definition do
     use Absinthe.Schema
 
+    # Embedded SDL
     import_sdl """
     type Query {
       "A list of posts"
       posts(filter: PostFilter): [Post]
       admin: User!
     }
-
-    "A submitted post"
-    type Post {
-      title: String!
-      body: String!
-      \"""
-      The post author
-      (is a user)
-      \"""
-      author: User!
-    }
     """
 
-    import_sdl """
-    type User {
-      name: String!
-    }
-    """
+    # Read SDL from file manually at compile-time
+    import_sdl File.read!("test/support/fixtures/import_sdl_binary_fn.graphql")
 
+    # Read from file at compile time (with support for automatic recompilation)
     import_sdl path: "test/support/fixtures/import_sdl_path_option.graphql"
+    import_sdl path: Path.join("test/support", "fixtures/import_sdl_path_option_fn.graphql")
+
 
     def get_posts(_, _, _) do
       posts = [

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -8,15 +8,11 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
   defmodule Definition do
     use Absinthe.Schema
 
-    import_sdl("""
+    import_sdl """
     type Query {
       "A list of posts"
       posts(filter: PostFilter): [Post]
       admin: User!
-    }
-
-    input PostFilter {
-      name: String
     }
 
     "A submitted post"
@@ -29,13 +25,15 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       \"""
       author: User!
     }
-    """)
+    """
 
-    import_sdl("""
+    import_sdl """
     type User {
       name: String!
     }
-    """)
+    """
+
+    import_sdl path: "test/support/fixtures/import_sdl_path_option.graphql"
 
     def get_posts(_, _, _) do
       posts = [

--- a/test/support/fixtures/import_sdl_binary_fn.graphql
+++ b/test/support/fixtures/import_sdl_binary_fn.graphql
@@ -1,0 +1,3 @@
+type User {
+  name: String!
+}

--- a/test/support/fixtures/import_sdl_path_option.graphql
+++ b/test/support/fixtures/import_sdl_path_option.graphql
@@ -1,0 +1,3 @@
+input PostFilter {
+  name: String
+}

--- a/test/support/fixtures/import_sdl_path_option_fn.graphql
+++ b/test/support/fixtures/import_sdl_path_option_fn.graphql
@@ -1,0 +1,10 @@
+"A submitted post"
+type Post {
+  title: String!
+  body: String!
+  """
+  The post author
+  (is a user)
+  """
+  author: User!
+}


### PR DESCRIPTION
This adds support for the `import_sdl/1` and `import_sdl/2` notation macros to load SDL from a file location while supporting recompilation via `@external_resource`.

This also adds support for more flexible arguments to the macro (supporting function calls, etc)

## Example

Given the following SDL:

```graphql
type Query {
  hello: String!
}
```

```elixir
defmodule MyAppWeb.Schema do
  use Absinthe.Schema

  # Option 1: Embed it
  import_sdl """
  type Query {
    hello: String!
  }
  """

  # Option 2: Load it (from a file, etc) using custom logic:
  import_sdl File.read!("path/to/schema.graphql")

  # Option 3: Load it from a file, supporting recompilation on-change:
  import_sdl path: "schema.graphql"

  # Option 4: The same as above, but programmatically determining the path:
  import_sdl path: Path.join(:code.priv_dir(:myapp), "schema.graphql")

  # Not shown: Use decorations to apply resolvers, etc
end
```