### PR TITLE
Add identifiers to SDL enum, scalar, interface, and union types

### DIFF
--- a/lib/absinthe/blueprint/schema/enum_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_type_definition.ex
@@ -23,6 +23,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
           name: String.t(),
           values: [Blueprint.Schema.EnumValueDefinition.t()],
           directives: [Blueprint.Directive.t()],
+          identifier: atom,
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
           flags: Blueprint.flags_t(),

--- a/lib/absinthe/language/enum_type_definition.ex
+++ b/lib/absinthe/language/enum_type_definition.ex
@@ -22,6 +22,7 @@ defmodule Absinthe.Language.EnumTypeDefinition do
       %Blueprint.Schema.EnumTypeDefinition{
         name: node.name,
         description: node.description,
+        identifier: Macro.underscore(node.name) |> String.to_atom(),
         values: Absinthe.Blueprint.Draft.convert(node.values, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         source_location: source_location(node)

--- a/lib/absinthe/language/interface_type_definition.ex
+++ b/lib/absinthe/language/interface_type_definition.ex
@@ -22,6 +22,7 @@ defmodule Absinthe.Language.InterfaceTypeDefinition do
       %Blueprint.Schema.InterfaceTypeDefinition{
         name: node.name,
         description: node.description,
+        identifier: Macro.underscore(node.name) |> String.to_atom(),
         fields: Absinthe.Blueprint.Draft.convert(node.fields, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         source_location: source_location(node)

--- a/lib/absinthe/language/scalar_type_definition.ex
+++ b/lib/absinthe/language/scalar_type_definition.ex
@@ -20,6 +20,7 @@ defmodule Absinthe.Language.ScalarTypeDefinition do
       %Blueprint.Schema.ScalarTypeDefinition{
         name: node.name,
         description: node.description,
+        identifier: Macro.underscore(node.name) |> String.to_atom(),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         source_location: source_location(node)
       }

--- a/lib/absinthe/language/union_type_definition.ex
+++ b/lib/absinthe/language/union_type_definition.ex
@@ -22,6 +22,7 @@ defmodule Absinthe.Language.UnionTypeDefinition do
       %Blueprint.Schema.UnionTypeDefinition{
         name: node.name,
         description: node.description,
+        identifier: Macro.underscore(node.name) |> String.to_atom(),
         types: Absinthe.Blueprint.Draft.convert(node.types, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         source_location: source_location(node)

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -15,6 +15,36 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       posts(filter: PostFilter): [Post]
       admin: User!
     }
+
+    type Comment {
+      author: User!
+      subject: Post!
+    }
+
+    enum Category {
+      NEWS
+      OPINION
+    }
+
+    enum PostState {
+      SUBMITTED
+      ACCEPTED
+      REJECTED
+    }
+
+    interface Named {
+      name: String!
+    }
+
+    interface Titled {
+      title: String!
+    }
+
+    scalar A
+    scalar B
+
+    union SearchResult = Post | User
+    union Content = Post | Comment
     """
 
     # Read SDL from file manually at compile-time


### PR DESCRIPTION
This PR adds identifiers to various types defined by SDL; caught by the recently added `Absinthe.Phase.Schema.Validation.TypeNamesAreUnique` schema validation.

Testing done by adding multiple enums, scalars, interfaces, and unions to the SDL schema in tests (blew up before, doesn't now).