### PR TITLE
Reuse the resolution struct to avoid unnecessary allocations

### DIFF
--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -33,7 +33,6 @@ defmodule Absinthe.Blueprint.Execution do
 
   defstruct [
     :adapter,
-    :root_value,
     :schema,
     fragments: %{},
     fields_cache: %{},


### PR DESCRIPTION
# Wide Query
```
Name                     ips        average  deviation         median         99th %
wide-query-new        803.28        1.24 ms    ±20.39%        1.13 ms        1.98 ms
wide-query-old        505.16        1.98 ms    ±11.62%        1.99 ms        2.54 ms

Comparison: 
wide-query-new        803.28
wide-query-old        505.16 - 1.59x slower

Memory usage statistics:

Name              Memory usage
wide-query-new         1.26 MB
wide-query-old         2.29 MB - 1.82x memory usage
```

# Deep Query
```
Name                     ips        average  deviation         median         99th %
deep-query-new         84.07       11.89 ms    ±13.62%       11.65 ms       16.01 ms
deep-query-old         67.71       14.77 ms    ±10.15%       14.56 ms       18.74 ms

Comparison: 
deep-query-new         84.07
deep-query-old         67.71 - 1.24x slower

Memory usage statistics:

Name              Memory usage
deep-query-new         9.00 MB
deep-query-old        14.25 MB - 1.58x memory usage
```