### PR TITLE
Absinthe.Type.Enum.Value typo

### DIFF
--- a/lib/absinthe/type/enum/value.ex
+++ b/lib/absinthe/type/enum/value.ex
@@ -17,8 +17,7 @@ defmodule Absinthe.Type.Enum.Value do
     value that will be provided by query documents.
   * `:description` - A nice description for introspection.
   * `:value` - The raw, internal value that `:name` map to. This will be
-    provided as the argument value to resolve functions.
-    to `resolve` functions
+    provided as the argument value to `resolve` functions.
   * `:deprecation` - Deprecation information for a value, usually
     set-up using the `Absinthe.Schema.Notation.deprecate/2` convenience
     function.


### PR DESCRIPTION
Fix a typo inside Absinthe.Type.Enum.Value's documentation