### PR TITLE
Fix url link to graphiql display showing create user mutation

### DIFF
--- a/guides/tutorial/complex-arguments.md
+++ b/guides/tutorial/complex-arguments.md
@@ -137,7 +137,7 @@ Everyone else gets an `"Access denied"` error for this field.
 
 Here's our mutation in action in GraphiQL.
 
-<img style="box-shadow: 0 0 6px #ccc;" src="assets/tutorial/graphiql_create_user.png" alt=""/>
+<img style="box-shadow: 0 0 6px #ccc;" src="./assets/tutorial/graphiql_create_user.png" alt=""/>
 
 > Note we're sending a `Authorization` header to authenticate, which a
 > plug is handling. Make sure to read the

--- a/guides/tutorial/start.md
+++ b/guides/tutorial/start.md
@@ -12,7 +12,7 @@ Before you start, it's a good idea to have some background into GraphQL in gener
 
 ## The Example
 
- The tutorial expects you to have a properly set-up [Phoenix application](http://www.phoenixframework.org/docs/up-and-running) with <a href="https://hex.pm/packages/absinthe">absinthe</a> and <a href="https://hex.pm/packages/absinthe_plug">absinthe_plug</a> added to the dependencies.
+ The tutorial expects you to have a properly set-up [Phoenix application](https://hexdocs.pm/phoenix/installation.html) with <a href="https://hex.pm/packages/absinthe">absinthe</a> and <a href="https://hex.pm/packages/absinthe_plug">absinthe_plug</a> added to the dependencies.
 
 >  If you'd like to cheat, you can find the finished code for the tutorial
 >  in the <a href="https://github.com/absinthe-graphql/absinthe_tutorial">Absinthe Example</a>


### PR DESCRIPTION
This pull requests aims to resolve the correct link to the graphiql screenshot.
The link seems to be working on hexdocs but the image isn't resolving on documentation on github.