### PR TITLE
WIP: fragment cycle phase errors for unknown nested fragments

### DIFF
--- a/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
+++ b/lib/absinthe/phase/document/validation/no_fragment_cycles.ex
@@ -45,7 +45,8 @@ defmodule Absinthe.Phase.Document.Validation.NoFragmentCycles do
           graph
           |> :digraph_utils.topsort()
           |> Enum.reverse()
-          |> Enum.map(&Map.fetch!(fragments, &1))
+          |> Enum.map(&Map.get(fragments, &1))
+          |> Enum.reject(&is_nil/1)
 
         {fragments, 0}
       end

--- a/test/absinthe/integration/validation/cycles_test.exs
+++ b/test/absinthe/integration/validation/cycles_test.exs
@@ -30,4 +30,26 @@ defmodule Elixir.Absinthe.Integration.Validation.CyclesTest do
               ]
             }} == Absinthe.run(@query, Absinthe.Fixtures.ThingsSchema, [])
   end
+
+  @query """
+  query Foo {
+    ...Bar
+  }
+  fragment Bar on RootQueryType {
+    version
+    ...Foo
+  }
+  """
+
+  test "does not choke on unknown fragments" do
+    assert {:ok,
+            %{
+              errors: [
+                %{
+                  message: "Unknown fragment \"Foo\"",
+                  locations: [%{column: 3, line: 6}]
+                }
+              ]
+            }} == Absinthe.run(@query, Absinthe.Fixtures.ThingsSchema, [])
+  end
 end


### PR DESCRIPTION
Running a query like 

```graphql
query {
  currentSession {
    ...knownFragment
  }
}

fragment knownFragment on Session {
  ...unkownFragment
}
```

currently results in `(KeyError) key "unknownFragment" not found in: [...]` at https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/phase/document/validation/no_fragment_cycles.ex#L48. The KnownFragmentName phase currently runs after the NoFragmentCycles phase. But even when flipped, this error will persist, as KnownFragmentName only flags the fragment spread, which is ignored in NoFragmentCycles.

As suggested, I've added a failing test, where I thought it would make the most sense.