### PR TITLE
Fix __typename prevent subscription deduplication

### DIFF
--- a/lib/absinthe/introspection/field.ex
+++ b/lib/absinthe/introspection/field.ex
@@ -12,28 +12,7 @@ defmodule Absinthe.Introspection.Field do
       type: :string,
       description: "The name of the object type currently being queried.",
       middleware: [
-        Absinthe.Resolution.resolver_spec(fn
-          _, %{parent_type: %Type.Object{} = type} ->
-            {:ok, type.name}
-
-          _, %{source: source, parent_type: %Type.Interface{} = iface} = env ->
-            case Type.Interface.resolve_type(iface, source, env) do
-              nil ->
-                {:error, "Could not resolve type of concrete " <> iface.name}
-
-              type ->
-                {:ok, type.name}
-            end
-
-          _, %{source: source, parent_type: %Type.Union{} = union} = env ->
-            case Type.Union.resolve_type(union, source, env) do
-              nil ->
-                {:error, "Could not resolve type of concrete " <> union.name}
-
-              type ->
-                {:ok, type.name}
-            end
-        end)
+        Absinthe.Resolution.resolver_spec(&__MODULE__.typename_resolver/2)
       ]
     }
   end
@@ -70,5 +49,29 @@ defmodule Absinthe.Introspection.Field do
         end)
       ]
     }
+  end
+
+  def typename_resolver(_, %{parent_type: %Type.Object{} = type}) do
+    {:ok, type.name}
+  end
+
+  def typename_resolver(_, %{source: source, parent_type: %Type.Interface{} = iface} = env) do
+    case Type.Interface.resolve_type(iface, source, env) do
+      nil ->
+        {:error, "Could not resolve type of concrete " <> iface.name}
+
+      type ->
+        {:ok, type.name}
+    end
+  end
+
+  def typename_resolver(_, %{source: source, parent_type: %Type.Union{} = union} = env) do
+    case Type.Union.resolve_type(union, source, env) do
+      nil ->
+        {:error, "Could not resolve type of concrete " <> union.name}
+
+      type ->
+        {:ok, type.name}
+    end
   end
 end


### PR DESCRIPTION
This fixes an issue where identical subscription GraphQL queries would not be deduplicated, i.e. would end up with different doc IDs here:

https://github.com/absinthe-graphql/absinthe/blob/d34d5ab682a8800a0831cd2b991d1d5d9dede5d5/lib/absinthe/phase/subscription/subscribe_self.ex#L22-L23

The anonymous function used when resolving `__typename` ends being "different" when run on separate processes, preventing identical subscription queries that use `__typename` from being deduplicated (when run from separate processes)

---

The root cause of the issue:

```elixir
defmodule Example do
  def print(msg), do: IO.puts msg

  def make_print_func(), do: &Example.print/1

  def make_anon_print_func(), do: &print/1
end

a = Example.make_print_func()
b = Task.await(Task.async(&Example.make_print_func/0))

IO.puts "a == b?  #{a == b}"
IO.puts ":erlang.term_to_binary(a) == :erlang.term_to_binary(b)?  #{:erlang.term_to_binary(a) == :erlang.term_to_binary(b)}"

anon_a = Example.make_anon_print_func()
anon_b = Task.await(Task.async(&Example.make_anon_print_func/0))

IO.puts "anon_a == anon_b?  #{anon_a == anon_b}"
IO.puts ":erlang.term_to_binary(anon_a) == :erlang.term_to_binary(anon_b)?  #{:erlang.term_to_binary(anon_a) == :erlang.term_to_binary(anon_b)}"

```

ends up producing:

```
a == b?  true
:erlang.term_to_binary(a) == :erlang.term_to_binary(b)?  true
anon_a == anon_b?  true
:erlang.term_to_binary(anon_a) == :erlang.term_to_binary(anon_b)?  false
```

---

I noticed this issue also happens with `Dataloader` / `Dataloader.Ecto` because of these anonymous functions:

https://github.com/absinthe-graphql/dataloader/blob/a61f550a28820d2befcd94411f7b03163f30db30/lib/dataloader/ecto.ex#L190-L191

(was able to workaround that on my end though, as I just provided non-anonymous functions for `query` and `run_batch` in my code)

---

@benwilson512 How do you feel about:

- Replacing `:crypto.hash(:sha256, :erlang.term_to_binary(blueprint)) |> Base.encode16()`? (maybe to ignore anonymous functions, or simply use the query's string representation, not sure)

and/or 

- Allowing projects to generate their own doc IDs?  I believe the project I work on could do some optimizations specific to our schema

I'd be happy to take on both of those tasks, just wanted to get your thoughts before I started on them