### PR TITLE
Adjust how subscription IDs are generated

### DIFF
--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -27,6 +27,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
       for field_key <- field_keys,
           do: Absinthe.Subscription.subscribe(pubsub, field_key, subscription_id, blueprint)
+
       {:replace, blueprint, [{Phase.Subscription.Result, topic: subscription_id}]}
     else
       {:error, error} ->
@@ -40,7 +41,11 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     end
   end
 
-  defp get_config(%{schema_node: schema_node, argument_data: argument_data} = field, context, blueprint) do
+  defp get_config(
+         %{schema_node: schema_node, argument_data: argument_data} = field,
+         context,
+         blueprint
+       ) do
     name = schema_node.identifier
 
     config =
@@ -86,6 +91,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
   defp get_field_keys(%{schema_node: schema_node} = _field, config) do
     name = schema_node.identifier
+
     find_field_keys!(config)
     |> Enum.map(fn key -> {name, key} end)
   end
@@ -147,7 +153,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
           |> :erlang.term_to_binary()
 
         :crypto.hash(:sha256, binary)
-        |> Base.encode16
+        |> Base.encode16()
 
       val ->
         val

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
     %{selections: [field]} = op
 
-    with {:ok, config} <- get_config(field, context) do
+    with {:ok, config} <- get_config(field, context, blueprint) do
       field_keys = get_field_keys(field, config)
       subscription_id = get_subscription_id(config, blueprint, options)
 
@@ -40,13 +40,13 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     end
   end
 
-  defp get_config(%{schema_node: schema_node, argument_data: argument_data} = field, context) do
+  defp get_config(%{schema_node: schema_node, argument_data: argument_data} = field, context, blueprint) do
     name = schema_node.identifier
 
     config =
       case Absinthe.Type.function(schema_node, :config) do
         fun when is_function(fun, 2) ->
-          apply(fun, [argument_data, %{context: context}])
+          apply(fun, [argument_data, %{context: context, document: blueprint}])
 
         fun when is_function(fun, 1) ->
           IO.write(

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -31,8 +31,6 @@ defmodule Absinthe.Schema.Notation do
   @doc """
   Configure a subscription field.
 
-  The returned topic can be single topic, or a list of topics
-
   ## Examples
 
   ```elixir
@@ -50,6 +48,18 @@ defmodule Absinthe.Schema.Notation do
   ```elixir
   config fn _, _ ->
     {:ok, topic: ["topic_one", "topic_two", "topic_three"]}
+  end
+  ```
+
+  Using `context_id` option to allow de-duplication of updates:
+
+  ```elixir
+  config fn _, %{context: context} ->
+    if authorized?(context) do
+      {:ok, topic: "topic_one", context_id: "authorized"}
+    else
+      {:ok, topic: "topic_one", context_id: "not-authorized"}
+    end
   end
   ```
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -124,6 +124,13 @@ defmodule Absinthe.Execution.SubscriptionTest do
             {:ok, topic: args[:id] || "*", context_id: context_id}
         end
       end
+
+      field :relies_on_document, :string do
+        config fn _, %{document: %Absinthe.Blueprint{} = document} ->
+          %{type: :subscription, name: op_name} = Absinthe.Blueprint.current_operation(document)
+          {:ok, topic: "*", context_id: "*", document_id: op_name}
+        end
+      end
     end
 
     mutation do
@@ -325,6 +332,15 @@ defmodule Absinthe.Execution.SubscriptionTest do
                variables: %{"clientId" => "abc"},
                context: %{pubsub: PubSub, authorized: false}
              )
+  end
+
+  @query """
+  subscription Example {
+    reliesOnDocument
+  }
+  """
+  test "topic function receives a document" do
+    assert {:ok, %{"subscribed" => _topic}} = run(@query, Schema, context: %{pubsub: PubSub})
   end
 
   @query """


### PR DESCRIPTION
First pass at the changes described in https://github.com/absinthe-graphql/absinthe/pull/652

If things look good, I'll go update all documentation, fix conflicts, etc.

I also need to add the blueprint to the resolution struct (https://github.com/absinthe-graphql/absinthe/pull/652#issuecomment-447462852)

---

Subscription IDs are now derived via a `context_id` option returned by a subscriptions `config` function, combined with the GraphQL document and any provided variables.

This gives library users more control over which subscription queries get merged.

If `context_id` is not provided, a unique integer is generated instead (to ensure we don't merge any queries by default).  

- We could also do the `:erlang.term_to_binary` + SHA256 hash dance on the `context` by default instead.  It _should_ be safe to merge subscriptions whose `context` is the same.. **Thoughts?**

Additionally, if one wants to override the default behaviour of combining the GraphQL document & provided variables to determine the `document_id`, they can return a `document_id` from the subscription's `config` function