### PR TITLE
Telemetry integration

### DIFF
--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -15,11 +15,12 @@ defmodule Absinthe.Blueprint do
             schema_definitions: [],
             schema: nil,
             adapter: nil,
-            telemetry: %{},
             # Added by phases
+            telemetry: %{},
             flags: %{},
             errors: [],
             input: nil,
+            source: nil,
             execution: %Blueprint.Execution{},
             result: %{}
 
@@ -31,10 +32,12 @@ defmodule Absinthe.Blueprint do
           fragments: [Blueprint.Document.Fragment.Named.t()],
           schema: nil | Absinthe.Schema.t(),
           adapter: nil | Absinthe.Adapter.t(),
-          telemetry: map(),
           # Added by phases
+          telemetry: map,
           errors: [Absinthe.Phase.Error.t()],
           flags: flags_t,
+          input: nil | Absinthe.Language.Document.t(),
+          source: nil | String.t() | Absinthe.Language.Source.t(),
           execution: Blueprint.Execution.t(),
           result: result_t
         }

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -15,6 +15,7 @@ defmodule Absinthe.Blueprint do
             schema_definitions: [],
             schema: nil,
             adapter: nil,
+            telemetry: %{},
             # Added by phases
             flags: %{},
             errors: [],
@@ -30,6 +31,7 @@ defmodule Absinthe.Blueprint do
           fragments: [Blueprint.Document.Fragment.Named.t()],
           schema: nil | Absinthe.Schema.t(),
           adapter: nil | Absinthe.Adapter.t(),
+          telemetry: map(),
           # Added by phases
           errors: [Absinthe.Phase.Error.t()],
           flags: flags_t,

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -2,34 +2,51 @@ defmodule Absinthe.Middleware.Telemetry do
   @moduledoc """
   Gather and report telemetry about an individual field resolution
   """
+  @telemetry_event_start [:absinthe, :resolve, :field, :start]
   @telemetry_event [:absinthe, :resolve, :field]
 
   @behaviour Absinthe.Middleware
 
   @impl Absinthe.Middleware
   def call(resolution, _) do
-    on_complete =
-      {{__MODULE__, :on_complete},
-       [
-         start_time: System.system_time(),
-         start_time_mono: System.monotonic_time(),
-         middleware: resolution.middleware
-       ]}
+    id = :erlang.unique_integer()
+    start_time = System.system_time()
+    start_time_mono = System.monotonic_time()
 
-    %{resolution | middleware: resolution.middleware ++ [on_complete]}
+    :telemetry.execute(@telemetry_event_start, %{start_time: start_time}, %{id: id})
+
+    %{
+      resolution
+      | middleware:
+          resolution.middleware ++
+            [
+              {{__MODULE__, :on_complete},
+               %{
+                 id: id,
+                 start_time: start_time,
+                 start_time_mono: start_time_mono,
+                 middleware: resolution.middleware
+               }}
+            ]
+    }
   end
 
-  def on_complete(%{state: :resolved} = resolution,
-        start_time: start_time,
-        start_time_mono: start_time_mono,
-        middleware: middleware
+  def on_complete(
+        %{state: :resolved} = resolution,
+        %{
+          id: id,
+          start_time: start_time,
+          start_time_mono: start_time_mono,
+          middleware: middleware
+        }
       ) do
+    end_time_mono = System.monotonic_time()
+
     :telemetry.execute(
       @telemetry_event,
+      %{duration: end_time_mono - start_time_mono},
       %{
-        duration: System.monotonic_time() - start_time_mono
-      },
-      %{
+        id: id,
         start_time: start_time,
         middleware: middleware,
         resolution: resolution

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -1,8 +1,8 @@
 defmodule Absinthe.Middleware.Telemetry do
   @moduledoc """
-  Gather and report telemetry about an individual resolver function
+  Gather and report telemetry about an individual field resolution
   """
-  @telemetry_event [:absinthe, :resolver]
+  @telemetry_event [:absinthe, :resolve, :field]
 
   @behaviour Absinthe.Middleware
 

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -2,8 +2,8 @@ defmodule Absinthe.Middleware.Telemetry do
   @moduledoc """
   Gather and report telemetry about an individual field resolution
   """
-  @telemetry_event_start [:absinthe, :resolve, :field, :start]
-  @telemetry_event [:absinthe, :resolve, :field]
+  @field_start [:absinthe, :resolve, :field, :start]
+  @field [:absinthe, :resolve, :field]
 
   @behaviour Absinthe.Middleware
 
@@ -13,7 +13,7 @@ defmodule Absinthe.Middleware.Telemetry do
     start_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
-    :telemetry.execute(@telemetry_event_start, %{start_time: start_time}, %{id: id})
+    :telemetry.execute(@field_start, %{start_time: start_time}, %{id: id})
 
     %{
       resolution
@@ -43,7 +43,7 @@ defmodule Absinthe.Middleware.Telemetry do
     end_time_mono = System.monotonic_time()
 
     :telemetry.execute(
-      @telemetry_event,
+      @field,
       %{duration: end_time_mono - start_time_mono},
       %{
         id: id,

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -7,24 +7,22 @@ defmodule Absinthe.Middleware.Telemetry do
   @behaviour Absinthe.Middleware
 
   @impl Absinthe.Middleware
-  def call(%{middleware: [{{Absinthe.Resolution, :call}, resolver_fun} | _]} = resolution, _) do
+  def call(resolution, _) do
     on_complete =
       {{__MODULE__, :on_complete},
        [
          start_time: System.system_time(),
          start_time_mono: System.monotonic_time(),
-         resolver_fun: resolver_fun
+         middleware: resolution.middleware
        ]}
 
     %{resolution | middleware: resolution.middleware ++ [on_complete]}
   end
 
-  def call(resolution, _config), do: resolution
-
   def on_complete(%{state: :resolved} = resolution,
         start_time: start_time,
         start_time_mono: start_time_mono,
-        resolver_fun: resolver_fun
+        middleware: middleware
       ) do
     :telemetry.execute(
       @telemetry_event,
@@ -33,7 +31,7 @@ defmodule Absinthe.Middleware.Telemetry do
       },
       %{
         start_time: start_time,
-        resolver_fun: resolver_fun,
+        middleware: middleware,
         resolution: resolution
       }
     )

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -1,0 +1,56 @@
+defmodule Absinthe.Middleware.Telemetry do
+  @moduledoc """
+  Gather and report telemetry about an individual resolver function
+  """
+  @telemetry_event [:absinthe, :resolver]
+
+  @behaviour Absinthe.Middleware
+
+  @impl Absinthe.Middleware
+  def call(%{middleware: [{{Absinthe.Resolution, :call}, resolver_fn} | _]} = res, _config) do
+    on_complete = [
+      {{__MODULE__, :on_complete},
+       [
+         start_time: System.system_time(),
+         start_time_mono: System.monotonic_time(),
+         resolver_fn: resolver_fn
+       ]}
+    ]
+
+    %{res | middleware: res.middleware ++ on_complete}
+  end
+
+  def call(res, _config), do: res
+
+  def on_complete(%{state: :resolved} = res,
+        start_time: start_time,
+        start_time_mono: start_time_mono,
+        resolver_fn: resolver_fn
+      ) do
+    :telemetry.execute(
+      @telemetry_event,
+      %{
+        start_time: start_time,
+        duration: System.monotonic_time() - start_time_mono
+      },
+      %{
+        schema: res.schema,
+        mfa: resolver_mfa(resolver_fn),
+        arguments: res.arguments,
+        path: Absinthe.Resolution.path(res),
+        field_name: res.definition.name,
+        field_type: Absinthe.Type.name(res.definition.schema_node.type, res.schema),
+        parent_type: res.parent_type.name
+      }
+    )
+
+    res
+  end
+
+  defp resolver_mfa({mod, fun}), do: {mod, fun, 3}
+
+  defp resolver_mfa(fun) when is_function(fun) do
+    info = :erlang.fun_info(fun)
+    {info[:module], info[:name], info[:arity]}
+  end
+end

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -7,50 +7,37 @@ defmodule Absinthe.Middleware.Telemetry do
   @behaviour Absinthe.Middleware
 
   @impl Absinthe.Middleware
-  def call(%{middleware: [{{Absinthe.Resolution, :call}, resolver_fn} | _]} = res, _config) do
-    on_complete = [
+  def call(%{middleware: [{{Absinthe.Resolution, :call}, resolver_fun} | _]} = resolution, _) do
+    on_complete =
       {{__MODULE__, :on_complete},
        [
          start_time: System.system_time(),
          start_time_mono: System.monotonic_time(),
-         resolver_fn: resolver_fn
+         resolver_fun: resolver_fun
        ]}
-    ]
 
-    %{res | middleware: res.middleware ++ on_complete}
+    %{resolution | middleware: resolution.middleware ++ [on_complete]}
   end
 
-  def call(res, _config), do: res
+  def call(resolution, _config), do: resolution
 
-  def on_complete(%{state: :resolved} = res,
+  def on_complete(%{state: :resolved} = resolution,
         start_time: start_time,
         start_time_mono: start_time_mono,
-        resolver_fn: resolver_fn
+        resolver_fun: resolver_fun
       ) do
     :telemetry.execute(
       @telemetry_event,
       %{
-        start_time: start_time,
         duration: System.monotonic_time() - start_time_mono
       },
       %{
-        schema: res.schema,
-        mfa: resolver_mfa(resolver_fn),
-        arguments: res.arguments,
-        path: Absinthe.Resolution.path(res),
-        field_name: res.definition.name,
-        field_type: Absinthe.Type.name(res.definition.schema_node.type, res.schema),
-        parent_type: res.parent_type.name
+        start_time: start_time,
+        resolver_fun: resolver_fun,
+        resolution: resolution
       }
     )
 
-    res
-  end
-
-  defp resolver_mfa({mod, fun}), do: {mod, fun, 3}
-
-  defp resolver_mfa(fun) when is_function(fun) do
-    info = :erlang.fun_info(fun)
-    {info[:module], info[:name], info[:arity]}
+    resolution
   end
 end

--- a/lib/absinthe/phase/document/variables.ex
+++ b/lib/absinthe/phase/document/variables.ex
@@ -46,16 +46,16 @@ defmodule Absinthe.Phase.Document.Variables do
   @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
   def run(input, options \\ []) do
     variables = options[:variables] || %{}
-    operations = update_operations(input, variables)
-    telemetry = put_in(input.telemetry, [:variables], variables)
-
-    {:ok, %{input | operations: operations, telemetry: telemetry}}
+    {:ok, update_operations(input, variables)}
   end
 
   def update_operations(input, variables) do
-    for op <- input.operations do
-      update_operation(op, variables)
-    end
+    operations =
+      for op <- input.operations do
+        update_operation(op, variables)
+      end
+
+    %{input | operations: operations}
   end
 
   def update_operation(%{variable_definitions: variable_definitions} = operation, variables) do

--- a/lib/absinthe/phase/document/variables.ex
+++ b/lib/absinthe/phase/document/variables.ex
@@ -46,16 +46,16 @@ defmodule Absinthe.Phase.Document.Variables do
   @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
   def run(input, options \\ []) do
     variables = options[:variables] || %{}
-    {:ok, update_operations(input, variables)}
+    operations = update_operations(input, variables)
+    telemetry = put_in(input.telemetry, [:variables], variables)
+
+    {:ok, %{input | operations: operations, telemetry: telemetry}}
   end
 
   def update_operations(input, variables) do
-    operations =
-      for op <- input.operations do
-        update_operation(op, variables)
-      end
-
-    %{input | operations: operations}
+    for op <- input.operations do
+      update_operation(op, variables)
+    end
   end
 
   def update_operation(%{variable_definitions: variable_definitions} = operation, variables) do

--- a/lib/absinthe/phase/init.ex
+++ b/lib/absinthe/phase/init.ex
@@ -1,0 +1,12 @@
+defmodule Absinthe.Phase.Init do
+  @moduledoc false
+
+  use Absinthe.Phase
+
+  alias Absinthe.{Blueprint, Language, Phase}
+
+  @spec run(Language.Source.t(), Keyword.t()) :: Phase.result_t()
+  def run(input, _options \\ []) do
+    {:ok, %Blueprint{input: input}}
+  end
+end

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -23,7 +23,13 @@ defmodule Absinthe.Phase.Parse do
   end
 
   def run(input, options) do
-    run(%Absinthe.Blueprint{input: input}, options)
+    telemetry = %{
+      start_time: System.system_time(),
+      start_time_mono: System.monotonic_time(),
+      source: input
+    }
+
+    run(%Absinthe.Blueprint{input: input, telemetry: telemetry}, options)
   end
 
   defp add_validation_error(bp, error) do

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -25,11 +25,10 @@ defmodule Absinthe.Phase.Parse do
   def run(input, options) do
     telemetry = %{
       start_time: System.system_time(),
-      start_time_mono: System.monotonic_time(),
-      source: input
+      start_time_mono: System.monotonic_time()
     }
 
-    run(%Absinthe.Blueprint{input: input, telemetry: telemetry}, options)
+    run(%Absinthe.Blueprint{input: input, source: input, telemetry: telemetry}, options)
   end
 
   defp add_validation_error(bp, error) do

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -24,12 +24,7 @@ defmodule Absinthe.Phase.Parse do
   end
 
   def run(input, options) do
-    telemetry = %{
-      start_time: System.system_time(),
-      start_time_mono: System.monotonic_time()
-    }
-
-    run(%Absinthe.Blueprint{input: input, source: input, telemetry: telemetry}, options)
+    run(%Absinthe.Blueprint{input: input}, options)
   end
 
   defp add_validation_error(bp, error) do

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -5,7 +5,8 @@ defmodule Absinthe.Phase.Parse do
 
   alias Absinthe.{Language, Phase}
 
-  @spec run(Language.Source.t(), Keyword.t()) :: Phase.result_t()
+  @type input_t :: Language.Source.t() | Blueprint.t()
+  @spec run(input_t, Keyword.t()) :: Phase.result_t()
   def run(input, options \\ [])
 
   def run(%Absinthe.Blueprint{} = blueprint, options) do

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -28,7 +28,8 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
       for field_key <- field_keys,
           do: Absinthe.Subscription.subscribe(pubsub, field_key, subscription_id, blueprint)
 
-      {:replace, blueprint, [{Phase.Subscription.Result, topic: subscription_id}]}
+      {:replace, blueprint,
+       [{Phase.Subscription.Result, topic: subscription_id}, {Phase.Telemetry, options}]}
     else
       {:error, error} ->
         blueprint = update_in(blueprint.execution.validation_errors, &[error | &1])

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -29,7 +29,10 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
           do: Absinthe.Subscription.subscribe(pubsub, field_key, subscription_id, blueprint)
 
       {:replace, blueprint,
-       [{Phase.Subscription.Result, topic: subscription_id}, {Phase.Telemetry, options}]}
+       [
+         {Phase.Subscription.Result, topic: subscription_id},
+         {Phase.Telemetry, [:execute, :operation, options]}
+       ]}
     else
       {:error, error} ->
         blueprint = update_in(blueprint.execution.validation_errors, &[error | &1])

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -1,0 +1,34 @@
+defmodule Absinthe.Phase.Telemetry do
+  @moduledoc """
+  Gather and report telemetry about a pipeline.
+  """
+  @telemetry_event [:absinthe, :query]
+
+  use Absinthe.Phase
+
+  def run(blueprint, _options \\ []) do
+    with %{start_time: start_time, start_time_mono: start_time_mono} <- blueprint.telemetry,
+         %{emitter: operation} <- blueprint.execution.result do
+      :telemetry.execute(
+        @telemetry_event,
+        %{
+          start_time: start_time,
+          duration: System.monotonic_time() - start_time_mono
+        },
+        %{
+          query: query(blueprint.telemetry.source),
+          schema: blueprint.schema,
+          variables: blueprint.telemetry.variables,
+          operation_complexity: operation.complexity,
+          operation_type: operation.type,
+          operation_name: operation.name
+        }
+      )
+    end
+
+    {:ok, blueprint}
+  end
+
+  defp query(%Absinthe.Language.Source{body: query}), do: query
+  defp query(query), do: query
+end

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -1,8 +1,8 @@
 defmodule Absinthe.Phase.Telemetry do
   @moduledoc """
-  Gather and report telemetry about a pipeline.
+  Gather and report telemetry about an operation.
   """
-  @telemetry_event [:absinthe, :query]
+  @telemetry_event [:absinthe, :execute, :operation]
 
   use Absinthe.Phase
 

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -6,29 +6,21 @@ defmodule Absinthe.Phase.Telemetry do
 
   use Absinthe.Phase
 
-  def run(blueprint, _options \\ []) do
-    with %{start_time: start_time, start_time_mono: start_time_mono} <- blueprint.telemetry,
-         %{emitter: operation} <- blueprint.execution.result do
+  def run(blueprint, options) do
+    with %{start_time: start_time, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(
         @telemetry_event,
         %{
-          start_time: start_time,
           duration: System.monotonic_time() - start_time_mono
         },
         %{
-          query: query(blueprint.telemetry.source),
-          schema: blueprint.schema,
-          variables: blueprint.telemetry.variables,
-          operation_complexity: operation.complexity,
-          operation_type: operation.type,
-          operation_name: operation.name
+          start_time: start_time,
+          blueprint: blueprint,
+          options: options
         }
       )
     end
 
     {:ok, blueprint}
   end
-
-  defp query(%Absinthe.Language.Source{body: query}), do: query
-  defp query(query), do: query
 end

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -2,27 +2,35 @@ defmodule Absinthe.Phase.Telemetry do
   @moduledoc """
   Gather and report telemetry about an operation.
   """
+  @telemetry_event_start [:absinthe, :execute, :operation, :start]
   @telemetry_event [:absinthe, :execute, :operation]
 
   use Absinthe.Phase
 
   def run(blueprint, [:start]) do
-    telemetry = %{
-      start_time: System.system_time(),
-      start_time_mono: System.monotonic_time()
-    }
+    id = :erlang.unique_integer()
+    start_time = System.system_time()
+    start_time_mono = System.monotonic_time()
 
-    {:ok, %{blueprint | source: blueprint.input, telemetry: telemetry}}
+    :telemetry.execute(@telemetry_event_start, %{start_time: start_time}, %{id: id})
+
+    {:ok,
+     %{
+       blueprint
+       | source: blueprint.input,
+         telemetry: %{id: id, start_time: start_time, start_time_mono: start_time_mono}
+     }}
   end
 
-  def run(blueprint, options) do
-    with %{start_time: start_time, start_time_mono: start_time_mono} <- blueprint.telemetry do
+  def run(%{telemetry: telemetry} = blueprint, options) do
+    end_time_mono = System.monotonic_time()
+
+    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <- telemetry do
       :telemetry.execute(
         @telemetry_event,
+        %{duration: end_time_mono - start_time_mono},
         %{
-          duration: System.monotonic_time() - start_time_mono
-        },
-        %{
+          id: id,
           start_time: start_time,
           blueprint: blueprint,
           options: options

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -2,20 +2,20 @@ defmodule Absinthe.Phase.Telemetry do
   @moduledoc """
   Gather and report telemetry about an operation.
   """
-  @telemetry_event_start [:absinthe, :execute, :operation, :start]
-  @telemetry_event [:absinthe, :execute, :operation]
+  @operation_start [:absinthe, :execute, :operation, :start]
+  @operation [:absinthe, :execute, :operation]
 
-  @telemetry_event_subscription_start [:absinthe, :subscription, :publish, :start]
-  @telemetry_event_subscription [:absinthe, :subscription, :publish]
+  @subscription_start [:absinthe, :subscription, :publish, :start]
+  @subscription [:absinthe, :subscription, :publish]
 
   use Absinthe.Phase
 
-  def run(blueprint, [:start]) do
+  def run(blueprint, [:execute, :operation, :start]) do
     id = :erlang.unique_integer()
     start_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
-    :telemetry.execute(@telemetry_event_start, %{start_time: start_time}, %{id: id})
+    :telemetry.execute(@operation_start, %{start_time: start_time}, %{id: id})
 
     {:ok,
      %{
@@ -29,12 +29,12 @@ defmodule Absinthe.Phase.Telemetry do
      }}
   end
 
-  def run(blueprint, [:subscription, :start]) do
+  def run(blueprint, [:subscription, :publish, :start]) do
     id = :erlang.unique_integer()
     start_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
-    :telemetry.execute(@telemetry_event_subscription_start, %{start_time: start_time}, %{id: id})
+    :telemetry.execute(@subscription_start, %{start_time: start_time}, %{id: id})
 
     {:ok,
      %{
@@ -53,7 +53,7 @@ defmodule Absinthe.Phase.Telemetry do
     with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
            blueprint.telemetry do
       :telemetry.execute(
-        @telemetry_event_subscription,
+        @subscription,
         %{duration: end_time_mono - start_time_mono},
         %{
           id: id,
@@ -66,13 +66,13 @@ defmodule Absinthe.Phase.Telemetry do
     {:ok, blueprint}
   end
 
-  def run(blueprint, options) do
+  def run(blueprint, [:execute, :operation, options]) do
     end_time_mono = System.monotonic_time()
 
     with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
            blueprint.telemetry do
       :telemetry.execute(
-        @telemetry_event,
+        @operation,
         %{duration: end_time_mono - start_time_mono},
         %{
           id: id,

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -6,6 +6,15 @@ defmodule Absinthe.Phase.Telemetry do
 
   use Absinthe.Phase
 
+  def run(blueprint, [:start]) do
+    telemetry = %{
+      start_time: System.system_time(),
+      start_time_mono: System.monotonic_time()
+    }
+
+    {:ok, %{blueprint | source: blueprint.input, telemetry: telemetry}}
+  end
+
   def run(blueprint, options) do
     with %{start_time: start_time, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -5,6 +5,9 @@ defmodule Absinthe.Phase.Telemetry do
   @telemetry_event_start [:absinthe, :execute, :operation, :start]
   @telemetry_event [:absinthe, :execute, :operation]
 
+  @telemetry_event_subscription_start [:absinthe, :subscription, :publish, :start]
+  @telemetry_event_subscription [:absinthe, :subscription, :publish]
+
   use Absinthe.Phase
 
   def run(blueprint, [:start]) do
@@ -18,14 +21,56 @@ defmodule Absinthe.Phase.Telemetry do
      %{
        blueprint
        | source: blueprint.input,
-         telemetry: %{id: id, start_time: start_time, start_time_mono: start_time_mono}
+         telemetry: %{
+           id: id,
+           start_time: start_time,
+           start_time_mono: start_time_mono
+         }
      }}
   end
 
-  def run(%{telemetry: telemetry} = blueprint, options) do
+  def run(blueprint, [:subscription, :start]) do
+    id = :erlang.unique_integer()
+    start_time = System.system_time()
+    start_time_mono = System.monotonic_time()
+
+    :telemetry.execute(@telemetry_event_subscription_start, %{start_time: start_time}, %{id: id})
+
+    {:ok,
+     %{
+       blueprint
+       | telemetry: %{
+           id: id,
+           start_time: start_time,
+           start_time_mono: start_time_mono
+         }
+     }}
+  end
+
+  def run(blueprint, [:subscription, :publish]) do
     end_time_mono = System.monotonic_time()
 
-    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <- telemetry do
+    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
+           blueprint.telemetry do
+      :telemetry.execute(
+        @telemetry_event_subscription,
+        %{duration: end_time_mono - start_time_mono},
+        %{
+          id: id,
+          start_time: start_time,
+          blueprint: blueprint
+        }
+      )
+    end
+
+    {:ok, blueprint}
+  end
+
+  def run(blueprint, options) do
+    end_time_mono = System.monotonic_time()
+
+    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
+           blueprint.telemetry do
       :telemetry.execute(
         @telemetry_event,
         %{duration: end_time_mono - start_time_mono},

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -104,7 +104,8 @@ defmodule Absinthe.Pipeline do
       {Phase.Subscription.SubscribeSelf, options},
       {Phase.Document.Execution.Resolution, options},
       # Format Result
-      Phase.Document.Result
+      Phase.Document.Result,
+      Phase.Telemetry
     ]
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -46,6 +46,7 @@ defmodule Absinthe.Pipeline do
     [
       # Parse Document
       Phase.Init,
+      {Phase.Telemetry, [:start]},
       {Phase.Parse, options},
       # Convert to Blueprint
       {Phase.Blueprint, options},

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -105,7 +105,7 @@ defmodule Absinthe.Pipeline do
       {Phase.Document.Execution.Resolution, options},
       # Format Result
       Phase.Document.Result,
-      Phase.Telemetry
+      {Phase.Telemetry, options}
     ]
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -46,7 +46,7 @@ defmodule Absinthe.Pipeline do
     [
       # Parse Document
       Phase.Init,
-      {Phase.Telemetry, [:start]},
+      {Phase.Telemetry, [:execute, :operation, :start]},
       {Phase.Parse, options},
       # Convert to Blueprint
       {Phase.Blueprint, options},
@@ -107,7 +107,7 @@ defmodule Absinthe.Pipeline do
       {Phase.Document.Execution.Resolution, options},
       # Format Result
       Phase.Document.Result,
-      {Phase.Telemetry, options}
+      {Phase.Telemetry, [:execute, :operation, options]}
     ]
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -45,6 +45,7 @@ defmodule Absinthe.Pipeline do
 
     [
       # Parse Document
+      Phase.Init,
       {Phase.Parse, options},
       # Convert to Blueprint
       {Phase.Blueprint, options},

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -25,8 +25,9 @@ defmodule Absinthe.Pipeline.BatchResolver do
     }
 
     resolution_phase = {Execution.Resolution, [plugin_callbacks: false] ++ options}
+    resolution_phases = [{Absinthe.Phase.Telemetry, [:start]}, resolution_phase]
 
-    do_resolve(blueprints, [resolution_phase], exec, plugins, resolution_phase, options)
+    do_resolve(blueprints, resolution_phases, exec, plugins, resolution_phase, options)
   end
 
   defp init(blueprints, attr) do

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -1,5 +1,6 @@
 defmodule Absinthe.Pipeline.BatchResolver do
   alias Absinthe.Phase.Document.Execution
+  alias Absinthe.Phase
 
   require Logger
 
@@ -25,7 +26,7 @@ defmodule Absinthe.Pipeline.BatchResolver do
     }
 
     resolution_phase = {Execution.Resolution, [plugin_callbacks: false] ++ options}
-    resolution_phases = [{Absinthe.Phase.Telemetry, [:subscription, :start]}, resolution_phase]
+    resolution_phases = [{Phase.Telemetry, [:subscription, :publish, :start]}, resolution_phase]
 
     do_resolve(blueprints, resolution_phases, exec, plugins, resolution_phase, options)
   end
@@ -33,8 +34,6 @@ defmodule Absinthe.Pipeline.BatchResolver do
   defp init(blueprints, attr) do
     Enum.reduce(blueprints, %{}, &Map.merge(Map.fetch!(&1.execution, attr), &2))
   end
-
-  # defp update()
 
   defp do_resolve(blueprints, phases, exec, plugins, resolution_phase_template, options) do
     exec =

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -25,7 +25,7 @@ defmodule Absinthe.Pipeline.BatchResolver do
     }
 
     resolution_phase = {Execution.Resolution, [plugin_callbacks: false] ++ options}
-    resolution_phases = [{Absinthe.Phase.Telemetry, [:start]}, resolution_phase]
+    resolution_phases = [{Absinthe.Phase.Telemetry, [:subscription, :start]}, resolution_phase]
 
     do_resolve(blueprints, resolution_phases, exec, plugins, resolution_phase, options)
   end

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -1,6 +1,5 @@
 defmodule Absinthe.Pipeline.BatchResolver do
   alias Absinthe.Phase.Document.Execution
-  alias Absinthe.Phase
 
   require Logger
 
@@ -9,6 +8,7 @@ defmodule Absinthe.Pipeline.BatchResolver do
   def run([], _), do: []
 
   def run([bp | _] = blueprints, options) do
+    {initial_phases, options} = Keyword.pop(options, :initial_phases, [])
     schema = Keyword.fetch!(options, :schema)
     plugins = schema.plugins()
 
@@ -25,10 +25,10 @@ defmodule Absinthe.Pipeline.BatchResolver do
         result: nil
     }
 
-    resolution_phase = {Execution.Resolution, [plugin_callbacks: false] ++ options}
-    resolution_phases = [{Phase.Telemetry, [:subscription, :publish, :start]}, resolution_phase]
+    resolution_phase = [{Execution.Resolution, [plugin_callbacks: false] ++ options}]
+    phases = initial_phases ++ [resolution_phase]
 
-    do_resolve(blueprints, resolution_phases, exec, plugins, resolution_phase, options)
+    do_resolve(blueprints, phases, exec, plugins, resolution_phase, options)
   end
 
   defp init(blueprints, attr) do

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -536,6 +536,7 @@ defmodule Absinthe.Schema.Notation do
     |> recordable!(:resolve, @placement[:resolve])
 
     quote do
+      meta :absinthe_telemetry, true
       middleware Absinthe.Resolution, unquote(func_ast)
     end
   end
@@ -1684,8 +1685,12 @@ defmodule Absinthe.Schema.Notation do
     [{Absinthe.Middleware.MapGet, identifier}]
   end
 
-  def __ensure_middleware__(middleware, _field, _object) do
-    middleware
+  def __ensure_middleware__(middleware, field, _object) do
+    if Absinthe.Type.meta(field, :absinthe_telemetry) do
+      [{Absinthe.Middleware.Telemetry, []} | middleware]
+    else
+      middleware
+    end
   end
 
   defp reverse_with_descs(attrs, descs, acc \\ [])

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -48,7 +48,7 @@ defmodule Absinthe.Subscription.Local do
 
     pipeline = [
       Absinthe.Phase.Document.Result,
-      {Absinthe.Phase.Telemetry, []}
+      {Absinthe.Phase.Telemetry, [:subscription, :publish]}
     ]
 
     for {doc, {topic, key_strategy}} <- Enum.zip(docs, topics), doc != :error do

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -47,7 +47,8 @@ defmodule Absinthe.Subscription.Local do
     docs = BatchResolver.run(docs, schema: hd(docs).schema, abort_on_error: false)
 
     pipeline = [
-      Absinthe.Phase.Document.Result
+      Absinthe.Phase.Document.Result,
+      {Absinthe.Phase.Telemetry, []}
     ]
 
     for {doc, {topic, key_strategy}} <- Enum.zip(docs, topics), doc != :error do

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -44,7 +44,13 @@ defmodule Absinthe.Subscription.Local do
 
   defp run_docset(pubsub, docs_and_topics) do
     {topics, docs} = Enum.unzip(docs_and_topics)
-    docs = BatchResolver.run(docs, schema: hd(docs).schema, abort_on_error: false)
+
+    docs =
+      BatchResolver.run(docs,
+        schema: hd(docs).schema,
+        abort_on_error: false,
+        initial_phases: [{Absinthe.Phase.Telemetry, [:subscription, :publish, :start]}]
+      )
 
     pipeline = [
       Absinthe.Phase.Document.Result,

--- a/mix.exs
+++ b/mix.exs
@@ -58,17 +58,18 @@ defmodule Absinthe.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do
     [
-      {:benchee, ">= 0.0.0", only: :dev},
       {:nimble_parsec, "~> 0.4"},
+      {:telemetry, "~> 0.4.0"},
       {:dataloader, "~> 1.0.0", optional: true},
-      {:ex_doc, "~> 0.20", only: :dev},
-      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev], runtime: false},
       {:decimal, "~> 1.0", optional: true},
+      {:ex_doc, "~> 0.20", only: :dev},
+      {:benchee, ">= 0.0.0", only: :dev},
+      {:dialyxir, "~> 1.0.0-rc.6", only: [:dev], runtime: false},
       {:phoenix_pubsub, ">= 0.0.0", only: :test},
       {:mix_test_watch, "~> 0.4.1", only: [:test, :dev]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -16,4 +16,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.4.1", "a98a84c795623f1ba020324f4354cf30e7120ba4dab65f9c2ae300f830a25f75", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.0", "d55e25ff1ff8ea2f9964638366dfd6e361c52dedfd50019353598d11d4441d14", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/absinthe/integration/execution/telemetry_test.exs
+++ b/test/absinthe/integration/execution/telemetry_test.exs
@@ -5,8 +5,8 @@ defmodule Elixir.Absinthe.Integration.Execution.TelemetryTest do
     :telemetry.attach_many(
       context.test,
       [
-        [:absinthe, :resolver],
-        [:absinthe, :query]
+        [:absinthe, :resolve, :field],
+        [:absinthe, :execute, :operation]
       ],
       &__MODULE__.handle_event/4,
       %{}
@@ -57,22 +57,22 @@ defmodule Elixir.Absinthe.Integration.Execution.TelemetryTest do
     {:ok, %{data: data}} = Absinthe.run(query, TestSchema, variables: %{"echo" => "ASYNC"})
     assert %{"asyncThing" => "ASYNC", "objectThing" => %{"name" => "Foo"}} == data
 
-    assert_receive {[:absinthe, :query], measurements, meta, _config}
+    assert_receive {[:absinthe, :execute, :operation], measurements, meta, _config}
 
     assert is_number(measurements[:duration])
     assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
     assert %Absinthe.Blueprint{} = meta[:blueprint]
     assert meta[:options][:schema] == TestSchema
 
-    assert_receive {[:absinthe, :resolver], measurements, meta, _}
+    assert_receive {[:absinthe, :resolve, :field], measurements, meta, _}
 
     assert is_number(measurements[:duration])
     assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
     assert %Absinthe.Resolution{} = meta[:resolution]
     assert is_list(meta[:middleware])
 
-    assert_receive {[:absinthe, :resolver], _, _, _}
+    assert_receive {[:absinthe, :resolve, :field], _, _, _}
     # Don't execute for resolvers that don't call a resolver function (ie: default `Map.get`)
-    refute_receive {[:absinthe, :resolver], _, _, _}
+    refute_receive {[:absinthe, :resolve, :field], _, _, _}
   end
 end

--- a/test/absinthe/integration/execution/telemetry_test.exs
+++ b/test/absinthe/integration/execution/telemetry_test.exs
@@ -1,0 +1,91 @@
+defmodule Elixir.Absinthe.Integration.Execution.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  setup context do
+    :telemetry.attach_many(
+      context.test,
+      [
+        [:absinthe, :resolver],
+        [:absinthe, :query]
+      ],
+      &__MODULE__.handle_event/4,
+      %{}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach(context.test)
+    end)
+
+    :ok
+  end
+
+  def handle_event(event, measurements, metadata, config) do
+    send(self(), {event, measurements, metadata, config})
+  end
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+
+    object :object_thing do
+      field :name, :string
+    end
+
+    query do
+      field :object_thing, :object_thing do
+        resolve fn _, _, _ -> {:ok, %{name: "Foo"}} end
+      end
+
+      field :async_thing, :string do
+        arg :echo, :string
+        resolve &TestSchema.resolve_async/3
+      end
+    end
+
+    def resolve_async(_, %{echo: echo}, _) do
+      async(fn -> {:ok, echo} end)
+    end
+  end
+
+  test "Execute expected telemetry events" do
+    query = """
+    query CustomOperationName ($echo: String!) {
+      asyncThing(echo: $echo)
+      objectThing { name }
+    }
+    """
+
+    {:ok, %{data: data}} =
+      Absinthe.run(query, TestSchema, analyze_complexity: true, variables: %{"echo" => "ASYNC"})
+
+    assert %{"asyncThing" => "ASYNC", "objectThing" => %{"name" => "Foo"}} == data
+
+    assert_receive {[:absinthe, :query], measurements, meta, _config}
+
+    assert measurements[:duration] |> is_number()
+    assert System.convert_time_unit(measurements[:start_time], :native, :millisecond)
+    assert meta[:query] == query
+    assert meta[:variables]["echo"] == "ASYNC"
+    assert meta[:schema] == TestSchema
+    assert meta[:operation_complexity] == 3
+    assert meta[:operation_type] == :query
+    assert meta[:operation_name] == "CustomOperationName"
+
+    assert_receive {[:absinthe, :resolver], measurements, %{path: ["asyncThing"]} = meta, _}
+
+    assert measurements[:duration] |> is_number()
+    assert System.convert_time_unit(measurements[:start_time], :native, :millisecond)
+    assert meta[:path] == ["asyncThing"]
+    assert meta[:schema] == TestSchema
+    assert meta[:arguments][:echo] == "ASYNC"
+    assert meta[:mfa] == {TestSchema, :resolve_async, 3}
+    assert meta[:path] |> is_list()
+    assert meta[:field_name] == "asyncThing"
+    assert meta[:field_type] == "String"
+    assert meta[:parent_type] == "RootQueryType"
+
+    assert_receive {[:absinthe, :resolver], _, %{path: ["objectThing"]}, _}
+
+    # Don't execute for resolvers that don't call a resolver function (ie: default `Map.get`)
+    refute_receive {[:absinthe, :resolver], _, %{path: ["objectThing", "name"]}, _}
+  end
+end

--- a/test/absinthe/integration/execution/telemetry_test.exs
+++ b/test/absinthe/integration/execution/telemetry_test.exs
@@ -54,25 +54,24 @@ defmodule Elixir.Absinthe.Integration.Execution.TelemetryTest do
     }
     """
 
-    {:ok, %{data: data}} =
-      Absinthe.run(query, TestSchema, analyze_complexity: true, variables: %{"echo" => "ASYNC"})
-
+    {:ok, %{data: data}} = Absinthe.run(query, TestSchema, variables: %{"echo" => "ASYNC"})
     assert %{"asyncThing" => "ASYNC", "objectThing" => %{"name" => "Foo"}} == data
 
     assert_receive {[:absinthe, :query], measurements, meta, _config}
 
-    assert measurements[:duration] |> is_number()
+    assert is_number(measurements[:duration])
     assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
     assert %Absinthe.Blueprint{} = meta[:blueprint]
     assert meta[:options][:schema] == TestSchema
 
-    assert_receive {[:absinthe, :resolver], _, _, _}
     assert_receive {[:absinthe, :resolver], measurements, meta, _}
 
-    assert measurements[:duration] |> is_number()
+    assert is_number(measurements[:duration])
     assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
     assert %Absinthe.Resolution{} = meta[:resolution]
+    assert is_list(meta[:middleware])
 
+    assert_receive {[:absinthe, :resolver], _, _, _}
     # Don't execute for resolvers that don't call a resolver function (ie: default `Map.get`)
     refute_receive {[:absinthe, :resolver], _, _, _}
   end

--- a/test/absinthe/integration/execution/telemetry_test.exs
+++ b/test/absinthe/integration/execution/telemetry_test.exs
@@ -62,30 +62,18 @@ defmodule Elixir.Absinthe.Integration.Execution.TelemetryTest do
     assert_receive {[:absinthe, :query], measurements, meta, _config}
 
     assert measurements[:duration] |> is_number()
-    assert System.convert_time_unit(measurements[:start_time], :native, :millisecond)
-    assert meta[:query] == query
-    assert meta[:variables]["echo"] == "ASYNC"
-    assert meta[:schema] == TestSchema
-    assert meta[:operation_complexity] == 3
-    assert meta[:operation_type] == :query
-    assert meta[:operation_name] == "CustomOperationName"
+    assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
+    assert %Absinthe.Blueprint{} = meta[:blueprint]
+    assert meta[:options][:schema] == TestSchema
 
-    assert_receive {[:absinthe, :resolver], measurements, %{path: ["asyncThing"]} = meta, _}
+    assert_receive {[:absinthe, :resolver], _, _, _}
+    assert_receive {[:absinthe, :resolver], measurements, meta, _}
 
     assert measurements[:duration] |> is_number()
-    assert System.convert_time_unit(measurements[:start_time], :native, :millisecond)
-    assert meta[:path] == ["asyncThing"]
-    assert meta[:schema] == TestSchema
-    assert meta[:arguments][:echo] == "ASYNC"
-    assert meta[:mfa] == {TestSchema, :resolve_async, 3}
-    assert meta[:path] |> is_list()
-    assert meta[:field_name] == "asyncThing"
-    assert meta[:field_type] == "String"
-    assert meta[:parent_type] == "RootQueryType"
-
-    assert_receive {[:absinthe, :resolver], _, %{path: ["objectThing"]}, _}
+    assert System.convert_time_unit(meta[:start_time], :native, :millisecond)
+    assert %Absinthe.Resolution{} = meta[:resolution]
 
     # Don't execute for resolvers that don't call a resolver function (ie: default `Map.get`)
-    refute_receive {[:absinthe, :resolver], _, %{path: ["objectThing", "name"]}, _}
+    refute_receive {[:absinthe, :resolver], _, _, _}
   end
 end

--- a/test/absinthe/phase/schema/inline_functions_test.exs
+++ b/test/absinthe/phase/schema/inline_functions_test.exs
@@ -41,17 +41,15 @@ defmodule Absinthe.Phase.Schema.InlineFunctionsTest do
 
   describe "resolvers and middleware" do
     test "are inlined when they are a literal external function", %{bp: bp} do
-      assert [
-               {{Absinthe.Resolution, :call}, &Schema.foo/3}
-             ] == get_field(bp, :inlined, :direct).middleware
+      assert {{Absinthe.Resolution, :call}, &Schema.foo/3} in get_field(bp, :inlined, :direct).middleware
 
-      assert [
-               {{Absinthe.Resolution, :call}, &Schema.foo/3}
-             ] == get_field(bp, :inlined, :indirect).middleware
+      assert {{Absinthe.Resolution, :call}, &Schema.foo/3} in get_field(bp, :inlined, :indirect).middleware
 
-      assert [
-               {{Absinthe.Resolution, :call}, &Schema.foo/3}
-             ] == get_field(bp, :inlined, :via_callback).middleware
+      assert {{Absinthe.Resolution, :call}, &Schema.foo/3} in get_field(
+               bp,
+               :inlined,
+               :via_callback
+             ).middleware
     end
 
     test "aren't inlined if they're a local capture", %{bp: bp} do

--- a/test/absinthe/pipeline_test.exs
+++ b/test/absinthe/pipeline_test.exs
@@ -21,7 +21,8 @@ defmodule Absinthe.PipelineTest do
         Pipeline.for_document(Schema)
         |> Pipeline.upto(Phase.Blueprint)
 
-      assert {:ok, %Blueprint{}, [Phase.Blueprint, Phase.Parse]} = Pipeline.run(@query, pipeline)
+      assert {:ok, %Blueprint{}, [Phase.Blueprint, Phase.Parse, Phase.Init]} =
+               Pipeline.run(@query, pipeline)
     end
   end
 

--- a/test/absinthe/pipeline_test.exs
+++ b/test/absinthe/pipeline_test.exs
@@ -21,7 +21,7 @@ defmodule Absinthe.PipelineTest do
         Pipeline.for_document(Schema)
         |> Pipeline.upto(Phase.Blueprint)
 
-      assert {:ok, %Blueprint{}, [Phase.Blueprint, Phase.Parse, Phase.Init]} =
+      assert {:ok, %Blueprint{}, [Phase.Blueprint, Phase.Parse, Phase.Telemetry, Phase.Init]} =
                Pipeline.run(@query, pipeline)
     end
   end


### PR DESCRIPTION
This PR builds out [Telemetry](https://github.com/beam-telemetry/telemetry) integration for Absinthe.

This integration executes the following events:

* `[:absinthe, :execute, :operation]` Upon completion of the entire operation pipeline
* `[:absinthe, :resolve, :field]` Upon completion of each defined resolver function call
* `[:absinthe, :subscription, :publish]` Upon publication in a subscription

To aid in tracing, we also execute events at the start of each of these ^:

* `[:absinthe, :execute, :operation, :start]`
* `[:absinthe, :resolve, :field, :start]`
* `[:absinthe, :subscription, :publish, :start]`

Notes:

* The default `Map.get` resolver doesn't execute events

closes #662 
