### PR TITLE
Fix exception in introspection types

### DIFF
--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -525,4 +525,15 @@ defmodule Absinthe.IntrospectionTest do
       )
     end
   end
+
+  test "Doesn't fail for unknown introspection fields" do
+    """
+    {
+      __foobar {
+        baz
+      }
+    }
+    """
+    |> run(Absinthe.Fixtures.ContactSchema)
+  end
 end


### PR DESCRIPTION
Howdy folks, a security scan found this bug, it causes a request failure if someone tries a non-existent introspection field like `__foobar`