### PR TITLE
Allow capital camel case in LanguageConventions adapter

### DIFF
--- a/lib/absinthe/adapter/language_conventions.ex
+++ b/lib/absinthe/adapter/language_conventions.ex
@@ -59,6 +59,10 @@ defmodule Absinthe.Adapter.LanguageConventions do
     camelized_name
   end
 
+  def to_internal_name(<<c::utf8, rest::binary>>, _) when c in ?A..?Z do
+    <<c>> <> Macro.underscore(rest)
+  end
+
   def to_internal_name(camelized_name, _role) do
     camelized_name
     |> Macro.underscore()

--- a/test/absinthe/adapters/language_conventions_test.exs
+++ b/test/absinthe/adapters/language_conventions_test.exs
@@ -11,6 +11,10 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
     test "converts external camelcase variable names to underscore" do
       assert "foo_bar" = LanguageConventions.to_internal_name("fooBar", :variable)
     end
+
+    test "converts capitalized camelcase to capitalized underscore" do
+      assert "Foo_bar" = LanguageConventions.to_internal_name("FooBar", :field)
+    end
   end
 
   describe "to_external_name/2" do


### PR DESCRIPTION
The GraphQL client I'm using has a convention where some of the requested fields are capitalized camel case ("MyBackendResource"). Since it is difficult for me to change the client code convention for this, I created a new adapter that allows a capitalized field in absinthe like this:

```
query name: "Query" do
  field :My_backend_resource, :my_backend_resource do
  ... 
```

Then it seemed to me like this is probably acceptable behavior for the `LanguageConventions` adapter. Let me know if its okay to add this in or if you have any questions.