### PR TITLE
Better unicode support in strings

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -83,7 +83,7 @@ defmodule Absinthe do
           root_value: term,
           operation_name: String.t(),
           analyze_complexity: boolean,
-          variables: %{optional(String.t) => any()},
+          variables: %{optional(String.t()) => any()},
           max_complexity: non_neg_integer | :infinity
         ]
 

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -205,8 +205,10 @@ defmodule Absinthe.Lexer do
     |> traverse({:string_value_token, []})
 
   block_string_value =
-    ignore(string(~S("""))
-    |> traverse({:mark_block_string_start, []}))
+    ignore(
+      string(~S("""))
+      |> traverse({:mark_block_string_start, []})
+    )
     |> repeat_while(block_string_character, {:not_end_of_block_quote, []})
     |> ignore(string(~S(""")))
     |> traverse({:block_string_value_token, []})
@@ -229,6 +231,7 @@ defmodule Absinthe.Lexer do
 
   def tokenize(input) do
     lines = String.split(input, ~r/\r?\n/)
+
     case do_tokenize(input) do
       {:ok, tokens, "", _, _, _} ->
         tokens = Enum.map(tokens, &convert_token_column(&1, lines))
@@ -246,6 +249,7 @@ defmodule Absinthe.Lexer do
   defp convert_token_column({ident, loc, data}, lines) do
     {ident, byte_loc_to_char_loc(loc, lines), data}
   end
+
   defp convert_token_column({ident, loc}, lines) do
     {ident, byte_loc_to_char_loc(loc, lines)}
   end

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -53,7 +53,8 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
     Mix.Task.run("loadpaths", argv)
     Mix.Project.compile(argv)
 
-    {opts, args, _} = OptionParser.parse(argv, strict: [schema: :string, json_codec: :string, pretty: :boolean])
+    {opts, args, _} =
+      OptionParser.parse(argv, strict: [schema: :string, json_codec: :string, pretty: :boolean])
 
     schema = find_schema(opts)
     json_codec = find_json(opts)

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -395,7 +395,7 @@ hexlist_to_utf8_binary(HexList) ->
 % Block String
 
 extract_quoted_block_string_token({_Token, _Loc, Value}) ->
-  iolist_to_binary(process_block_string(lists:sublist(Value, 4, length(Value) - 6))).
+  unicode:characters_to_binary(process_block_string(lists:sublist(Value, 4, length(Value) - 6))).
 
 -spec process_block_string(string()) -> string().
 process_block_string(Escaped) ->
@@ -410,7 +410,7 @@ process_block_string([H | T], Acc) -> process_block_string(T, [H | Acc]).
 
 -spec block_string_value(string()) -> string().
 block_string_value(Value) ->
-  [FirstLine | Rest] = re:split(Value, "\n", [{return,list}]),
+  [FirstLine | Rest] = string:split(Value, "\n", all),
   Prefix = indentation_prefix(common_indent(Rest)),
   UnindentedLines = unindent(Rest, Prefix),
   Lines = trim_blank_lines([FirstLine | UnindentedLines]),

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -59,19 +59,17 @@ defmodule Absinthe.LexerTest do
   """
   test "document with emojis" do
     assert {:ok,
-    [
-      {:block_string_value, {2, 1},
-       '"""\nA block quote with a 👍 emoji.\n"""'},
-      {:"{", {5, 1}},
-      {:name, {6, 3}, 'foo'},
-      {:"(", {6, 6}},
-      {:name, {6, 7}, 'bar'},
-      {:":", {6, 10}},
-      {:string_value, {6, 12}, '"A string with a 🎉 emoji."'},
-      {:")", {6, 38}},
-      {:name, {6, 40}, 'anotherOnSameLine'},
-      {:"}", {7, 1}}
-    ]} == Absinthe.Lexer.tokenize(@query)
+            [
+              {:block_string_value, {2, 1}, '"""\nA block quote with a 👍 emoji.\n"""'},
+              {:"{", {5, 1}},
+              {:name, {6, 3}, 'foo'},
+              {:"(", {6, 6}},
+              {:name, {6, 7}, 'bar'},
+              {:":", {6, 10}},
+              {:string_value, {6, 12}, '"A string with a 🎉 emoji."'},
+              {:")", {6, 38}},
+              {:name, {6, 40}, 'anotherOnSameLine'},
+              {:"}", {7, 1}}
+            ]} == Absinthe.Lexer.tokenize(@query)
   end
-
 end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -54,7 +54,7 @@ defmodule Absinthe.LexerTest do
   A block quote with a 👍 emoji.
   \"""
   {
-    foo(bar: "A string with a 🎉 emoji.")
+    foo(bar: "A string with a 🎉 emoji.") anotherOnSameLine
   }
   """
   test "document with emojis" do
@@ -68,7 +68,8 @@ defmodule Absinthe.LexerTest do
       {:name, {6, 7}, 'bar'},
       {:":", {6, 10}},
       {:string_value, {6, 12}, '"A string with a 🎉 emoji."'},
-      {:")", {6, 37}},
+      {:")", {6, 38}},
+      {:name, {6, 40}, 'anotherOnSameLine'},
       {:"}", {7, 1}}
     ]} == Absinthe.Lexer.tokenize(@query)
   end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -31,7 +31,7 @@ defmodule Absinthe.LexerTest do
   {
     foo(bar: \"""
     stuff
-    \""") 
+    \""")
   }
   """
   test "basic document, multiple lines with block string" do
@@ -47,4 +47,30 @@ defmodule Absinthe.LexerTest do
               {:"}", {5, 1}}
             ]} = Absinthe.Lexer.tokenize(@query)
   end
+
+  @query """
+  # A comment with a 😕 emoji.
+  \"""
+  A block quote with a 👍 emoji.
+  \"""
+  {
+    foo(bar: "A string with a 🎉 emoji.")
+  }
+  """
+  test "document with emojis" do
+    assert {:ok,
+    [
+      {:block_string_value, {2, 1},
+       '"""\nA block quote with a 👍 emoji.\n"""'},
+      {:"{", {5, 1}},
+      {:name, {6, 3}, 'foo'},
+      {:"(", {6, 6}},
+      {:name, {6, 7}, 'bar'},
+      {:":", {6, 10}},
+      {:string_value, {6, 12}, '"A string with a 🎉 emoji."'},
+      {:")", {6, 37}},
+      {:"}", {7, 1}}
+    ]} == Absinthe.Lexer.tokenize(@query)
+  end
+
 end

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -196,15 +196,6 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
              ])
   end
 
-  defp extract_error_message(err) do
-    get_in(err, [
-      Access.key(:execution, %{}),
-      Access.key(:validation_errors, []),
-      Access.at(0),
-      Access.key(:message, nil)
-    ])
-  end
-
   defp extract_body(value) do
     get_in(value, [
       Access.key(:definitions),

--- a/test/absinthe/phase/parse/block_strings_test.exs
+++ b/test/absinthe/phase/parse/block_strings_test.exs
@@ -179,15 +179,6 @@ defmodule Absinthe.Phase.Parse.BlockStringsTest do
     assert ~S<text""" > == extract_body(result)
   end
 
-  test "returns an error for a bad byte" do
-    assert {:error, err} =
-             run(
-               ~s<{ post(title: "single", body: """trying to escape a \u0000 byte""") { name } }>
-             )
-
-    assert "Parsing failed at" <> _ = extract_error_message(err)
-  end
-
   test "parses a query with a block string literal as a variable default" do
     assert {:ok, result} =
              run(

--- a/test/absinthe/phase/parse/language_test.exs
+++ b/test/absinthe/phase/parse/language_test.exs
@@ -17,6 +17,14 @@ defmodule Absinthe.Phase.Parse.LanguageTest do
     assert {:ok, _} = run(input)
   end
 
+  test "parses schema-with-emojis.graphql" do
+    filename =
+      Path.join(__DIR__, "../../../support/fixtures/language/schema-with-emojis.graphql")
+
+    input = File.read!(filename)
+    assert {:ok, _} = run(input)
+  end
+
   def run(input) do
     with {:ok, %{input: input}} <- Absinthe.Phase.Parse.run(input) do
       {:ok, input}

--- a/test/absinthe/phase/parse/language_test.exs
+++ b/test/absinthe/phase/parse/language_test.exs
@@ -18,8 +18,7 @@ defmodule Absinthe.Phase.Parse.LanguageTest do
   end
 
   test "parses schema-with-emojis.graphql" do
-    filename =
-      Path.join(__DIR__, "../../../support/fixtures/language/schema-with-emojis.graphql")
+    filename = Path.join(__DIR__, "../../../support/fixtures/language/schema-with-emojis.graphql")
 
     input = File.read!(filename)
     assert {:ok, _} = run(input)

--- a/test/support/fixtures/language/schema-with-emojis.graphql
+++ b/test/support/fixtures/language/schema-with-emojis.graphql
@@ -1,0 +1,11 @@
+# Comment with a 😕 emoji.
+schema {
+  """
+  Description with a 🎉 emoji.
+  """
+  query: QueryType
+}
+
+type QueryType {
+  hello: String
+}


### PR DESCRIPTION
This pull request modifies the new lexer to better support Unicode within strings; according to [Section 2.1.1 of the GraphQL Specification](https://facebook.github.io/graphql/draft/#sec-Unicode):

> Non‐ASCII Unicode characters may freely appear within StringValue and Comment portions of GraphQL.

