### PR TITLE
SDL: Add draft implementation for directive definition identifiers

### DIFF
--- a/lib/absinthe/language/directive_definition.ex
+++ b/lib/absinthe/language/directive_definition.ex
@@ -20,17 +20,6 @@ defmodule Absinthe.Language.DirectiveDefinition do
         }
 
   defimpl Blueprint.Draft do
-    @spec convert(
-            %{
-              arguments: any(),
-              description: any(),
-              directives: any(),
-              loc: nil | %{column: pos_integer(), line: pos_integer()},
-              locations: any(),
-              name: atom() | binary()
-            },
-            any()
-          ) :: Absinthe.Blueprint.Schema.DirectiveDefinition.t()
     def convert(node, doc) do
       %Blueprint.Schema.DirectiveDefinition{
         name: node.name,

--- a/lib/absinthe/language/directive_definition.ex
+++ b/lib/absinthe/language/directive_definition.ex
@@ -20,9 +20,21 @@ defmodule Absinthe.Language.DirectiveDefinition do
         }
 
   defimpl Blueprint.Draft do
+    @spec convert(
+            %{
+              arguments: any(),
+              description: any(),
+              directives: any(),
+              loc: nil | %{column: pos_integer(), line: pos_integer()},
+              locations: any(),
+              name: atom() | binary()
+            },
+            any()
+          ) :: Absinthe.Blueprint.Schema.DirectiveDefinition.t()
     def convert(node, doc) do
       %Blueprint.Schema.DirectiveDefinition{
         name: node.name,
+        identifier: Macro.underscore(node.name) |> String.to_atom(),
         description: node.description,
         arguments: Absinthe.Blueprint.Draft.convert(node.arguments, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -10,6 +10,9 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
     # Embedded SDL
     import_sdl """
+    directive @feature(name: String!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+    directive @another(name: String!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
     type Query {
       "A list of posts"
       posts(filter: PostFilter): [Post]
@@ -37,11 +40,10 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       name: String!
     }
 
-    interface Titled {
+    interface Titled @feature(name: "bar") {
       title: String!
     }
 
-    scalar A
     scalar B
 
     union SearchResult = Post | User


### PR DESCRIPTION
Fixes directive definition conversion via `Absinthe.Blueprint.Draft` protocol (`identifier` wasn't being set, causing collision as `nil`).