### PR TITLE
Fix mix task to pass `pretty` flag to custom codecs, add tests

### DIFF
--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -58,6 +58,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
           }
   end
 
+  @doc "Main entry point to mix task"
   def run(argv) do
     Application.ensure_all_started(:absinthe)
 
@@ -72,6 +73,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
     end
   end
 
+  @doc "Encode the Absinthe schema to a string, using the specified codec"
   @spec generate_schema(Options.t()) :: String.t()
   def generate_schema(%Options{
         pretty: pretty,
@@ -89,6 +91,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
     end
   end
 
+  @doc "Convert CLI arguments into an Options struct"
   @spec parse_options([String.t()]) :: Options.t()
   def parse_options(argv) do
     parse_options = [strict: [schema: :string, json_codec: :string, pretty: :boolean]]

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -14,12 +14,17 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
 
       absinthe.schema.json [FILENAME] [OPTIONS]
 
+    The JSON codec to be used needs to be included in your `mix.exs` dependencies. If using the default codec,
+    see the Jason [installation instructions](https://hexdocs.pm/jason).
 
   ## Options
 
-  * `--schema` - The name of the `Absinthe.Schema` module defining the schema to be generated. Default: As [configured](https://hexdocs.pm/mix/Mix.Config.html) for `:absinthe` `:schema`
-  * `--json-codec` - Codec to use to generate the JSON file (see [Custom Codecs](#module-custom-codecs)). Default: [`Jason`](https://hexdocs.pm/jason/)
-  * `--pretty` - Whether to pretty-print. Default: `false`
+  * `--schema` - The name of the `Absinthe.Schema` module defining the schema to be generated.
+     Default: As [configured](https://hexdocs.pm/mix/Mix.Config.html) for `:absinthe` `:schema`
+  * `--json-codec` - Codec to use to generate the JSON file (see [Custom Codecs](#module-custom-codecs)).
+     Default: [`Jason`](https://hexdocs.pm/jason/)
+  * `--pretty` - Whether to pretty-print.
+     Default: `false`
 
 
   ## Examples

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -82,8 +82,8 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
       }) do
     with {:ok, query} <- File.read(@introspection_graphql),
          {:ok, result} <- Absinthe.run(query, schema),
-         {:ok, _} <- check_function_available(json_codec, :encode),
-         {:ok, content} <- json_codec.encode(result, pretty: pretty) do
+         {:ok, _} <- check_function_available(json_codec, :encode!),
+         content <- json_codec.encode!(result, pretty: pretty) do
       {:ok, content}
     else
       {:error, reason} -> {:error, reason}

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -1,0 +1,76 @@
+defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
+  use Absinthe.Case, async: true
+
+  alias Mix.Tasks.Absinthe.Schema.Json, as: Task
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+
+    query do
+      field :item, :item
+    end
+
+    object :item do
+      description "A Basic Type"
+      field :id, :id
+      field :name, :string
+    end
+  end
+
+  defmodule TestEncoder do
+    def encode(_map, opts) do
+      pretty_flag = Keyword.get(opts, :pretty, false)
+      pretty_string = if pretty_flag, do: "pretty", else: "ugly"
+      {:ok, "test-encoder-#{pretty_string}"}
+    end
+  end
+
+  @test_schema "Mix.Tasks.Absinthe.Schema.JsonTest.TestSchema"
+  @test_encoder "Mix.Tasks.Absinthe.Schema.JsonTest.TestEncoder"
+
+  describe "absinthe.schema.json" do
+    test "parses options" do
+      argv = ["output.json", "--schema", @test_schema, "--json-codec", @test_encoder, "--pretty"]
+
+      opts = Task.parse_options(argv)
+
+      assert opts.filename == "output.json"
+      assert opts.json_codec == TestEncoder
+      assert opts.pretty == true
+      assert opts.schema == TestSchema
+    end
+
+    test "provides default options" do
+      argv = ["--schema", @test_schema]
+
+      opts = Task.parse_options(argv)
+
+      assert opts.filename == "./schema.json"
+      assert opts.json_codec == Jason
+      assert opts.pretty == false
+      assert opts.schema == TestSchema
+    end
+
+    test "fails if no schema arg is provided" do
+      argv = []
+      catch_error(Task.parse_options(argv))
+    end
+
+    test "fails if codec hasn't been loaded" do
+      argv = ["--schema", @test_schema, "--json-codec", "UnloadedCodec"]
+      opts = Task.parse_options(argv)
+      assert {:error, _} = Task.generate_schema(opts)
+    end
+
+    test "can use a custom codec" do
+      argv = ["--schema", @test_schema, "--json-codec", @test_encoder, "--pretty"]
+
+      opts = Task.parse_options(argv)
+      {:ok, pretty_content} = Task.generate_schema(opts)
+      {:ok, ugly_content} = Task.generate_schema(%{opts | pretty: false})
+
+      assert pretty_content == "test-encoder-pretty"
+      assert ugly_content == "test-encoder-ugly"
+    end
+  end
+end

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -18,10 +18,10 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
   end
 
   defmodule TestEncoder do
-    def encode(_map, opts) do
+    def encode!(_map, opts) do
       pretty_flag = Keyword.get(opts, :pretty, false)
       pretty_string = if pretty_flag, do: "pretty", else: "ugly"
-      {:ok, "test-encoder-#{pretty_string}"}
+      "test-encoder-#{pretty_string}"
     end
   end
 

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
     test "fails if codec hasn't been loaded" do
       argv = ["--schema", @test_schema, "--json-codec", "UnloadedCodec"]
       opts = Task.parse_options(argv)
-      assert {:error, _} = Task.generate_schema(opts)
+      catch_error(Task.generate_schema(opts))
     end
 
     test "can use a custom codec" do


### PR DESCRIPTION
This fixes an issue preventing the `pretty` flag from being passed to custom codecs. It also adds tests to ensure that CLI options are parsed correctly, appropriate defaults are used, and custom codecs are called successfully.

Note that in order to make the tests perform an actual conversion to JSON, we would have to add Jason or Poison as a test-mode dependency. I opted against this because if we can ensure that the codec is accessed correctly, the risk of Poison's or Jason's `encode/2` method failing should be low.

However, if we don't add Jason or Poison as production-mode dependencies, we may want .to update the README to indicate that the application must load the the codec module  in order for the mix task to work, even if using the default Jason encoder.
