### PR TITLE
Updates to documentation and examples.

### DIFF
--- a/guides/schemas.md
+++ b/guides/schemas.md
@@ -58,14 +58,14 @@ object :item do
 end
 ```
 
-Now, you can use Absinthe to execute a query document. Keep in mind that for
+Now you can use Absinthe to execute a query document. Keep in mind that for
 HTTP, you'll probably want to use
 [Absinthe.Plug](plug-phoenix.html) instead of executing
 GraphQL query documents yourself. Absinthe doesn't know or care about HTTP,
-but the `absinthe_plug` project does -- and handles the vagaries of interacting
+but the `absinthe_plug` project does: it handles the vagaries of interacting
 with HTTP GraphQL clients so you don't have to.
 
-If you _were_ executing query documents yourself (lets assume for a local tool),
+If you _were_ executing query documents yourself (let's assume for a local tool),
 it would go something like this:
 
 ```elixir
@@ -80,6 +80,20 @@ it would go something like this:
 
 # Result
 {:ok, %{data: %{"item" => %{"name" => "Foo"}}}}
+```
+
+Your schemas can be further customized using the options available to
+`Absinthe.Schema.Notation.field/4` to help provide for a richer experience for 
+your users, customize the field names, or mark fields as deprecated.
+
+```elixir
+# filename: myapp/language_schema.ex
+@desc "A Language"
+object :language do
+  field :id, :id
+  field :iso_639_1, :string, description: "2 character ISO 639-1 code", name: "iso639"
+  field :name, :string, description: "English name of the language"
+end
 ```
 
 ## Importing Types

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -71,7 +71,7 @@ defmodule Absinthe.Type.Field do
   The configuration for a field.
 
   * `:name` - The name of the field, usually assigned automatically by
-     the `Absinthe.Schema.Notation.field/1`.
+     the `Absinthe.Schema.Notation.field/1`. Including this option will bypass the snake_case to camelCase conversion.
   * `:description` - Description of a field, useful for introspection.
   * `:deprecation` - Deprecation information for a field, usually
      set-up using `Absinthe.Schema.Notation.deprecate/1`.
@@ -104,7 +104,7 @@ defmodule Absinthe.Type.Field do
   ### Custom Resolution
 
   When accepting arguments, however, you probably need to use them for
-  something. Here's an example of definining a field that looks up a list of
+  something. Here's an example of defining a field that looks up a list of
   users for a given `location_id`:
   ```
   query do


### PR DESCRIPTION
Adds an example of schema definition that uses additional options and provides a cross reference to the field macro.

This PR addresses issue #678 
**No code was changed**

I attempted to run all tests, but I am encountering this issue with my setup that I cannot figure out:

```
mix test
==> fs (compile)
Compiling c_src/mac/cli.c
c_src/mac/cli.c:1:10: fatal error: 'getopt.h' file not found
#include <getopt.h>
         ^~~~~~~~~~
1 error generated.
ERROR: compile failed while processing /Users/everettgriffiths/DropboxDM/absinthe/deps/fs: rebar_abort
** (Mix) Could not compile dependency :fs, "/path/to/.mix/rebar compile skip_deps=true deps_dir="/path/to/absinthe/_build/test/lib"" command failed. You can recompile this dependency with "mix deps.compile fs", update it with "mix deps.update fs" or clean it with "mix deps.clean fs"
```

So unfortunately, I cannot run the tests, so even though this PR only updates documentation and comments, I have to disclose that fact.