### PR TITLE
Add support for passing tasks to async middleware

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -16,9 +16,27 @@ defmodule Absinthe.Resolution.Helpers do
   This is a helper function for using the `Absinthe.Middleware.Async`.
 
   Forbidden in mutation fields. (TODO: actually enforce this)
+
+  ## Options
+     - `:timeout` default: `30_000`. The maximum timeout to wait for running
+     the task.
+
+  ## Example
+
+  Using the `Absinthe.Resolution.Helpers.async/1` helper function:
+  ```elixir
+  field :time_consuming, :thing do
+    resolve fn _, _, _ ->
+      async(fn ->
+        {:ok, long_time_consuming_function()}
+      end)
+    end
+  end
+  ```
   """
   @spec async((() -> term)) :: {:middleware, Middleware.Async, term}
-  @spec async((() -> term), Keyword.t()) :: {:middleware, Middleware.Async, term}
+  @spec async((() -> term), opts :: [{:timeout, pos_integer}]) ::
+          {:middleware, Middleware.Async, term}
   def async(fun, opts \\ []) do
     {:middleware, Middleware.Async, {fun, opts}}
   end
@@ -29,10 +47,11 @@ defmodule Absinthe.Resolution.Helpers do
   Helper function for creating `Absinthe.Middleware.Batch`
 
   ## Options
-    - `:timeout` default: `5_000`. The maximum timeout to wait for running 
+    - `:timeout` default: `5_000`. The maximum timeout to wait for running
     a batch.
-    
-  # Example
+
+  ## Example
+
   Raw usage:
   ```elixir
   object :post do

--- a/test/absinthe/middleware/async_test.exs
+++ b/test/absinthe/middleware/async_test.exs
@@ -26,6 +26,24 @@ defmodule Absinthe.Middleware.AsyncTest do
                   {:ok, nil}
                 end)
       end
+
+      field :async_bare_thing_with_opts, :string do
+        resolve fn _, _, _ ->
+          task = Task.async(fn ->
+            {:ok, "bare task"}
+          end)
+          {:middleware, Elixir.Absinthe.Middleware.Async, {task, []}}
+        end
+      end
+
+      field :async_bare_thing, :string do
+        resolve fn _, _, _ ->
+          task = Task.async(fn ->
+            {:ok, "bare task"}
+          end)
+          {:middleware, Elixir.Absinthe.Middleware.Async, task}
+        end
+      end
     end
 
     def cool_async(fun) do
@@ -37,7 +55,24 @@ defmodule Absinthe.Middleware.AsyncTest do
     end
   end
 
-  test "can resolve a field using the normal async helper" do
+  test "can resolve a field using the bare api with opts" do
+    doc = """
+    {asyncBareThingWithOpts}
+    """
+
+    assert {:ok, %{data: %{"asyncBareThingWithOpts" => "bare task"}}} == Absinthe.run(doc, Schema)
+  end
+
+  test "can resolve a field using the bare api" do
+    doc = """
+    {asyncBareThing}
+    """
+
+    assert {:ok, %{data: %{"asyncBareThing" => "bare task"}}} == Absinthe.run(doc, Schema)
+  end
+
+
+  test "can resolve a field using the normal test helper" do
     doc = """
     {asyncThing}
     """


### PR DESCRIPTION
The docs mentioned that you could use the bare plugin api but the module did not support it:

See https://hexdocs.pm/absinthe/Absinthe.Middleware.Async.html

  Using the bare plugin API
  ```elixir
  field :time_consuming, :thing do
    resolve fn _, _, _ ->
      task = Task.async(fn ->
        {:ok, long_time_consuming_function()}
      end)
      {:middleware, #{__MODULE__}, task}
    end
  end
  ```

This PR adds support for using the bare api.