### PR TITLE
Fix complexity analysis on inline fragments

### DIFF
--- a/lib/absinthe/phase/document/complexity/analysis.ex
+++ b/lib/absinthe/phase/document/complexity/analysis.ex
@@ -50,6 +50,14 @@ defmodule Absinthe.Phase.Document.Complexity.Analysis do
   end
 
   def handle_node(
+    %Blueprint.Document.Fragment.Inline{selections: fields} = node,
+    _info,
+    _fragments
+  ) do
+    %{node | complexity: sum_complexity(fields)}
+  end
+
+  def handle_node(
         %Blueprint.Document.Field{
           complexity: nil,
           selections: fields,

--- a/test/absinthe/phase/document/complexity_test.exs
+++ b/test/absinthe/phase/document/complexity_test.exs
@@ -77,6 +77,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
         unionComplexity {
            ... on Foo {
              bar
+             heavy
           }
         }
       }
@@ -84,7 +85,7 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
 
       assert {:ok, result, _} = run_phase(doc, operation_name: "UnionComplexity", variables: %{})
       op = result.operations |> Enum.find(&(&1.name == "UnionComplexity"))
-      assert op.complexity == 2
+      assert op.complexity == 102
       errors = result.execution.validation_errors |> Enum.map(& &1.message)
       assert errors == []
     end


### PR DESCRIPTION
Previously, the complexity of inline fragments was not being taken into
account at all. This would result in the wrong value being returned for
the complexity.