### PR TITLE
Fix typo in docs for `on_load/2` resolution helper

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -111,7 +111,7 @@ defmodule Absinthe.Resolution.Helpers do
           reports =
             loader
             |> Dataloader.get(SourceName, :automatic_reports, shipment)
-            |> Enum.concat(Dataloader.load(loader, SourceName, :manual_reports, shipment))
+            |> Enum.concat(Dataloader.get(loader, SourceName, :manual_reports, shipment))
             |> Enum.sort_by(&reported_at/1)
           {:ok, reports}
         end)


### PR DESCRIPTION
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
Small typo fix in docs in `Absinthe.Resolution.Helpers`