### PR TITLE
Fix dialyzer error with custom scalar

### DIFF
--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -27,6 +27,7 @@ defmodule Absinthe.Blueprint.Execution do
   values within the resolution struct are pulled out and used to update the execution.
   """
 
+  alias Absinthe.Blueprint.Result
   alias Absinthe.Phase
 
   @type acc :: map
@@ -55,7 +56,7 @@ defmodule Absinthe.Blueprint.Execution do
           | Result.Leaf
 
   def get(%{execution: %{result: nil} = exec} = bp_root, operation) do
-    result = %Absinthe.Blueprint.Result.Object{
+    result = %Result.Object{
       root_value: exec.root_value,
       emitter: operation
     }
@@ -74,7 +75,7 @@ defmodule Absinthe.Blueprint.Execution do
   end
 
   def get_result(%__MODULE__{result: nil, root_value: root_value}, operation) do
-    %Absinthe.Blueprint.Result.Object{
+    %Result.Object{
       root_value: root_value,
       emitter: operation
     }


### PR DESCRIPTION
This PR adds a missing alias which should resolve #694

Error: `:0: Unknown type 'Elixir.Result.Object':t/0`
Location: https://github.com/absinthe-graphql/absinthe/blob/c049c8a838e3ae60d0d01455d52613af5dab169b/lib/absinthe/blueprint/execution.ex#L49