### PR TITLE
Fix broken typespecs

### DIFF
--- a/lib/absinthe/blueprint/input/raw_value.ex
+++ b/lib/absinthe/blueprint/input/raw_value.ex
@@ -1,7 +1,7 @@
 defmodule Absinthe.Blueprint.Input.RawValue do
   @moduledoc false
 
-  Absinthe.Blueprint.Input.Object
+  alias Absinthe.Blueprint.Input.Object
 
   @enforce_keys [:content]
   defstruct [

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -320,7 +320,7 @@ defmodule Absinthe.Pipeline do
       iex> Pipeline.reject([A, B, C], ~r/A|B/)
       [C]
   """
-  @spec reject(t, Regex.t() | (Module.t() -> boolean)) :: t
+  @spec reject(t, Regex.t() | (module -> boolean)) :: t
   def reject(pipeline, %Regex{} = pattern) do
     reject(pipeline, fn phase ->
       Regex.match?(pattern, Atom.to_string(phase))

--- a/lib/absinthe/schema/notation/sdl.ex
+++ b/lib/absinthe/schema/notation/sdl.ex
@@ -4,7 +4,7 @@ defmodule Absinthe.Schema.Notation.SDL do
   @doc """
   Parse definitions from SDL source
   """
-  @spec parse(sdl :: String.t(), Module.t(), map(), Keyword.t()) ::
+  @spec parse(sdl :: String.t(), module, map(), Keyword.t()) ::
           {:ok, [Absinthe.Blueprint.Schema.t()]} | {:error, String.t()}
   def parse(sdl, module, ref, opts) do
     with {:ok, doc} <- Absinthe.Phase.Parse.run(sdl) do

--- a/lib/absinthe/type/argument.ex
+++ b/lib/absinthe/type/argument.ex
@@ -24,7 +24,7 @@ defmodule Absinthe.Type.Argument do
           default_value: any,
           deprecation: Type.Deprecation.t() | nil,
           description: binary | nil,
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -27,7 +27,7 @@ defmodule Absinthe.Type.Directive do
           args: map,
           locations: [location],
           expand: (map, Absinthe.Blueprint.node_t() -> atom),
-          definition: Module.t(),
+          definition: module,
           __private__: Keyword.t(),
           __reference__: Type.Reference.t()
         }

--- a/lib/absinthe/type/enum.ex
+++ b/lib/absinthe/type/enum.ex
@@ -73,7 +73,7 @@ defmodule Absinthe.Type.Enum do
           values: %{binary => Type.Enum.Value.t()},
           identifier: atom,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -195,7 +195,7 @@ defmodule Absinthe.Type.Field do
           middleware: [],
           complexity: complexity_t | nil,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -52,7 +52,7 @@ defmodule Absinthe.Type.InputObject do
           fields: map,
           identifier: atom,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -64,7 +64,7 @@ defmodule Absinthe.Type.Interface do
           fields: map,
           identifier: atom,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -90,7 +90,7 @@ defmodule Absinthe.Type.Object do
           fields: map,
           interfaces: [Absinthe.Type.Interface.t()],
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -67,7 +67,7 @@ defmodule Absinthe.Type.Scalar do
           description: binary,
           identifier: atom,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -44,7 +44,7 @@ defmodule Absinthe.Type.Union do
           types: [Type.identifier_t()],
           identifier: atom,
           __private__: Keyword.t(),
-          definition: Module.t(),
+          definition: module,
           __reference__: Type.Reference.t()
         }
 


### PR DESCRIPTION
I don't know if `Module.t()` was ever valid elixir, but at least in elixir `1.8.1` it's not:

```elixir
> t Module
@typep def_kind() :: :def | :defp | :defmacro | :defmacrop

@typep definition() :: {atom(), arity()}
```

I have one application using absinthe, and it shows this dialyzer error:

```elixir
:0:unknown_type
Unknown type: Module.t/0.
```

The error is gone after this change 👍🏼

EDIT:

Another dialyzer error fixed (just a missing `alias`)

```elixir
:0:unknown_type
Unknown type: Object.t/0.
________________________________________________________________________________
```