### PR TITLE
Fix Absinthe.run/3 typespec

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -29,6 +29,7 @@ defmodule Absinthe do
             | boolean
             | binary
             | atom
+            | result_selection_t
             | [result_selection_t]
         }
 


### PR DESCRIPTION
Dialyzer would fail if the data response was a nested map, i.e. `%{"node" => %{"zone" => _zone}}`.