### PR TITLE
Add note to Date and Time custom types indicating acceptable values

### DIFF
--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -40,7 +40,7 @@ defmodule Absinthe.Type.Custom do
   scalar :date do
     description """
     The `Date` scalar type represents a date. The Date appears in a JSON
-    response as an ISO8601 formatted string.
+    response as an ISO8601 formatted string, without a time component.
     """
 
     serialize &Date.to_iso8601/1
@@ -50,7 +50,7 @@ defmodule Absinthe.Type.Custom do
   scalar :time do
     description """
     The `Time` scalar type represents a time. The Time appears in a JSON
-    response as an ISO8601 formatted string.
+    response as an ISO8601 formatted string, without a date component.
     """
 
     serialize &Time.to_iso8601/1


### PR DESCRIPTION
Add a note to the Date and Time custom types indicating that they _do
not_ accept Time and date values respectively.

```elixir
Date.from_iso8601("2019-04-15T11:55:15")
# => {:error, :invalid_format}

Date.from_iso8601("2019-04-15")
# => {:ok, ~D[2019-04-15]}

Time.from_iso8601("2019-04-15T11:55:15")
# => {:error, :invalid_format}

Time.from_iso8601("11:55:15")
# => {:ok, ~T[11:55:15]}
```

Some platforms, such as iOS Apollo, cast Date/Time to types native to that platform. Swift Date accepts full ISO8601:2019 datetime stamps.
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->