### PR TITLE
Upgrade nimble_parsec to 0.50

### DIFF
--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -92,12 +92,12 @@ defmodule Absinthe.Lexer do
       ]),
       times(ascii_char([?.]), 3)
     ])
-    |> traverse({:atom_token, []})
+    |> post_traverse({:atom_token, []})
 
   boolean_value_or_name_or_reserved_word =
     ascii_char([?_, ?A..?Z, ?a..?z])
     |> repeat(ascii_char([?_, ?0..?9, ?A..?Z, ?a..?z]))
-    |> traverse({:boolean_value_or_name_or_reserved_word, []})
+    |> post_traverse({:boolean_value_or_name_or_reserved_word, []})
 
   # NegativeSign :: -
   negative_sign = ascii_char([?-])
@@ -122,7 +122,7 @@ defmodule Absinthe.Lexer do
   int_value =
     empty()
     |> concat(integer_part)
-    |> traverse({:labeled_token, [:int_value]})
+    |> post_traverse({:labeled_token, [:int_value]})
 
   # FractionalPart :: . Digit+
   fractional_part =
@@ -148,15 +148,15 @@ defmodule Absinthe.Lexer do
   float_value =
     choice([
       integer_part |> concat(fractional_part) |> concat(exponent_part),
-      integer_part |> traverse({:fill_mantissa, []}) |> concat(exponent_part),
+      integer_part |> post_traverse({:fill_mantissa, []}) |> concat(exponent_part),
       integer_part |> concat(fractional_part)
     ])
-    |> traverse({:labeled_token, [:float_value]})
+    |> post_traverse({:labeled_token, [:float_value]})
 
   # EscapedUnicode :: /[0-9A-Fa-f]{4}/
   escaped_unicode =
     times(ascii_char([?0..?9, ?A..?F, ?a..?f]), 4)
-    |> traverse({:unescape_unicode, []})
+    |> post_traverse({:unescape_unicode, []})
 
   # EscapedCharacter :: one of `"` \ `/` b f n r t
   escaped_character =
@@ -199,19 +199,19 @@ defmodule Absinthe.Lexer do
   #   - `"""` BlockStringCharacter* `"""`
   string_value =
     ignore(ascii_char([?"]))
-    |> traverse({:mark_string_start, []})
+    |> post_traverse({:mark_string_start, []})
     |> repeat_while(string_character, {:not_end_of_quote, []})
     |> ignore(ascii_char([?"]))
-    |> traverse({:string_value_token, []})
+    |> post_traverse({:string_value_token, []})
 
   block_string_value =
     ignore(
       string(~S("""))
-      |> traverse({:mark_block_string_start, []})
+      |> post_traverse({:mark_block_string_start, []})
     )
     |> repeat_while(block_string_character, {:not_end_of_block_quote, []})
     |> ignore(string(~S(""")))
-    |> traverse({:block_string_value_token, []})
+    |> post_traverse({:block_string_value_token, []})
 
   defp not_end_of_quote(<<?", _::binary>>, context, _, _) do
     {:halt, context}

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -205,10 +205,8 @@ defmodule Absinthe.Lexer do
     |> post_traverse({:string_value_token, []})
 
   block_string_value =
-    ignore(
-      string(~S("""))
-      |> post_traverse({:mark_block_string_start, []})
-    )
+    ignore(string(~S(""")))
+    |> post_traverse({:mark_block_string_start, []})
     |> repeat_while(block_string_character, {:not_end_of_block_quote, []})
     |> ignore(string(~S(""")))
     |> post_traverse({:block_string_value_token, []})
@@ -340,8 +338,8 @@ defmodule Absinthe.Lexer do
     {[chars], Map.put(context, :token_location, line_and_column(loc, byte_offset, 1))}
   end
 
-  defp mark_block_string_start(_rest, chars, context, loc, byte_offset) do
-    {[chars], Map.put(context, :token_location, line_and_column(loc, byte_offset, 3))}
+  defp mark_block_string_start(_rest, _chars, context, loc, byte_offset) do
+    {[], Map.put(context, :token_location, line_and_column(loc, byte_offset, 3))}
   end
 
   defp block_string_value_token(_rest, chars, context, _loc, _byte_offset) do

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,6 @@
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.4.1", "a98a84c795623f1ba020324f4354cf30e7120ba4dab65f9c2ae300f830a25f75", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.0", "d55e25ff1ff8ea2f9964638366dfd6e361c52dedfd50019353598d11d4441d14", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
I upgraded nimble_parsec to 0.50 (see https://github.com/plataformatec/nimble_parsec/blob/master/CHANGELOG.md). 

One change was the deprecation of traverse/3 over post_traverse/3. I also made some changes to the lexer to make the tests pass again. 