### PR TITLE
Add Absinthe.Adapter.StrictLanguageConventions

### DIFF
--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -8,12 +8,12 @@ defmodule Absinthe.Adapter do
   Adapters aren't a part of GraphQL, but a utility that Absinthe adds so that
   both client and server can use use conventions most natural to them.
 
-  Absinthe ships with two adapters:
+  Absinthe ships with four adapters:
 
   * `Absinthe.Adapter.LanguageConventions`, which expects schemas to be defined
     in `snake_case` (the standard Elixir convention), translating to/from `camelCase`
     for incoming query documents and outgoing results. (This is the default as of v0.3.)
-  * `Absinthe.Adapter.Underscore`, which is similar to the `LanguageConventions`
+  * `Absinthe.Adapter.Underscore`, which is similar to the `Absinthe.Adapter.LanguageConventions`
     adapter but converts all incoming identifiers to underscores and does not
     modify outgoing identifiers (since those are already expected to be
     underscores). Unlike `Absinthe.Adapter.Passthrough` this does not break
@@ -21,6 +21,9 @@ defmodule Absinthe.Adapter do
   * `Absinthe.Adapter.Passthrough`, which is a no-op adapter and makes no
     modifications. (Note at the current time this does not support introspection
     if you're using camelized conventions).
+  * `Absinthe.Adapter.StrictLanguageConventions`, which expects schemas to be
+    defined in `snake_case`, translating to `camelCase` for outgoing results.
+    This adapter requires incoming query documents to use `camelCase`.
 
   To set an adapter, you pass a configuration option at runtime:
 
@@ -108,7 +111,7 @@ defmodule Absinthe.Adapter do
   end
   ```
   """
-  @callback to_internal_name(binary, role_t) :: binary
+  @callback to_internal_name(binary | nil, role_t) :: binary | nil
 
   @doc """
   Convert a name from an internal name to an external name.
@@ -124,5 +127,5 @@ defmodule Absinthe.Adapter do
   end
   ```
   """
-  @callback to_external_name(binary, role_t) :: binary
+  @callback to_external_name(binary | nil, role_t) :: binary | nil
 end

--- a/lib/absinthe/adapter/language_conventions.ex
+++ b/lib/absinthe/adapter/language_conventions.ex
@@ -47,6 +47,7 @@ defmodule Absinthe.Adapter.LanguageConventions do
   """
 
   @doc "Converts a camelCase to snake_case"
+  @impl Absinthe.Adapter
   def to_internal_name(nil, _role) do
     nil
   end
@@ -55,16 +56,17 @@ defmodule Absinthe.Adapter.LanguageConventions do
     "__" <> to_internal_name(camelized_name, role)
   end
 
-  def to_internal_name(camelized_name, :operation) do
+  def to_internal_name(camelized_name, :operation) when is_binary(camelized_name) do
     camelized_name
   end
 
-  def to_internal_name(camelized_name, _role) do
+  def to_internal_name(camelized_name, _role) when is_binary(camelized_name) do
     camelized_name
     |> Macro.underscore()
   end
 
   @doc "Converts a snake_case name to camelCase"
+  @impl Absinthe.Adapter
   def to_external_name(nil, _role) do
     nil
   end
@@ -73,11 +75,15 @@ defmodule Absinthe.Adapter.LanguageConventions do
     "__" <> to_external_name(underscored_name, role)
   end
 
+  def to_external_name(underscored_name, :operation) when is_binary(underscored_name) do
+    underscored_name
+  end
+
   def to_external_name(<<c::utf8, _::binary>> = name, _) when c in ?A..?Z do
     name |> Utils.camelize()
   end
 
-  def to_external_name(underscored_name, _role) do
+  def to_external_name(underscored_name, _role) when is_binary(underscored_name) do
     underscored_name
     |> Utils.camelize(lower: true)
   end

--- a/lib/absinthe/adapter/strict_language_conventions.ex
+++ b/lib/absinthe/adapter/strict_language_conventions.ex
@@ -1,0 +1,62 @@
+defmodule Absinthe.Adapter.StrictLanguageConventions do
+  @moduledoc """
+  Strict version of `Absinthe.Adapter.LanguageConventions` that will reject
+  improperly formatted external names.
+
+  For example, this document:
+
+  ```graphql
+  {
+    create_user(user_id: 2) {
+      first_name
+      last_name
+    }
+  }
+  ```
+
+  Would result in name-mismatch errors returned to the client.
+
+  The client should instead send the camelcase variant of the names:
+
+  ```graphql
+  {
+    createUser(userId: 2) {
+      firstName
+      lastName
+    }
+  }
+  ```
+
+  See `Absinthe.Adapter.LanguageConventions` for more information.
+  """
+
+  use Absinthe.Adapter
+
+  @doc """
+  Converts a camelCase to snake_case
+
+  Returns `nil` if the converted internal name does not match the converted external name.
+
+  See `Absinthe.Adapter.LanguageConventions.to_internal_name/2`
+  """
+  @impl Absinthe.Adapter
+  def to_internal_name(external_name, role) do
+    internal_name = Absinthe.Adapter.LanguageConventions.to_internal_name(external_name, role)
+
+    if external_name == Absinthe.Adapter.LanguageConventions.to_external_name(internal_name, role) do
+      internal_name
+    else
+      nil
+    end
+  end
+
+  @doc """
+  Converts a snake_case to camelCase
+
+  See `Absinthe.Adapter.LanguageConventions.to_external_name/2`
+  """
+  @impl Absinthe.Adapter
+  def to_external_name(internal_name, role) do
+    Absinthe.Adapter.LanguageConventions.to_external_name(internal_name, role)
+  end
+end

--- a/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
+++ b/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
@@ -180,7 +180,12 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
   end
 
   defp suggested_type_names(external_field_name, type, blueprint) do
-    internal_field_name = blueprint.adapter.to_internal_name(external_field_name, :field)
+    internal_field_name =
+      case blueprint.adapter.to_internal_name(external_field_name, :field) do
+        nil -> external_field_name
+        internal_field_name -> internal_field_name
+      end
+
     possible_types = find_possible_types(internal_field_name, type, blueprint.schema)
 
     possible_interfaces =
@@ -193,7 +198,11 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
   end
 
   defp suggested_field_names(external_field_name, %{fields: _} = type, blueprint) do
-    internal_field_name = blueprint.adapter.to_internal_name(external_field_name, :field)
+    internal_field_name =
+      case blueprint.adapter.to_internal_name(external_field_name, :field) do
+        nil -> external_field_name
+        internal_field_name -> internal_field_name
+      end
 
     Map.values(type.fields)
     |> Enum.map(& &1.name)

--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -85,12 +85,7 @@ defmodule Absinthe.Phase.Schema do
   end
 
   defp set_schema_node(%Blueprint.Directive{name: name} = node, _parent, schema, adapter) do
-    schema_node =
-      name
-      |> adapter.to_internal_name(:directive)
-      |> schema.__absinthe_directive__
-
-    %{node | schema_node: schema_node}
+    %{node | schema_node: find_schema_directive(name, schema, adapter)}
   end
 
   defp set_schema_node(
@@ -225,6 +220,14 @@ defmodule Absinthe.Phase.Schema do
     arguments
     |> Map.values()
     |> Enum.find(&match?(%{name: ^internal_name}, &1))
+  end
+
+  # Given a name, lookup a schema directive
+  @spec find_schema_directive(String.t(), Absinthe.Schema.t(), Absinthe.Adapter.t()) ::
+          nil | Type.Directive.t()
+  defp find_schema_directive(name, schema, adapter) do
+    internal_name = adapter.to_internal_name(name, :directive)
+    schema.__absinthe_directive__(internal_name)
   end
 
   # Given a schema type, lookup a child field definition

--- a/mix.exs
+++ b/mix.exs
@@ -182,6 +182,7 @@ defmodule Absinthe.Mixfile do
         Absinthe.Adapter,
         Absinthe.Adapter.LanguageConventions,
         Absinthe.Adapter.Passthrough,
+        Absinthe.Adapter.StrictLanguageConventions,
         Absinthe.Adapter.Underscore
       ],
       Execution: [

--- a/test/absinthe/adapters/language_conventions_test.exs
+++ b/test/absinthe/adapters/language_conventions_test.exs
@@ -11,6 +11,16 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
     test "converts external camelcase variable names to underscore" do
       assert "foo_bar" = LanguageConventions.to_internal_name("fooBar", :variable)
     end
+
+    test "preserves external operation names" do
+      assert "fooBar" = LanguageConventions.to_internal_name("fooBar", :operation)
+    end
+
+    test "converts external field names that do not match internal name" do
+      assert "foo_bar" = LanguageConventions.to_internal_name("foo_bar", :field)
+      assert "foo_bar" = LanguageConventions.to_internal_name("FooBar", :field)
+      assert "foo_bar" = LanguageConventions.to_internal_name("FOO_BAR", :field)
+    end
   end
 
   describe "to_external_name/2" do
@@ -20,6 +30,10 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
 
     test "converts internal underscored variable names to camelcase external variable names" do
       assert "fooBar" = LanguageConventions.to_external_name("foo_bar", :variable)
+    end
+
+    test "preserves internal operation names" do
+      assert "foo_bar" = LanguageConventions.to_external_name("foo_bar", :operation)
     end
   end
 end

--- a/test/absinthe/adapters/strict_language_conventions_test.exs
+++ b/test/absinthe/adapters/strict_language_conventions_test.exs
@@ -1,0 +1,43 @@
+defmodule Absinthe.Adapter.StrictLanguageConventionsTest do
+  use Absinthe.Case, async: true
+
+  alias Absinthe.Adapter.StrictLanguageConventions
+
+  describe "to_internal_name/2" do
+    test "converts external camelcase directive names to underscore" do
+      assert "foo_bar" = StrictLanguageConventions.to_internal_name("fooBar", :directive)
+    end
+
+    test "converts external camelcase field names to underscore" do
+      assert "foo_bar" = StrictLanguageConventions.to_internal_name("fooBar", :field)
+    end
+
+    test "converts external camelcase variable names to underscore" do
+      assert "foo_bar" = StrictLanguageConventions.to_internal_name("fooBar", :variable)
+    end
+
+    test "preserves external operation names" do
+      assert "fooBar" = StrictLanguageConventions.to_internal_name("fooBar", :operation)
+    end
+
+    test "nullifies external field names that do not match internal name" do
+      assert is_nil(StrictLanguageConventions.to_internal_name("foo_bar", :field))
+      assert is_nil(StrictLanguageConventions.to_internal_name("FooBar", :field))
+      assert is_nil(StrictLanguageConventions.to_internal_name("FOO_BAR", :field))
+    end
+  end
+
+  describe "to_external_name/2" do
+    test "converts internal underscored field names to camelcase external field names" do
+      assert "fooBar" = StrictLanguageConventions.to_external_name("foo_bar", :field)
+    end
+
+    test "converts internal underscored variable names to camelcase external variable names" do
+      assert "fooBar" = StrictLanguageConventions.to_external_name("foo_bar", :variable)
+    end
+
+    test "preserves internal operation names" do
+      assert "foo_bar" = StrictLanguageConventions.to_external_name("foo_bar", :operation)
+    end
+  end
+end

--- a/test/absinthe/strict_schema_test.exs
+++ b/test/absinthe/strict_schema_test.exs
@@ -1,0 +1,375 @@
+defmodule Absinthe.StrictSchemaTest do
+  use Absinthe.Case, async: true
+
+  describe "directive strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @fooBarDirective(bazQux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @foo_bar_directive(bazQux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Unknown directive `foo_bar_directive'.",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used in argument" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @fooBarDirective(baz_qux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Unknown argument \"baz_qux\" on directive \"@fooBarDirective\".",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+
+  describe "directive non-strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @fooBarDirective(bazQux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @foo_bar_directive(bazQux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name in argument" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery @fooBarDirective(baz_qux: $input) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+
+  describe "query strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used" do
+      document = """
+      query ($input: FooBarInput!) {
+        foo_bar_query(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Cannot query field \"foo_bar_query\" on type \"RootQueryType\". Did you mean to use an inline fragment on \"RootQueryType\"?",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used in argument" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery(baz_qux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Unknown argument \"baz_qux\" on field \"fooBarQuery\" of type \"RootQueryType\".",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+
+  describe "query non-strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name" do
+      document = """
+      query ($input: FooBarInput!) {
+        foo_bar_query(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naive_datetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naive_datetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"foo_bar_query" => %{"naive_datetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name in argument" do
+      document = """
+      query ($input: FooBarInput!) {
+        fooBarQuery(baz_qux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarQuery" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+
+  describe "mutation strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        fooBarMutation(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarMutation" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        foo_bar_mutation(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Cannot query field \"foo_bar_mutation\" on type \"RootMutationType\". Did you mean to use an inline fragment on \"RootMutationType\"?",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "returns an error when underscore external name used in argument" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        fooBarMutation(baz_qux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_error_message(
+        "Unknown argument \"baz_qux\" on field \"fooBarMutation\" of type \"RootMutationType\".",
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.StrictLanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+
+  describe "mutation non-strict adapter" do
+    test "can use camelcase external name" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        fooBarMutation(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarMutation" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        foo_bar_mutation(bazQux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naive_datetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naive_datetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"foo_bar_mutation" => %{"naive_datetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+
+    test "can use underscore external name in argument" do
+      document = """
+      mutation ($input: FooBarInput!) {
+        fooBarMutation(baz_qux: $input) @fooBarDirective(bazQux: {naiveDatetime: "2017-01-27T20:31:56"}) {
+          naiveDatetime
+        }
+      }
+      """
+
+      variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
+
+      assert_data(
+        %{"fooBarMutation" => %{"naiveDatetime" => "2017-01-27T20:31:55"}},
+        run(document, Absinthe.Fixtures.StrictSchema,
+          adapter: Absinthe.Adapter.LanguageConventions,
+          variables: variables
+        )
+      )
+    end
+  end
+end

--- a/test/support/fixtures/strict_schema.ex
+++ b/test/support/fixtures/strict_schema.ex
@@ -1,0 +1,56 @@
+defmodule Absinthe.Fixtures.StrictSchema do
+  use Absinthe.Schema
+
+  import_types Absinthe.Type.Custom
+
+  directive :foo_bar_directive do
+    arg :baz_qux, non_null(:foo_bar_input)
+    on [:field]
+
+    expand fn %{baz_qux: %{naive_datetime: naive_datetime}}, node = %{flags: flags} ->
+      %{node | flags: Map.put(flags, :baz_qux, naive_datetime)}
+    end
+  end
+
+  input_object :foo_bar_input do
+    field :naive_datetime, non_null(:naive_datetime)
+  end
+
+  object :foo_bar_object do
+    field :naive_datetime, non_null(:naive_datetime)
+  end
+
+  query do
+    field :foo_bar_query, :foo_bar_object do
+      arg :baz_qux, :foo_bar_input
+
+      resolve fn
+        %{baz_qux: %{naive_datetime: naive_datetime}}, _ ->
+          {:ok, %{naive_datetime: naive_datetime}}
+
+        _, %{definition: %{flags: %{baz_qux: naive_datetime}}} ->
+          {:ok, %{naive_datetime: naive_datetime}}
+
+        _, _ ->
+          {:ok, nil}
+      end
+    end
+  end
+
+  mutation do
+    field :foo_bar_mutation, :foo_bar_object do
+      arg :baz_qux, :foo_bar_input
+
+      resolve fn
+        %{baz_qux: %{naive_datetime: naive_datetime}}, _ ->
+          {:ok, %{naive_datetime: naive_datetime}}
+
+        _, %{definition: %{flags: %{baz_qux: naive_datetime}}} ->
+          {:ok, %{naive_datetime: naive_datetime}}
+
+        _, _ ->
+          {:ok, nil}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Alternative adapter for enforcing strict incoming document directive, field, and argument naming to be explicitly camelCase.

##### What needs to be solved?

The default [`Absinthe.Adapter.LanguageConventions`](https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/adapter/language_conventions.ex) allows non-camelcase external names to be converted to their respective internal names.

A stricter version of the language conventions adapter would be preferable where the "external" in an "external-to-internal" conversion matches the "external" in an "internal-to-external" conversion.

It is also preferable that any changes to absinthe cause as little disruption as possible to existing users who are not concerned about this implicit flexibility.

##### Why?

@ferigis Initially brought this unintentional feature-or-bug to my attention today where incoming documents by default can use a variety of invalid directive, field, and/or argument names and the server will respond normally without any errors.

For example, for a given field:

```elixir
field :expires_at, :datetime
```

The default [`Absinthe.Adapter.LanguageConventions`](https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/adapter/language_conventions.ex) accepts any inbound name like: `expiresAt`, `expires_at`, `EXPIRES_AT`, or `ExpiresAt` and maps them to the internal `expires_at`.

Clients, like [GraphQL Playground built into `absinthe_plug`](https://github.com/absinthe-graphql/absinthe_plug), properly warn that these are invalid as they do not match the field names exposed in the introspection query:

<img width="642" alt="Playground - 2019-04-24 14-41-53" src="https://user-images.githubusercontent.com/1804/56688844-539ad500-669f-11e9-8d3c-6fea74f1d664.png">

The server, however, responds to the request as if it is a valid query:

<img width="496" alt="Playground - 2019-04-24 14-42-47" src="https://user-images.githubusercontent.com/1804/56689003-b12f2180-669f-11e9-9f99-ac71d530919a.png">

I am of the opinion that this is an error or bug on the server's part.

In my opinion, the server should not respond to a directive, field, or argument that has not been returned as part of the introspection query (with the exception of [two underscore `__` reserved names](https://graphql.github.io/graphql-spec/draft/#sec-Reserved-Names)).

At the very least, I think there should be an optional way to enforce this behavior server-side even if it is not the default.

##### How?

I reached out on [#absinthe-graphql](https://elixir-lang.slack.com/messages/C0PR49P4P/) to provide a brief description of the behavior and to find out whether this was intentional or well-known at this point:

<img width="1150" alt="absinthe-graphql | Elixir Slack 2019-04-24 11-44-40" src="https://user-images.githubusercontent.com/1804/56689116-f2bfcc80-669f-11e9-8f53-227dfc9d6fe4.png">

I initially began by changing [`Absinthe.Adapter.LanguageConventions`](https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/adapter/language_conventions.ex) directly, but found that there are several tests (like [`test/absinthe/custom_types_test.exs`](https://github.com/absinthe-graphql/absinthe/blob/master/test/absinthe/custom_types_test.exs)) that actually make use of the underscored version of field names.

Unless we're okay with enforcing this behavior by default (which may be a breaking change for some users of absinthe), I think the simplest route may be to just provide an alternative adapter that allows the server to operate in strict mode.

Summary of changes:

* Added [`Absinthe.Adapter.StrictLanguageConventions`](https://github.com/potatosalad/absinthe/blob/strict-language-conventions/lib/absinthe/adapter/strict_language_conventions.ex) which first converts the name to the internal (underscored) representation.  It then takes this internal representation and converts it back to the external representation.  If the external representation does not match the originally supplied name, then `nil` is returned.
* Modified [`Absinthe.Phase.Document.Validation.FieldsOnCorrectType`](https://github.com/potatosalad/absinthe/blob/strict-language-conventions/lib/absinthe/phase/document/validation/fields_on_correct_type.ex) to handle the `nil` returned by `to_internal_name/2` so that suggested field names can still be returned on mismatch.
* Added tests to [`test/absinthe/adapters/language_conventions_test.exs`](https://github.com/potatosalad/absinthe/blob/strict-language-conventions/test/absinthe/adapters/language_conventions_test.exs) to demonstrate the existing behavior of the default adapter.
* Added tests to [`test/absinthe/adapters/strict_language_conventions_test.exs`](https://github.com/potatosalad/absinthe/blob/strict-language-conventions/test/absinthe/adapters/strict_language_conventions_test.exs) to demonstrate the alternative behavior of the strict adapter.
* Added tests to [`test/absinthe/strict_schema_test.exs`](https://github.com/potatosalad/absinthe/blob/strict-language-conventions/test/absinthe/strict_schema_test.exs) to demonstrate the effect of the different adapters for directives, queries, and mutations.
* Added some basic documentation describing the adapter.