### PR TITLE
Adds notes to subscription guide about GraphiQL setup

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -64,6 +64,17 @@ use Absinthe.Phoenix.Socket,
 
 Where `MyAppWeb.Schema` is the name of your Absinthe schema module.
 
+### GraphiQL (optional)
+
+If you're using the GraphiQL plug, in your `MyAppWeb.Router`, specify the `socket` option:
+
+```elixir
+forward "/graphiql",
+        Absinthe.Plug.GraphiQL,
+        schema: MyAppWeb.Schema,
+        socket: MyAppWeb.UserSocket
+```
+
 That is all that's required for setup on the server.
 
 ### Setting Options


### PR DESCRIPTION
Hi!

Was recently configuring Absinthe for a project by following the guides, but at the end subscriptions didn't seem to work for me.

After debugging and re-reading the subscriptions chapter in the book, it turned out they were working all along (doh!), but just not in GraphiQL. It was because `Absinthe.Plug.GraphiQL`'s `socket` option isn't mentioned in the guide. 

This PR adds a paragraph about configuring GraphiQL.
