### PR TITLE
Fail fast in formatting check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ otp_release:
   - 20.0
   - 21.0
 script:
- - MIX_ENV=test mix local.hex --force && MIX_ENV=test mix do deps.get, test
  - mix format --check-formatted
+ - MIX_ENV=test mix local.hex --force && MIX_ENV=test mix do deps.get, test


### PR DESCRIPTION
@benwilson512 I think it's helpful to fail fast if the formatting is incorrect, instead of waiting for the full test suite to run only to fail.