### PR TITLE
Phase.Init: pass blueprints through

### DIFF
--- a/lib/absinthe/phase/init.ex
+++ b/lib/absinthe/phase/init.ex
@@ -5,8 +5,14 @@ defmodule Absinthe.Phase.Init do
 
   alias Absinthe.{Blueprint, Language, Phase}
 
-  @spec run(Language.Source.t(), Keyword.t()) :: Phase.result_t()
-  def run(input, _options \\ []) do
+  @spec run(Blueprint.t() | Language.Source.t(), Keyword.t()) :: Phase.result_t()
+  def run(blueprint, options \\ [])
+
+  def run(%Absinthe.Blueprint{} = blueprint, _options) do
+    {:ok, blueprint}
+  end
+
+  def run(input, _options) do
     {:ok, %Blueprint{input: input}}
   end
 end


### PR DESCRIPTION
The telemetry branch added a new phase which runs before Phase.Parse: https://github.com/absinthe-graphql/absinthe/commit/8ff081647bff240c80b259a6032204d1c652c1a1#diff-bf69d2d0e622a30890fc6e89dc61c094R1

The problem is, while Phase.Parse allowed passing in an existing blueprint, Phase.Init currently doesn't account for that, and essentially returns `%Blueprint{input: blueprint}`. This is a problem for us, because the invalid state would later fail saying "No operations provided.". 

This PR restores the old behaviour.