### PR TITLE
Define schema in SDL

### DIFF
--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -13,6 +13,10 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     directive @foo(name: String!) on SCALAR | OBJECT
     directive @bar(name: String!) on SCALAR | OBJECT
 
+    schema {
+      query: Query
+    }
+
     type Query {
       "A list of posts"
       posts(filter: PostFilter, reverse: Boolean): [Post]


### PR DESCRIPTION
I noticed that things blow up if the `schema` is defined in the SDL

```
** (KeyError) key :name not found in: %Absinthe.Blueprint.Schema.SchemaDefinition{...}
```

https://graphql.github.io/graphql-spec/draft/#example-e2969

```graphql
schema {
  query: Query
  mutation: Mutation
}
```