### PR TITLE
Fix #650 (@desc not working on field arguments)

### DIFF
--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -94,6 +94,7 @@ defmodule Absinthe.Blueprint.Schema do
     Schema.EnumTypeDefinition,
     Schema.DirectiveDefinition,
     Schema.InputObjectTypeDefinition,
+    Schema.InputValueDefinition,
     Schema.InterfaceTypeDefinition,
     Schema.UnionTypeDefinition,
     Schema.EnumValueDefinition
@@ -141,16 +142,6 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [enum | stack], buff)
   end
 
-  defp build_types([%Schema.InputValueDefinition{} = arg, {:desc, desc} | rest], stack, buff) do
-    arg = %{arg | description: desc}
-    build_types([arg | rest], stack, buff)
-  end
-
-  defp build_types([%Schema.InputValueDefinition{} = arg | rest], [field | stack], buff) do
-    arg = Map.update!(arg, :default_value, fn val -> {:unquote, [], [val]} end)
-    build_types(rest, [push(field, :arguments, arg) | stack], buff)
-  end
-
   defp build_types([{:sdl, sdl_definitions} | rest], [schema | stack], buff) do
     # TODO: Handle directives, etc
     build_types(rest, [concat(schema, :type_definitions, sdl_definitions) | stack], buff)
@@ -168,6 +159,11 @@ defmodule Absinthe.Blueprint.Schema do
 
   defp build_types([:close | rest], [%Schema.EnumValueDefinition{} = value, enum | stack], buff) do
     build_types(rest, [push(enum, :values, value) | stack], buff)
+  end
+
+  defp build_types([:close | rest], [%Schema.InputValueDefinition{} = arg, field | stack], buff) do
+    arg = Map.update!(arg, :default_value, fn val -> {:unquote, [], [val]} end)
+    build_types(rest, [push(field, :arguments, arg) | stack], buff)
   end
 
   defp build_types([:close | rest], [%Schema.FieldDefinition{} = field, obj | stack], buff) do

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -141,6 +141,11 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [enum | stack], buff)
   end
 
+  defp build_types([%Schema.InputValueDefinition{} = arg, {:desc, desc} | rest], stack, buff) do
+    arg = %{arg | description: desc}
+    build_types([arg | rest], stack, buff)
+  end
+
   defp build_types([%Schema.InputValueDefinition{} = arg | rest], [field | stack], buff) do
     arg = Map.update!(arg, :default_value, fn val -> {:unquote, [], [val]} end)
     build_types(rest, [push(field, :arguments, arg) | stack], buff)

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1201,7 +1201,7 @@ defmodule Absinthe.Schema.Notation do
       attrs
       |> handle_deprecate
       |> Keyword.put(:identifier, identifier)
-      |> Keyword.put(:name, to_string(identifier))
+      |> Keyword.put_new(:name, to_string(identifier))
       |> put_reference(env)
 
     struct!(Schema.InputValueDefinition, attrs)
@@ -1209,7 +1209,11 @@ defmodule Absinthe.Schema.Notation do
 
   def record_arg!(env, identifier, attrs) do
     arg = build_arg(identifier, Keyword.put(attrs, :module, env.module), env)
-    put_attr(env.module, arg)
+    ref = put_attr(env.module, arg)
+
+    [
+      get_desc(ref)
+    ]
   end
 
   @doc false

--- a/test/absinthe/schema/notation/experimental/argument_test.exs
+++ b/test/absinthe/schema/notation/experimental/argument_test.exs
@@ -1,0 +1,54 @@
+defmodule Absinthe.Schema.Notation.Experimental.ArgumentTest do
+  use Absinthe.Case
+  import ExperimentalNotationHelpers
+
+  @moduletag :experimental
+
+  defmodule Definition do
+    use Absinthe.Schema.Notation
+
+    @desc "Object"
+    object :obj do
+      @desc "Field"
+      field :field, :string do
+        arg :plain, :string
+
+        arg :with_attrs, type: :boolean, name: "HasAttrs"
+
+        @desc "Desc One"
+        arg :with_desc, :string
+
+        @desc "Desc Three"
+        arg :with_desc_attr, type: :string, description: "overridden"
+
+        arg :with_desc_attr_literal, type: :string, description: "Desc Four"
+      end
+    end
+  end
+
+  describe "arg" do
+    test "with a bare type" do
+      assert %{name: "plain", description: nil, type: :string, identifier: :plain} =
+               lookup_argument(Definition, :obj, :field, :plain)
+    end
+
+    test "with attrs" do
+      assert %{name: "HasAttrs", type: :boolean, identifier: :with_attrs} =
+               lookup_argument(Definition, :obj, :field, :with_attrs)
+    end
+
+    test "with @desc" do
+      assert %{description: "Desc One"} = lookup_argument(Definition, :obj, :field, :with_desc)
+    end
+
+    test "with @desc and a description attr" do
+      assert %{description: "Desc Three"} =
+               lookup_argument(Definition, :obj, :field, :with_desc_attr)
+    end
+
+    test "with a description attribute as a literal" do
+      assert %{description: "Desc Four"} =
+               lookup_argument(Definition, :obj, :field, :with_desc_attr_literal)
+    end
+  end
+end


### PR DESCRIPTION
- Fix #650 (`@desc` not working on field arguments)
- Also fixes the `:name` option not working for arguments

### Approach I took

Since `Absinthe.Blueprint.Schema.build_types/3` doesn't push a `InputValueDefinition` onto the stack (it sets is on the `FieldDefinition`), a `{:desc, _}` tuple doesn't get applied to the `Schema.InputValueDefinition`.

I added a clause to `build_types/3` that peeks ahead of a `InputValueDefinition` to consume the `{:desc, _}` tuple

### Other thoughts

Looking back, would it make more sense to instead to:

- Have `Absinthe.Schema.Notation` create a `:close` element after `Schema.InputValueDefinition` (and any `{:desc, _}` for that argument), and,
- put the `Schema.InputValueDefinition` on the stack in `build_types/3`, then wait for the `:close` to set it on the `Schema.FieldDefinition`, and
- let the existing `build_types/3` clause for `{:desc, _}` handle setting `description` on the `Schema.InputValueDefinition`

Thoughts?