### PR TITLE
Specify nimble-parsec version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule Absinthe.Mixfile do
 
   defp deps do
     [
-      {:nimble_parsec, "~> 0.4"},
+      {:nimble_parsec, "~> 0.5"},
       {:telemetry, "~> 0.4.0"},
       {:dataloader, "~> 1.0.0", optional: true},
       {:decimal, "~> 1.0", optional: true},


### PR DESCRIPTION
We need version `0.5.0` explicitly for `post_traverse`. When pulled in via `absinthe_plug`, another dep was forcing it to use `0.4.0` which doesn't contain that function

@bruce 