### PR TITLE
Add directive locations for schema

### DIFF
--- a/lib/absinthe/blueprint/directive.ex
+++ b/lib/absinthe/blueprint/directive.ex
@@ -55,7 +55,6 @@ defmodule Absinthe.Blueprint.Directive do
   def placement(%Blueprint.Document.Fragment.Named{}), do: :fragment_definition
   def placement(%Blueprint.Document.Fragment.Spread{}), do: :fragment_spread
   def placement(%Blueprint.Document.Fragment.Inline{}), do: :inline_fragment
-  def placement(%Blueprint.Document.Operation{}), do: :operation_definition
   def placement(%Blueprint.Schema.SchemaDefinition{}), do: :schema
   def placement(%Blueprint.Schema.SchemaDeclaration{}), do: :schema
   def placement(%Blueprint.Schema.ScalarTypeDefinition{}), do: :scalar

--- a/lib/absinthe/phase/schema/attach_directives.ex
+++ b/lib/absinthe/phase/schema/attach_directives.ex
@@ -39,5 +39,4 @@ defmodule Absinthe.Phase.Schema.AttachDirectives do
   defp handle_node(node, _schema, _proto_schema) do
     node
   end
-
 end

--- a/lib/absinthe/phase/schema/attach_directives.ex
+++ b/lib/absinthe/phase/schema/attach_directives.ex
@@ -35,7 +35,12 @@ defmodule Absinthe.Phase.Schema.AttachDirectives do
     [
       %Absinthe.Type.Directive{
         name: "deprecated",
-        locations: [:field_definition, :input_field_definition, :argument_definition],
+        locations: [
+          :field_definition,
+          :input_field_definition,
+          :argument_definition,
+          :enum_value
+        ],
         expand: &expand_deprecate/2
       }
     ]

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -77,7 +77,6 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
   enum :__directive_location,
     values: [
-      # OPERATIONS
       :query,
       :mutation,
       :subscription,
@@ -85,7 +84,6 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       :fragment_definition,
       :fragment_spread,
       :inline_fragment,
-      :operation_definition,
       :schema,
       :scalar,
       :object,

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -84,8 +84,19 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       :field,
       :fragment_definition,
       :fragment_spread,
-      :inline_fragment
-      # TODO: Schema definitions to support Schema input
+      :inline_fragment,
+      :operation_definition,
+      :schema,
+      :scalar,
+      :object,
+      :field_definition,
+      :interface,
+      :union,
+      :enum,
+      :enum_value,
+      :input_object,
+      :argument_definition,
+      :input_field_definition
     ]
 
   object :__type do

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -61,7 +61,6 @@ defmodule Absinthe.Type.Directive do
   defp do_on?(:fragment_definition, %Language.Fragment{}), do: true
   defp do_on?(:fragment_spread, %Language.FragmentSpread{}), do: true
   defp do_on?(:inline_fragment, %Language.InlineFragment{}), do: true
-  defp do_on?(:operation_definition, %Language.OperationDefinition{}), do: true
   defp do_on?(:schema, %Language.SchemaDefinition{}), do: true
   defp do_on?(:schema, %Language.SchemaDeclaration{}), do: true
   defp do_on?(:scalar, %Language.ScalarTypeDefinition{}), do: true

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -61,6 +61,18 @@ defmodule Absinthe.Type.Directive do
   defp do_on?(:fragment_definition, %Language.Fragment{}), do: true
   defp do_on?(:fragment_spread, %Language.FragmentSpread{}), do: true
   defp do_on?(:inline_fragment, %Language.InlineFragment{}), do: true
-  # TODO: Schema definitions to support Schema input
+  defp do_on?(:operation_definition, %Language.OperationDefinition{}), do: true
+  defp do_on?(:schema, %Language.SchemaDefinition{}), do: true
+  defp do_on?(:schema, %Language.SchemaDeclaration{}), do: true
+  defp do_on?(:scalar, %Language.ScalarTypeDefinition{}), do: true
+  defp do_on?(:object, %Language.ObjectTypeDefinition{}), do: true
+  defp do_on?(:field_definition, %Language.FieldDefinition{}), do: true
+  defp do_on?(:interface, %Language.InterfaceTypeDefinition{}), do: true
+  defp do_on?(:union, %Language.UnionTypeDefinition{}), do: true
+  defp do_on?(:enum, %Language.EnumTypeDefinition{}), do: true
+  defp do_on?(:enum_value, %Language.EnumValueDefinition{}), do: true
+  defp do_on?(:input_object, %Language.InputObjectTypeDefinition{}), do: true
+  defp do_on?(:argument_definition, %Language.InputValueDefinition{}), do: true
+  defp do_on?(:input_field_definition, %Language.InputValueDefinition{}), do: true
   defp do_on?(_, _), do: false
 end


### PR DESCRIPTION
* Updating directive locations for schemas..

As noted in https://github.com/absinthe-graphql/absinthe/pull/736/files/d3d9dcde3bc6623ff839148fbe21df7f6bef2b6b#r289664556

* Update built-in `@deprecated` to allow it on enum values