### PR TITLE
Add note on graphql docs in phoenix controllers

### DIFF
--- a/guides/plug-phoenix.md
+++ b/guides/plug-phoenix.md
@@ -201,3 +201,20 @@ plug Absinthe.Plug,
 
 It also takes several options. See [the documentation](https://hexdocs.pm/absinthe_plug/Absinthe.Plug.html#init/1)
 for the full listing.
+
+## Inside Phoenix controllers
+
+You can use GraphQL as the datasource for your Phoenix controllers. 
+
+```elixir
+@graphql """
+  query ($filter: UserFilter) {
+    users(filter: $filter, limit: 10)
+  }
+"""
+def index(conn, %{data: data}) do
+  render conn, "index.html", data
+end
+```
+The results of the query are now available in the "index.html" template. For
+more information, see [`Absinthe.Phoenix.Controller`](https://hexdocs.pm/absinthe_phoenix/Absinthe.Phoenix.Controller.html)

--- a/guides/plug-phoenix.md
+++ b/guides/plug-phoenix.md
@@ -204,7 +204,8 @@ for the full listing.
 
 ## Inside Phoenix controllers
 
-You can use GraphQL as the datasource for your Phoenix controllers. 
+You can use GraphQL as the datasource for your Phoenix controllers. For this 
+you'll need to add `absinthe_phoenix` to your dependencies. See [Absinthe Phoenix](https://github.com/absinthe-graphql/absinthe_phoenix) for installation instructions.
 
 ```elixir
 @graphql """


### PR DESCRIPTION
The absinthe documentation does not mention the usage of graphql docs inside Phoenix controllers.
This is a pretty cool feature, so I added it to "Plug and Phoenix Setup " section and linked it to https://hexdocs.pm/absinthe_phoenix/Absinthe.Phoenix.Controller.html