### PR TITLE
Easy extension of built-in (schema) directives for SDL

### DIFF
--- a/lib/absinthe/schema/prototype/notation.ex
+++ b/lib/absinthe/schema/prototype/notation.ex
@@ -1,0 +1,51 @@
+defmodule Absinthe.Schema.Prototype.Notation do
+  @moduledoc false
+
+  defmacro __using__(opts \\ []) do
+    content(opts)
+  end
+
+  def content(_opts \\ []) do
+    quote do
+      use Absinthe.Schema
+      @pipeline_modifier __MODULE__
+
+      directive :deprecated do
+        arg :reason, :string
+
+        on [
+          :field_definition,
+          :input_field_definition,
+          # Technically, argument deprecation is not yet defined by the GraphQL
+          # specification. Absinthe does provide some support, but deprecating
+          # arguments is not recommended.
+          #
+          # For more information, see:
+          # - https://github.com/graphql/graphql-spec/pull/525
+          # - https://github.com/absinthe-graphql/absinthe/issues/207
+          :argument_definition
+        ]
+
+        expand &__MODULE__.expand_deprecate/2
+      end
+
+      def pipeline(pipeline) do
+        pipeline
+        |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.Validation.QueryTypeMustBeObject)
+      end
+
+      @doc """
+      Add a deprecation (with an optional reason) to a node.
+      """
+      @spec expand_deprecate(
+              arguments :: %{optional(:reason) => String.t()},
+              node :: Absinthe.Blueprint.node_t()
+            ) :: Absinthe.Blueprint.node_t()
+      def expand_deprecate(arguments, node) do
+        %{node | deprecation: %Absinthe.Type.Deprecation{reason: arguments[:reason]}}
+      end
+
+      defoverridable(pipeline: 1)
+    end
+  end
+end

--- a/test/absinthe/phase/execution/non_null_test.exs
+++ b/test/absinthe/phase/execution/non_null_test.exs
@@ -200,7 +200,6 @@ defmodule Absinthe.Phase.Document.Execution.NonNullTest do
       assert {:ok, %{data: data, errors: errors}} == Absinthe.run(doc, Schema)
     end
 
-    @tag :syntax
     test "list of non null things works when child has a null violation" do
       doc = """
       {

--- a/test/absinthe/schema/experimental_test.exs
+++ b/test/absinthe/schema/experimental_test.exs
@@ -65,7 +65,6 @@ defmodule Absinthe.Schema.ExperimentalTest do
              Absinthe.run(query, Schema)
   end
 
-  @tag :simple
   test "simple input" do
     query = """
     { hello(name: "bob") }

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -371,7 +371,6 @@ defmodule Absinthe.SchemaTest do
   end
 
   describe "can add metadata to an object" do
-    @tag :wip
     test "sets object metadata" do
       foo = Schema.lookup_type(MetadataSchema, :foo)
 


### PR DESCRIPTION
See the `@moduledoc` for `Absinthe.Schema.Prototype`.