### PR TITLE
Expand error message for invalid resolver

### DIFF
--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -218,6 +218,16 @@ defmodule Absinthe.Resolution do
 
           Instead got: #{inspect(resolution_function)}
 
+          Resolving field:
+
+              #{res.definition.name}
+
+          Defined at:
+
+              #{res.definition.schema_node.__reference__.location.file}:#{
+            res.definition.schema_node.__reference__.location.line
+          }
+
           Info: #{inspect(res)}
           """
       end

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -26,6 +26,10 @@ defmodule Absinthe.ResolutionTest do
           {:ok, nil}
         end
       end
+
+      field :invalid_resolver, :string do
+        resolve("bogus")
+      end
     end
   end
 
@@ -60,5 +64,17 @@ defmodule Absinthe.ResolutionTest do
     assert_receive({:fields, fields})
 
     assert ["id", "name"] == fields
+  end
+
+  test "invalid resolver" do
+    doc = """
+    { invalidResolver }
+    """
+
+    assert_raise Absinthe.ExecutionError,
+                 ~r/Field resolve property must be a 2 arity anonymous function, 3 arity\nanonymous function, or a `{Module, :function}` tuple.\n\nInstead got: \"bogus\"\n\nResolving field:\n\n    invalidResolver/,
+                 fn ->
+                   {:ok, _} = Absinthe.run(doc, Schema)
+                 end
   end
 end


### PR DESCRIPTION
I ran across an issue where I accidentally had a invalid resolver but was unable to quickly trace where it was defined. 

This PR makes the error more verbose and adds the field name and where it was defined to the error message. I also added a test for this behaviour.