### PR TITLE
Fixed dangling documentation links.

### DIFF
--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -15,7 +15,7 @@ defmodule Absinthe.Type.Directive do
 
   * `:name` - The name of the directivee. Should be a lowercase `binary`. Set automatically.
   * `:description` - A nice description for introspection.
-  * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/1`.
+  * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/2`.
   * `:locations` - A list of places the directives can be used.
 
   The `:__reference__` key is for internal use.

--- a/lib/absinthe/type/enum/value.ex
+++ b/lib/absinthe/type/enum/value.ex
@@ -19,7 +19,7 @@ defmodule Absinthe.Type.Enum.Value do
   * `:value` - The raw, internal value that `:name` map to. This will be
     provided as the argument value to `resolve` functions.
   * `:deprecation` - Deprecation information for a value, usually
-    set-up using the `Absinthe.Schema.Notation.deprecate/2` convenience
+    set-up using the `Absinthe.Schema.Notation.deprecate/1` convenience
     function.
   """
   @type t :: %{

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -71,7 +71,7 @@ defmodule Absinthe.Type.Field do
   The configuration for a field.
 
   * `:name` - The name of the field, usually assigned automatically by
-     the `Absinthe.Schema.Notation.field/1`. Including this option will bypass the snake_case to camelCase conversion.
+     the `Absinthe.Schema.Notation.field/4`. Including this option will bypass the snake_case to camelCase conversion.
   * `:description` - Description of a field, useful for introspection.
   * `:deprecation` - Deprecation information for a field, usually
      set-up using `Absinthe.Schema.Notation.deprecate/1`.

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Type.InputObject do
 
   * `:name` - The name of the input object type. Should be a TitleCased `binary`. Set automatically.
   * `:description` - A nice description for introspection.
-  * `:fields` - A map of `Absinthe.Type.Field` structs. Usually built via `Absinthe.Schema.Notation.field/1`.
+  * `:fields` - A map of `Absinthe.Type.Field` structs. Usually built via `Absinthe.Schema.Notation.field/4`.
 
   The `__private__` and `:__reference__` fields are for internal use.
   """

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -50,7 +50,7 @@ defmodule Absinthe.Type.Interface do
   @typedoc """
   * `:name` - The name of the interface type. Should be a TitleCased `binary`. Set automatically.
   * `:description` - A nice description for introspection.
-  * `:fields` - A map of `Absinthe.Type.Field` structs. See `Absinthe.Schema.Notation.field/1` and
+  * `:fields` - A map of `Absinthe.Type.Field` structs. See `Absinthe.Schema.Notation.field/4` and
   * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/2`.
   * `:resolve_type` - A function used to determine the implementing type of a resolved object. See also `Absinthe.Type.Object`'s `:is_type_of`.
 

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -77,7 +77,7 @@ defmodule Absinthe.Type.Object do
 
   * `:name` - The name of the object type. Should be a TitleCased `binary`. Set automatically.
   * `:description` - A nice description for introspection.
-  * `:fields` - A map of `Absinthe.Type.Field` structs. Usually built via `Absinthe.Schema.Notation.field/1`.
+  * `:fields` - A map of `Absinthe.Type.Field` structs. Usually built via `Absinthe.Schema.Notation.field/4`.
   * `:interfaces` - A list of interfaces that this type guarantees to implement. See `Absinthe.Type.Interface`.
   * `:is_type_of` - A function used to identify whether a resolved object belongs to this defined type. For use with `:interfaces` entry and `Absinthe.Type.Interface`.
 


### PR DESCRIPTION
Update references in documentation to actually existing function calls or macro definitions.