### PR TITLE
Convert SDL schema default value into Elixir terms

### DIFF
--- a/lib/absinthe/language/input_value_definition.ex
+++ b/lib/absinthe/language/input_value_definition.ex
@@ -29,7 +29,7 @@ defmodule Absinthe.Language.InputValueDefinition do
         description: node.description,
         type: Blueprint.Draft.convert(node.type, doc),
         identifier: Macro.underscore(node.name) |> String.to_atom(),
-        default_value: Blueprint.Draft.convert(node.default_value, doc),
+        default_value: to_term(node.default_value),
         directives: Blueprint.Draft.convert(node.directives, doc),
         source_location: source_location(node)
       }
@@ -37,5 +37,20 @@ defmodule Absinthe.Language.InputValueDefinition do
 
     defp source_location(%{loc: nil}), do: nil
     defp source_location(%{loc: loc}), do: Blueprint.SourceLocation.at(loc)
+
+    defp to_term(nil),
+      do: nil
+
+    defp to_term(%Language.EnumValue{value: value}),
+      do: value |> Macro.underscore() |> String.to_atom()
+
+    defp to_term(%Language.ListValue{values: values}),
+      do: Enum.map(values, &to_term/1)
+
+    defp to_term(%Language.ObjectValue{fields: fields}),
+      do: Enum.into(fields, %{}, &{String.to_atom(&1.name), to_term(&1.value)})
+
+    defp to_term(%{value: value}),
+      do: value
   end
 end

--- a/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
+++ b/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
@@ -73,7 +73,7 @@ defmodule Absinthe.Phase.Schema.Validation.DefaultEnumValuePresent do
     """
     The default_value for an enum must be present in the enum values.
 
-    Could not use default value of "#{inspect(default_value)}" for #{inspect(type)}.
+    Could not use default value of `#{inspect(default_value)}` for #{inspect(type)}.
 
     Valid values are:
     #{value_list}

--- a/test/absinthe/language/field_definition_test.exs
+++ b/test/absinthe/language/field_definition_test.exs
@@ -49,10 +49,7 @@ defmodule Absinthe.Language.FieldDefinitionTest do
                    name: "limit",
                    identifier: :limit,
                    type: %Blueprint.TypeReference.Name{name: "Int"},
-                   default_value: %Blueprint.Input.Integer{
-                     value: 4,
-                     source_location: %Blueprint.SourceLocation{column: 23, line: 4}
-                   },
+                   default_value: 4,
                    source_location: %Absinthe.Blueprint.SourceLocation{column: 10, line: 4}
                  }
                ],

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -37,6 +37,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       order: Int
       deprecatedField: String @deprecated
       deprecatedFieldWithReason: String @deprecated(reason: "Reason")
+      enumArg(category: Category = NEWS): Category
     }
 
     enum Category {

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -29,6 +29,19 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       posts(filterBy: PostFilter, reverse: Boolean): [Post]
       admin: User!
       droppedField: String
+      defaultsOfVariousFlavors(
+        name: String = "Foo"
+        count: Int = 3
+        average: Float = 3.14
+        category: Category = NEWS
+        category: [Category] = [NEWS]
+        valid: Boolean = false
+        complex: ComplexInput = {nested: "String"}
+      ): String
+    }
+
+    input ComplexInput {
+      nested: String
     }
 
     type Comment {
@@ -37,7 +50,6 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       order: Int
       deprecatedField: String @deprecated
       deprecatedFieldWithReason: String @deprecated(reason: "Reason")
-      enumArg(category: Category = NEWS): Category
     }
 
     enum Category {
@@ -311,12 +323,12 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
     test "default values" do
       type = Absinthe.Schema.lookup_type(FakerSchema, :fake__options)
-      assert %Absinthe.Blueprint.Input.Object{} = type.fields.base_color.default_value
+      assert %{red255: _, blue255: _, green255: _} = type.fields.base_color.default_value
 
       type = Absinthe.Schema.lookup_type(FakerSchema, :fake__color)
-      assert type.fields.red255.default_value.value == 0
-      assert type.fields.green255.default_value.value == 0
-      assert type.fields.blue255.default_value.value == 0
+      assert type.fields.red255.default_value == 0
+      assert type.fields.green255.default_value == 0
+      assert type.fields.blue255.default_value == 0
     end
   end
 end


### PR DESCRIPTION
This PR updates the `Blueprint.Draft.convert` function for `Language.InputValueDefinition` to set the `default_value` to a plain Elixir term, which aligns the behavior of SDL based schemas with existing Macro based schemas.