### PR TITLE
Updates recommended package in errors.md

### DIFF
--- a/guides/errors.md
+++ b/guides/errors.md
@@ -50,4 +50,4 @@ Generic handler for interoperability with errors from other libraries:
 
 ## Ecto.Changeset Errors
 
-You may want to look at the [kronky](https://hex.pm/packages/kronky) package.
+You may want to look at the [Absinthe ErrorPayload](https://hex.pm/packages/absinthe_error_payload) package.


### PR DESCRIPTION
Looks like Kronky has been forked and isn't maintained any longer – they are recommending Absinthe ErrorPayload now.

For reference: https://github.com/Ethelo/kronky/commit/5661f3a950c839065f0b2380c3bb294348b051bf
