### PR TITLE
fix: Interface and union on project

### DIFF
--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -171,6 +171,12 @@ defmodule Absinthe.Resolution.Projector do
     end
   end
 
+  defp passes_type_condition?(%Type.Object{} = condition, %Type.Union{} = type) do
+    if Type.Union.member?(type, condition) do
+      condition
+    end
+  end
+
   defp passes_type_condition?(_, _) do
     nil
   end

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -88,7 +88,7 @@ defmodule Absinthe.ResolutionTest do
         }
 
         ... on Named {
-            name
+          name
         }
       }
     }

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -69,14 +69,14 @@ defmodule Absinthe.ResolutionTest do
 
   test "project/1 works" do
     doc = """
-    { user { name } }
+    { user { id name } }
     """
 
     {:ok, _} = Absinthe.run(doc, Schema)
 
     assert_receive({:fields, fields})
 
-    assert ["name"] == fields
+    assert ["id", "name"] == fields
   end
 
   test "project/1 works with fragments and things" do


### PR DESCRIPTION
This PR fix: if the type of a query is an interface or union, the project function would ignore selections under the interface or union.