### PR TITLE
Fix handling of default value with list_of(enum)

### DIFF
--- a/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
+++ b/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
@@ -69,7 +69,7 @@ defmodule Absinthe.Phase.Schema.Validation.DefaultEnumValuePresent do
     """
     The default_value for an enum must be present in the enum values.
 
-    Could not use default value of "#{default_value}" for #{inspect(type)}.
+    Could not use default value of "#{inspect(default_value)}" for #{inspect(type)}.
 
     Valid values are:
     #{value_list}

--- a/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
+++ b/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
@@ -25,7 +25,7 @@ defmodule Absinthe.Phase.Schema.Validation.DefaultEnumValuePresent do
     node
   end
 
-  def validate_defaults(%{default_value: default, type: type} = node, enums) do
+  def validate_defaults(%{default_value: default_value, type: type} = node, enums) do
     type = Blueprint.TypeReference.unwrap(type)
 
     case Map.fetch(enums, type) do
@@ -33,11 +33,15 @@ defmodule Absinthe.Phase.Schema.Validation.DefaultEnumValuePresent do
         values = Enum.map(enum.values, & &1.value)
         value_list = Enum.map(values, &"\n * #{inspect(&1)}")
 
-        if not (default in values) do
+        default_valid? =
+          List.wrap(default_value)
+          |> Enum.all?(fn default -> default in values end)
+
+        if not default_valid? do
           detail = %{
             value_list: value_list,
             type: type,
-            default_value: default
+            default_value: default_value
           }
 
           node |> put_error(error(node, detail))

--- a/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
+++ b/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
@@ -1,0 +1,28 @@
+defmodule Elixir.Absinthe.Integration.Execution.InputTypes.Enum.DefaultValueTest do
+  use Absinthe.Case, async: true
+
+  @query """
+  query {
+    default: info {
+      name
+      value
+    }
+    defaults: infos {
+      name
+      value
+    }
+  }
+  """
+  test "default values" do
+    assert {:ok,
+            %{
+              data: %{
+                "default" => %{"name" => "RED", "value" => 100},
+                "defaults" => [
+                  %{"name" => "RED", "value" => 100},
+                  %{"name" => "GREEN", "value" => 200}
+                ]
+              }
+            }} == Absinthe.run(@query, Absinthe.Fixtures.ColorSchema, [])
+  end
+end

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -107,9 +107,6 @@ defmodule Absinthe.IntrospectionTest do
             queryType {
               fields {
                 name
-                type {
-                  name
-                }
                 args {
                   name
                   defaultValue
@@ -123,9 +120,7 @@ defmodule Absinthe.IntrospectionTest do
 
       assert {:ok, %{data: %{"__schema" => %{"queryType" => %{"fields" => fields}}}}} = result
 
-      assert [
-               %{"name" => "info", "args" => [%{"name" => "channel", "defaultValue" => "RED"}]}
-             ] = fields
+      assert %{"name" => "info", "args" => [%{"name" => "channel", "defaultValue" => "RED"}]} in fields
     end
   end
 

--- a/test/support/fixtures/color_schema.ex
+++ b/test/support/fixtures/color_schema.ex
@@ -19,7 +19,8 @@ defmodule Absinthe.Fixtures.ColorSchema do
     field :info,
       type: :channel_info,
       args: [
-        channel: [type: non_null(:channel), default_value: :r]
+        channel: [type: non_null(:channel), default_value: :r],
+        channels: [type: list_of(:channel), default_value: [:r]]
       ],
       resolve: fn %{channel: channel}, _ ->
         {:ok, %{name: @names[channel], value: @values[channel]}}

--- a/test/support/fixtures/color_schema.ex
+++ b/test/support/fixtures/color_schema.ex
@@ -19,11 +19,22 @@ defmodule Absinthe.Fixtures.ColorSchema do
     field :info,
       type: :channel_info,
       args: [
-        channel: [type: non_null(:channel), default_value: :r],
-        channels: [type: list_of(:channel), default_value: [:r]]
+        channel: [type: non_null(:channel), default_value: :r]
       ],
       resolve: fn %{channel: channel}, _ ->
         {:ok, %{name: @names[channel], value: @values[channel]}}
+      end
+
+    field :infos,
+      type: list_of(:channel_info),
+      args: [
+        channels: [type: list_of(:channel), default_value: [:r, :g]]
+      ],
+      resolve: fn %{channels: channels}, _ ->
+        {:ok,
+         Enum.map(channels, fn channel ->
+           %{name: @names[channel], value: @values[channel]}
+         end)}
       end
   end
 


### PR DESCRIPTION
This PR intends to fix handling of default value processing when the type is a `list_of(enum)`