### PR TITLE
Add support for brokered subscriptions

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -146,6 +146,7 @@ defmodule Absinthe.Subscription do
   @doc false
   def publish_remote(pubsub, mutation_result, subscribed_fields) do
     store_module = pubsub |> store_module
+
     {:ok, pool_size} =
       pubsub
       |> registry_name

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -68,7 +68,7 @@ defmodule Absinthe.Subscription.Local do
         Data: #{inspect(data)}
         """)
 
-        :ok = pubsub.publish_subscription(topic, data)
+        :ok = pubsub.publish_subscription(topic, data, doc.execution.context)
       rescue
         e ->
           BatchResolver.pipeline_error(e, System.stacktrace())

--- a/lib/absinthe/subscription/pubsub.ex
+++ b/lib/absinthe/subscription/pubsub.ex
@@ -72,5 +72,10 @@ defmodule Absinthe.Subscription.Pubsub do
   the newly resolved data. The broadcast should be limited to the current node 
   only.
   """
-  @callback publish_subscription(topic :: binary, data :: map) :: term
+  @callback publish_subscription(topic :: binary, data :: map, context :: map) :: term
+
+  @doc """
+  Return the storage module.
+  """
+  @callback store() :: module
 end

--- a/lib/absinthe/subscription/redix_store.ex
+++ b/lib/absinthe/subscription/redix_store.ex
@@ -17,11 +17,12 @@ defmodule Absinthe.Subscription.RedixStore do
           subscription_id,
           :erlang.term_to_binary(doc)
         ])
+
       Redix.command(:redix, [
-            "SADD",
-            subscription_key,
-            binary_key
-          ])
+        "SADD",
+        subscription_key,
+        binary_key
+      ])
     after
       {:ok, _} = Redix.command(:redix, ["EXEC"])
     end

--- a/lib/absinthe/subscription/redix_store.ex
+++ b/lib/absinthe/subscription/redix_store.ex
@@ -1,0 +1,66 @@
+defmodule Absinthe.Subscription.RedixStore do
+  @behaviour Absinthe.Subscription.Store
+
+  @impl true
+  def add_subscription(registry, key, subscription_id, doc) do
+    registry_name = to_string(registry)
+    binary_key = registry_name <> ":" <> :erlang.term_to_binary(key)
+    subscription_key = registry_name <> ":" <> subscription_id
+
+    {:ok, _} = Redix.command(:redix, ["MULTI"])
+
+    try do
+      {:ok, _} =
+        Redix.command(:redix, [
+          "HSET",
+          binary_key,
+          subscription_id,
+          :erlang.term_to_binary(doc)
+        ])
+      Redix.command(:redix, [
+            "SADD",
+            subscription_key,
+            binary_key
+          ])
+    after
+      {:ok, _} = Redix.command(:redix, ["EXEC"])
+    end
+  end
+
+  @impl true
+  def remove_subscriptions(registry, subscription_id) do
+    {:ok, _} = Redix.command(:redix, ["MULTI"])
+
+    registry_name = to_string(registry)
+    subscription_key = registry_name <> ":" <> subscription_id
+
+    try do
+      {:ok, keys} = Redix.command(:redix, ["SMEMBERS", subscription_key])
+
+      for key <- keys do
+        Redix.command(:redix, ["HDEL", key, subscription_id])
+      end
+
+      Redix.command(:redix, ["DEL", subscription_key])
+    after
+      {:ok, _} = Redix.command(:redix, ["EXEC"])
+    end
+  end
+
+  @impl true
+  def lookup_by_key(registry, key) do
+    registry_name = to_string(registry)
+    binary_key = registry_name <> ":" <> :erlang.term_to_binary(key)
+
+    {:ok, docs} = Redix.command(:redix, ["HGETALL", binary_key])
+
+    docs
+    |> Enum.chunk_every(2)
+    |> Map.new(fn [k, v] -> {k, :erlang.binary_to_term(v)} end)
+  end
+
+  @impl true
+  def pool_size(_registry) do
+    {:ok, 0}
+  end
+end

--- a/lib/absinthe/subscription/registry_store.ex
+++ b/lib/absinthe/subscription/registry_store.ex
@@ -1,0 +1,32 @@
+defmodule Absinthe.Subscription.RegistryStore do
+  @behaviour Absinthe.Subscription.Store
+
+  @impl true
+  def add_subscription(registry, field_key, doc_id, doc) do
+    {:ok, _} = Registry.register(registry, field_key, {doc_id, doc})
+    {:ok, _} = Registry.register(registry, doc_id, field_key)
+  end
+
+  @impl true
+  def remove_subscriptions(registry, doc_id) do
+    self = self()
+
+    for {^self, field_key} <- Registry.lookup(registry, doc_id) do
+      Registry.unregister_match(registry, field_key, {doc_id, :_})
+    end
+
+    Registry.unregister(registry, doc_id)
+  end
+
+  @impl true
+  def lookup_by_key(registry, key) do
+    Registry.lookup(registry, key)
+    |> Enum.map(&elem(&1, 1))
+    |> Map.new()
+  end
+
+  @impl true
+  def pool_size(registry) do
+    Registry.meta(registry, :pool_size)
+  end
+end

--- a/lib/absinthe/subscription/store.ex
+++ b/lib/absinthe/subscription/store.ex
@@ -9,19 +9,26 @@ defmodule Absinthe.Subscription.Store do
   Add a subscription for the given key, subscription ID and document
   to the store.
   """
-  @callback add_subscription(registry :: module, key :: term, subscription_id :: binary, doc :: map) :: {:ok, any} | {:error, any}
+  @callback add_subscription(
+              registry :: module,
+              key :: term,
+              subscription_id :: binary,
+              doc :: map
+            ) :: {:ok, any} | {:error, any}
 
   @doc """
   Remove all subscriptions for the given subscription ID from the store.
   """
-  @callback remove_subscriptions(registry :: module, subscription_id :: binary) :: {:ok, any} | {:error, any}
+  @callback remove_subscriptions(registry :: module, subscription_id :: binary) ::
+              {:ok, any} | {:error, any}
 
   @doc """
   Look up all subscriptions for the given key in the store.
 
   Return a map from subscription ID to document.
   """
-  @callback lookup_by_key(registry :: module, key :: term) :: {:ok, %{required(binary) => map}} | {:error, any}
+  @callback lookup_by_key(registry :: module, key :: term) ::
+              {:ok, %{required(binary) => map}} | {:error, any}
 
   @doc """
   Return the proxy pool size.

--- a/lib/absinthe/subscription/store.ex
+++ b/lib/absinthe/subscription/store.ex
@@ -1,0 +1,30 @@
+defmodule Absinthe.Subscription.Store do
+  @moduledoc """
+  Store behaviour expected by Absinthe to power subscriptions
+  """
+
+  @type t :: module()
+
+  @doc """
+  Add a subscription for the given key, subscription ID and document
+  to the store.
+  """
+  @callback add_subscription(registry :: module, key :: term, subscription_id :: binary, doc :: map) :: {:ok, any} | {:error, any}
+
+  @doc """
+  Remove all subscriptions for the given subscription ID from the store.
+  """
+  @callback remove_subscriptions(registry :: module, subscription_id :: binary) :: {:ok, any} | {:error, any}
+
+  @doc """
+  Look up all subscriptions for the given key in the store.
+
+  Return a map from subscription ID to document.
+  """
+  @callback lookup_by_key(registry :: module, key :: term) :: {:ok, %{required(binary) => map}} | {:error, any}
+
+  @doc """
+  Return the proxy pool size.
+  """
+  @callback pool_size(registry :: module) :: {:ok, integer} | {:error, any}
+end

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -6,6 +6,10 @@ defmodule Absinthe.Execution.SubscriptionTest do
   defmodule PubSub do
     @behaviour Absinthe.Subscription.Pubsub
 
+    def store() do
+      Absinthe.Subscription.RegistryStore
+    end
+
     def start_link() do
       Registry.start_link(keys: :unique, name: __MODULE__)
     end
@@ -19,7 +23,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
       :ok
     end
 
-    def publish_subscription(topic, data) do
+    def publish_subscription(topic, data, _context) do
       message = %{
         topic: topic,
         event: "subscription:data",


### PR DESCRIPTION
This is work in progress, for now I'm putting it up here only to start a conversation.

The aim of this change is to enable use of message brokers for delivering subscription updates.  I'm planning to use it with AWT IoT, but it should pave the way for using any broker, including other MQTT/AMQP/etc brokers and commercial offerings such as Pusher or Ably.

This requires two changes outlined below.

## Subscription Documents Storage Abstraction

The Registry works well when the lifetime of a subscription is tied to an underlying WebSocket, but doesn't for the case where subscriptions are "out of band" in the sense that there is no direct connection between client and server.

Specifically, when a node goes down it takes all the documents in its Registry with it, which isn't a problem for WebSockets as the client will be forced to reconnect anyway. It is a problem when a broker is used since there's no easy way to make the client aware of the need to set up the subscription anew.

There's also a wrinkle in that the Registry implementation is tied to the HTTP request pid, which works well only when both the subscription setup and update delivery are handled in the same request.

All of this is why the major change here is to move storage behind an abstraction so that it can be swapped out.  I've included an alternate storage layer based on Redix for illustrative purposes; it wouldn't necessarily have to stay for the final PR, although I'd be happy to donate it. (It's incomplete though, I'm planning to add expiry/keep-alive in order to preempt misbehaved clients. This shouldn't affect the interface though.)

## Context During Publishing

The other change is passing the Absinthe context to `publish_subscription`. This is useful because `publish_subscription` can use it to construct an (external) topic that includes some kind of user indentification, which in turn enables access control.  Without being able to scope topics by user, authorizing access is much less convenient and efficient.

## absinthe_plug changes

There's also a change necessary to `absinthe_plug`, which currently assumes that subscriptions are updated through a WebSocket.  I'll open a separate PR for that.

------

What do you think about these changes? If you agree with them in general I'm happy to spend some time on polish and adding a few tests. As far as naming goes I'm not attached to the names I've picked, feel free to suggest alternatives.

One open question is how to handle backward compatibility, as you can see I've put in a transparent fallback for the first change but not for the second. Happy to tweak that for consistency, one way or the other.
