### PR TITLE
Hydrate more in SDL based schema

### DIFF
--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -80,23 +80,40 @@ defmodule Absinthe.Phase.Schema.Hydrate do
     %{node | description: text}
   end
 
-  def apply_hydration(node, {:resolve, resolver}) do
+  def apply_hydration(
+        %Blueprint.Schema.FieldDefinition{} = node,
+        {:resolve, resolver}
+      ) do
     %{node | middleware: [{Absinthe.Resolution, resolver}]}
   end
 
-  def apply_hydration(node, {:parse, parse}) when is_function(parse) do
+  def apply_hydration(
+        %Blueprint.Schema.ScalarTypeDefinition{} = node,
+        {:parse, parse}
+      )
+      when is_function(parse) do
     %{node | parse: parse}
   end
 
-  def apply_hydration(node, {:serialize, serialize}) do
+  def apply_hydration(
+        %Blueprint.Schema.ScalarTypeDefinition{} = node,
+        {:serialize, serialize}
+      )
+      when is_function(serialize) do
     %{node | serialize: serialize}
   end
 
-  def apply_hydration(node, {:resolve_type, resolve_type}) do
+  def apply_hydration(
+        %Blueprint.Schema.InterfaceTypeDefinition{} = node,
+        {:resolve_type, resolve_type}
+      ) do
     %{node | resolve_type: resolve_type}
   end
 
-  def apply_hydration(node, {:is_type_of, is_type_of}) do
+  def apply_hydration(
+        %Blueprint.Schema.ObjectTypeDefinition{} = node,
+        {:is_type_of, is_type_of}
+      ) do
     %{node | is_type_of: is_type_of}
   end
 

--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -96,6 +96,10 @@ defmodule Absinthe.Phase.Schema.Hydrate do
     %{node | resolve_type: resolve_type}
   end
 
+  def apply_hydration(node, {:is_type_of, is_type_of}) do
+    %{node | is_type_of: is_type_of}
+  end
+
   @hydration_level1 [
     Blueprint.Schema.DirectiveDefinition,
     Blueprint.Schema.EnumTypeDefinition,

--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -88,6 +88,21 @@ defmodule Absinthe.Phase.Schema.Hydrate do
   end
 
   def apply_hydration(
+        %Blueprint.Schema.FieldDefinition{} = node,
+        {:middleware, {_module, _opts} = middleware}
+      ) do
+    %{node | middleware: [middleware]}
+  end
+
+  def apply_hydration(
+        %Blueprint.Schema.FieldDefinition{} = node,
+        {:complexity, complexity}
+      )
+      when is_integer(complexity) do
+    %{node | complexity: complexity}
+  end
+
+  def apply_hydration(
         %Blueprint.Schema.ScalarTypeDefinition{} = node,
         {:parse, parse}
       )

--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -121,14 +121,16 @@ defmodule Absinthe.Phase.Schema.Hydrate do
   def apply_hydration(
         %Blueprint.Schema.InterfaceTypeDefinition{} = node,
         {:resolve_type, resolve_type}
-      ) do
+      )
+      when is_function(resolve_type) do
     %{node | resolve_type: resolve_type}
   end
 
   def apply_hydration(
         %Blueprint.Schema.ObjectTypeDefinition{} = node,
         {:is_type_of, is_type_of}
-      ) do
+      )
+      when is_function(is_type_of) do
     %{node | is_type_of: is_type_of}
   end
 

--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -84,6 +84,14 @@ defmodule Absinthe.Phase.Schema.Hydrate do
     %{node | middleware: [{Absinthe.Resolution, resolver}]}
   end
 
+  def apply_hydration(node, {:parse, parse}) when is_function(parse) do
+    %{node | parse: parse}
+  end
+
+  def apply_hydration(node, {:serialize, serialize}) do
+    %{node | serialize: serialize}
+  end
+
   def apply_hydration(node, {:resolve_type, resolve_type}) do
     %{node | resolve_type: resolve_type}
   end

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -166,7 +166,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     end
 
     def hydrate(%{identifier: :scalar_echo}, [%{identifier: :query} | _]) do
-      [{:resolve, &__MODULE__.scalar_echo/3}]
+      [{:middleware, {Absinthe.Resolution, &__MODULE__.scalar_echo/3}}]
     end
 
     def hydrate(%{identifier: :titled}, _) do

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -40,6 +40,8 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       ): String
       metaEcho: String
       scalarEcho(input: CoolScalar): CoolScalar
+      namedThings: [Named]
+      titledThings: [Titled]
     }
 
     scalar CoolScalar
@@ -71,8 +73,28 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       name: String!
     }
 
+    type Human implements Named {
+      name: String!
+      age: Int!
+    }
+
+    type City implements Named {
+      name: String!
+      population: Int!
+    }
+
     interface Titled @feature(name: "bar") {
       title: String!
+    }
+
+    type Book implements Titled {
+      title: String!
+      pages: Int!
+    }
+
+    type Movie implements Titled {
+      title: String!
+      duration: Int!
     }
 
     scalar B
@@ -109,6 +131,14 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       {:ok, scalar}
     end
 
+    def named_things(_source, _args, _resolution) do
+      {:ok, [%{name: "Sue", age: 38}, %{name: "Portland", population: 647_000}]}
+    end
+
+    def titled_things(_source, _args, _resolution) do
+      {:ok, [%{title: "The Matrix", duration: 150}, %{title: "Origin of Species", pages: 502}]}
+    end
+
     def hydrate(%{identifier: :admin}, [%{identifier: :query} | _]) do
       {:description, "The admin"}
     end
@@ -139,6 +169,26 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       [{:resolve, &__MODULE__.scalar_echo/3}]
     end
 
+    def hydrate(%{identifier: :titled}, _) do
+      [{:resolve_type, &__MODULE__.titled_resolve_type/2}]
+    end
+
+    def hydrate(%{identifier: :human}, _) do
+      [{:is_type_of, &__MODULE__.human_is_type_of/1}]
+    end
+
+    def hydrate(%{identifier: :city}, _) do
+      [{:is_type_of, &__MODULE__.city_is_type_of/1}]
+    end
+
+    def hydrate(%{identifier: :named_things}, [%{identifier: :query} | _]) do
+      [{:resolve, &__MODULE__.named_things/3}]
+    end
+
+    def hydrate(%{identifier: :titled_things}, [%{identifier: :query} | _]) do
+      [{:resolve, &__MODULE__.titled_things/3}]
+    end
+
     def hydrate(%Absinthe.Blueprint{}, _) do
       %{
         query: %{
@@ -158,6 +208,15 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     def hydrate(_node, _ancestors) do
       []
     end
+
+    def city_is_type_of(%{population: _}), do: true
+    def city_is_type_of(_), do: false
+
+    def human_is_type_of(%{age: _}), do: true
+    def human_is_type_of(_), do: false
+
+    def titled_resolve_type(%{duration: _}, _), do: :movie
+    def titled_resolve_type(%{pages: _}, _), do: :book
 
     def parse_cool_scalar(value), do: {:ok, value}
     def serialize_cool_scalar(%{value: value}), do: value
@@ -318,6 +377,50 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     """
     test "enables scalar creation" do
       assert {:ok, %{data: %{"scalarEcho" => "Hey there"}}} = Absinthe.run(@query, Definition)
+    end
+
+    @query """
+    {
+      namedThings {
+        __typename
+        name
+        ... on Human { age }
+        ... on City { population }
+      }
+    }
+    """
+    test "interface via is_type_of" do
+      assert {:ok,
+              %{
+                data: %{
+                  "namedThings" => [
+                    %{"__typename" => "Human", "name" => "Sue", "age" => 38},
+                    %{"__typename" => "City", "name" => "Portland", "population" => 647_000}
+                  ]
+                }
+              }} = Absinthe.run(@query, Definition)
+    end
+
+    @query """
+    {
+      titledThings {
+        __typename
+        title
+        ... on Book { pages }
+        ... on Movie { duration }
+      }
+    }
+    """
+    test "interface via resolve_type" do
+      assert {:ok,
+              %{
+                data: %{
+                  "titledThings" => [
+                    %{"__typename" => "Movie", "title" => "The Matrix", "duration" => 150},
+                    %{"__typename" => "Book", "title" => "Origin of Species", "pages" => 502}
+                  ]
+                }
+              }} = Absinthe.run(@query, Definition)
     end
   end
 

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -158,7 +158,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       ]
     end
 
-    def hydrate(%{identifier: :cool_scalar}, _) do
+    def hydrate(%{name: "CoolScalar"}, _) do
       [
         {:parse, &__MODULE__.parse_cool_scalar/1},
         {:serialize, &__MODULE__.serialize_cool_scalar/1}


### PR DESCRIPTION
This PR further extends the ability to hydrate various things in an SDL defined schema.

* `parse` & `serialize` for Scalars
* `middleware` & `complexity` for Fields
* `resolve_type` & `is_type_of` for Interfaces

It also makes the `apply_hydration` function heads more specific based on where hydrations are valid to apply.

Open to thoughts on the format of these...

closes #702