### PR TITLE
Fix telemetry event name in guide

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -49,7 +49,7 @@ your `iex -S mix phx.server` prompt. Paste in:
 ```elixir
 :telemetry.attach_many(
   :demo,
-  [[:absinthe, :execute, :operation, :stop], [:absinthe, :resolve, :field, :stop, :stop]],
+  [[:absinthe, :execute, :operation, :stop], [:absinthe, :resolve, :field, :stop]],
   fn event_name, measurements, metadata, _config ->
     %{
       event_name: event_name,


### PR DESCRIPTION
Small documentation duplication in the telemetry changes just merged

cc @binaryseed 