### PR TITLE
Fix default value rendering for list of enums

### DIFF
--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -335,7 +335,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
       %Absinthe.Type.List{of_type: type} ->
         list_values =
-          Enum.map(value, &render_default_value(schema, adapter, type, &1))
+          value
+          |> List.wrap()
+          |> Enum.map(&render_default_value(schema, adapter, type, &1))
           |> Enum.join(", ")
 
         "[#{list_values}]"

--- a/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
+++ b/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
@@ -26,7 +26,7 @@ defmodule Elixir.Absinthe.Integration.Execution.InputTypes.Enum.DefaultValueTest
             }} == Absinthe.run(@query, Absinthe.Fixtures.ColorSchema, [])
   end
 
-  test "Introspection render_default_value" do
+  test "Introspection renders default value properly" do
     {:ok, %{data: data}} =
       """
       {
@@ -44,5 +44,12 @@ defmodule Elixir.Absinthe.Integration.Execution.InputTypes.Enum.DefaultValueTest
       }
       """
       |> run(Absinthe.Fixtures.ColorSchema)
+
+    fields = get_in(data, ["__schema", "queryType", "fields"])
+
+    assert %{
+             "args" => [%{"defaultValue" => "[RED]", "name" => "channels"}],
+             "name" => "moreInfos"
+           } in fields
   end
 end

--- a/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
+++ b/test/absinthe/integration/execution/input_types/enum/default_value_test.exs
@@ -25,4 +25,24 @@ defmodule Elixir.Absinthe.Integration.Execution.InputTypes.Enum.DefaultValueTest
               }
             }} == Absinthe.run(@query, Absinthe.Fixtures.ColorSchema, [])
   end
+
+  test "Introspection render_default_value" do
+    {:ok, %{data: data}} =
+      """
+      {
+        __schema {
+          queryType {
+            fields {
+              name
+              args {
+                name
+                defaultValue
+              }
+            }
+          }
+        }
+      }
+      """
+      |> run(Absinthe.Fixtures.ColorSchema)
+  end
 end

--- a/test/support/fixtures/color_schema.ex
+++ b/test/support/fixtures/color_schema.ex
@@ -36,6 +36,18 @@ defmodule Absinthe.Fixtures.ColorSchema do
            %{name: @names[channel], value: @values[channel]}
          end)}
       end
+
+    field :more_infos,
+      type: list_of(:channel_info),
+      args: [
+        channels: [type: list_of(:channel), default_value: :r]
+      ],
+      resolve: fn %{channels: channels}, _ ->
+        {:ok,
+         Enum.map(channels, fn channel ->
+           %{name: @names[channel], value: @values[channel]}
+         end)}
+      end
   end
 
   @desc "A color channel"


### PR DESCRIPTION
This PR fixes a bug when rendering the `defaultValue` for a List of Enums when the default value provided is a single enum atom.