### PR TITLE
fix: #791 custom scalar parse

### DIFF
--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -39,7 +39,8 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     {:error, :non_null}
   end
 
-  defp build_value(normalized, %Type.Scalar{} = schema_node, context) do
+  defp build_value(%{__struct__: struct} = normalized, %Type.Scalar{} = schema_node, context)
+       when struct in [Input.Boolean, Input.Float, Input.Integer, Input.String, Input.Null] do
     case Type.Scalar.parse(schema_node, normalized, context) do
       :error ->
         {:error, :bad_parse}
@@ -47,6 +48,10 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
       {:ok, val} ->
         {:ok, val}
     end
+  end
+
+  defp build_value(_normalized, %Type.Scalar{}, _context) do
+    {:error, :bad_parse}
   end
 
   defp build_value(%Input.Null{}, %Type.Enum{}, _) do

--- a/test/absinthe/execution/arguments/scalar_test.exs
+++ b/test/absinthe/execution/arguments/scalar_test.exs
@@ -1,5 +1,6 @@
 defmodule Absinthe.Execution.Arguments.ScalarTest do
   use Absinthe.Case, async: true
+  alias Absinthe.Blueprint.Input
 
   @schema Absinthe.Fixtures.ArgumentsSchema
 
@@ -19,5 +20,42 @@ defmodule Absinthe.Execution.Arguments.ScalarTest do
   """
   test "works when passed to resolution" do
     assert_data(%{"something" => "bob"}, run(@graphql, @schema))
+  end
+
+  @graphql """
+  query {
+    raisingThing(name: {firstName: "bob"})
+  }
+  """
+  test "invalid scalar does not call parse" do
+    assert_error_message(
+      "Argument \"name\" has invalid value {firstName: \"bob\"}.\nIn field \"firstName\": Unknown field.",
+      run(@graphql, @schema)
+    )
+  end
+
+  @graphql """
+  query ($scalarVar: InputNameRaising) {
+    raisingThing(name: $scalarVar)
+  }
+  """
+
+  @valid_scalars %{
+    Input.Boolean => true,
+    Input.Float => 42.42,
+    Input.Integer => 42,
+    Input.String => "bob",
+    Input.Null => nil
+  }
+  test "valid scalar does call parse" do
+    for {expected_struct, value} <- @valid_scalars do
+      assert_raise(
+        RuntimeError,
+        "inputNameRaising scalar parse was called for #{expected_struct}",
+        fn ->
+          run(@graphql, @schema, variables: %{"scalarVar" => value})
+        end
+      )
+    end
   end
 end

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -11,6 +11,12 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
     serialize fn %{first_name: name} -> name end
   end
 
+  scalar :input_name_raising do
+    parse fn %{__struct__: struct} ->
+      raise "inputNameRaising scalar parse was called for #{struct}"
+    end
+  end
+
   scalar :name do
     serialize &to_string/1
 
@@ -138,6 +144,10 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
         %{name: %{first_name: name}}, _ -> {:ok, name}
         args, _ -> {:error, "Got #{inspect(args)} instead"}
       end
+    end
+
+    field :raising_thing, :string do
+      arg :name, :input_name_raising
     end
   end
 end


### PR DESCRIPTION
Hi!

This PR addresses #791. The idea is to check for the correct input type in the parse phase. As far as I understand the spec, that means any built-in scalars are valid as input for a custom scalar. 

I've made some adjustments to the `ArgumentsSchema` fixture in order to be able to test the parse function being called. Let me know what you think.

Cheers!