### PR TITLE
Fix default dataloader middleware when get_policy is 'tuples'

### DIFF
--- a/test/absinthe/middleware/dataloader_test.exs
+++ b/test/absinthe/middleware/dataloader_test.exs
@@ -2,98 +2,120 @@ defmodule Absinthe.Middleware.DataloaderTest do
   use Absinthe.Case, async: true
 
   defmodule Schema do
-    use Absinthe.Schema
+    defmacro __using__(_opts) do
+      quote do
+        use Absinthe.Schema
 
-    import Absinthe.Resolution.Helpers
+        import Absinthe.Resolution.Helpers
 
-    @organizations 1..3
-                   |> Map.new(
-                     &{&1,
-                      %{
-                        id: &1,
-                        name: "Organization: ##{&1}"
-                      }}
-                   )
-    @users 1..3
-           |> Enum.map(
-             &%{
-               id: &1,
-               name: "User: ##{&1}",
-               organization_id: &1
-             }
-           )
+        @organizations 1..3
+                       |> Map.new(
+                         &{&1,
+                          %{
+                            id: &1,
+                            name: "Organization: ##{&1}"
+                          }}
+                       )
+        @users 1..3
+               |> Enum.map(
+                 &%{
+                   id: &1,
+                   name: "User: ##{&1}",
+                   organization_id: &1
+                 }
+               )
 
-    def organizations(), do: @organizations
+        def organizations(), do: @organizations
 
-    defp batch_load({:organization_id, %{pid: test_pid}}, sources) do
-      send(test_pid, :loading)
+        defp batch_load({:organization_id, %{pid: test_pid}}, sources) do
+          send(test_pid, :loading)
 
-      Map.new(sources, fn src ->
-        {src, Map.fetch!(@organizations, src.organization_id)}
-      end)
+          Map.new(sources, fn src ->
+            {src, Map.fetch!(@organizations, src.organization_id)}
+          end)
+        end
+
+        def batch_dataloader(opts \\ []) do
+          source = Dataloader.KV.new(&batch_load/2)
+          Dataloader.add_source(Dataloader.new(opts), :test, source)
+        end
+
+        def plugins do
+          [Absinthe.Middleware.Dataloader] ++ Absinthe.Plugin.defaults()
+        end
+
+        object :organization do
+          field :id, :integer
+          field :name, :string
+        end
+
+        object :user do
+          field :name, :string
+
+          field :foo_organization, :organization do
+            resolve dataloader(:test, fn _, _, %{context: %{test_pid: pid}} ->
+                      {:organization_id, %{pid: pid}}
+                    end)
+          end
+
+          field :bar_organization, :organization do
+            resolve dataloader(:test, :organization_id, args: %{pid: self()})
+          end
+        end
+
+        query do
+          field :users, list_of(:user) do
+            resolve fn _, _, _ -> {:ok, @users} end
+          end
+
+          field :organization, :organization do
+            arg :id, non_null(:integer)
+
+            resolve fn _, %{id: id}, %{context: %{loader: loader, test_pid: test_pid}} ->
+              loader
+              |> Dataloader.load(:test, {:organization_id, %{pid: test_pid}}, %{
+                organization_id: id
+              })
+              |> Dataloader.put(
+                :test,
+                {:organization_id, %{pid: self()}},
+                %{organization_id: 123},
+                %{}
+              )
+              |> on_load(fn loader ->
+                {:ok,
+                 Dataloader.get(loader, :test, {:organization_id, %{pid: test_pid}}, %{
+                   organization_id: id
+                 })}
+              end)
+            end
+          end
+        end
+      end
     end
+  end
 
-    def dataloader() do
-      source = Dataloader.KV.new(&batch_load/2)
-      Dataloader.add_source(Dataloader.new(), :test, source)
-    end
+  defmodule DefaultSchema do
+    use Schema
 
     def context(ctx) do
       ctx
-      |> Map.put_new(:loader, dataloader())
+      |> Map.put_new(:loader, batch_dataloader())
       |> Map.merge(%{
         test_pid: self()
       })
     end
+  end
 
-    def plugins do
-      [Absinthe.Middleware.Dataloader] ++ Absinthe.Plugin.defaults()
-    end
+  defmodule TuplesSchema do
+    use Schema
 
-    object :organization do
-      field :id, :integer
-      field :name, :string
-    end
-
-    object :user do
-      field :name, :string
-
-      field :foo_organization, :organization do
-        resolve dataloader(:test, fn _, _, %{context: %{test_pid: pid}} ->
-                  {:organization_id, %{pid: pid}}
-                end)
-      end
-
-      field :bar_organization, :organization do
-        resolve dataloader(:test, :organization_id, args: %{pid: self()})
-      end
-    end
-
-    query do
-      field :users, list_of(:user) do
-        resolve fn _, _, _ -> {:ok, @users} end
-      end
-
-      field :organization, :organization do
-        arg :id, non_null(:integer)
-
-        resolve fn _, %{id: id}, %{context: %{loader: loader, test_pid: test_pid}} ->
-          loader
-          |> Dataloader.load(:test, {:organization_id, %{pid: test_pid}}, %{organization_id: id})
-          |> Dataloader.put(
-            :test,
-            {:organization_id, %{pid: self()}},
-            %{organization_id: 123},
-            %{}
-          )
-          |> on_load(fn loader ->
-            {:ok,
-             Dataloader.get(loader, :test, {:organization_id, %{pid: test_pid}}, %{
-               organization_id: id
-             })}
-          end)
-        end
-      end
+    def context(ctx) do
+      ctx
+      |> Map.put_new(:loader, batch_dataloader(get_policy: :tuples))
+      |> Map.merge(%{
+        test_pid: self()
+      })
     end
   end
 
@@ -116,7 +138,33 @@ defmodule Absinthe.Middleware.DataloaderTest do
       ]
     }
 
-    assert {:ok, %{data: data}} = Absinthe.run(doc, Schema)
+    assert {:ok, %{data: data}} = Absinthe.run(doc, DefaultSchema)
+    assert expected_data == data
+
+    assert_receive(:loading)
+    refute_receive(:loading)
+  end
+
+  test "can resolve a field when dataloader uses 'tuples' get_policy" do
+    doc = """
+    {
+      users {
+        organization: barOrganization {
+          name
+        }
+      }
+    }
+    """
+
+    expected_data = %{
+      "users" => [
+        %{"organization" => %{"name" => "Organization: #1"}},
+        %{"organization" => %{"name" => "Organization: #2"}},
+        %{"organization" => %{"name" => "Organization: #3"}}
+      ]
+    }
+
+    assert {:ok, %{data: data}} = Absinthe.run(doc, TuplesSchema)
     assert expected_data == data
 
     assert_receive(:loading)
@@ -146,7 +194,7 @@ defmodule Absinthe.Middleware.DataloaderTest do
       "organization" => %{"id" => 1}
     }
 
-    assert {:ok, %{data: data}} = Absinthe.run(doc, Schema)
+    assert {:ok, %{data: data}} = Absinthe.run(doc, DefaultSchema)
     assert expected_data == data
     assert_receive(:loading)
     refute_receive(:loading)
@@ -163,19 +211,19 @@ defmodule Absinthe.Middleware.DataloaderTest do
 
     expected_data = %{"organization" => %{"id" => 1}}
 
-    org = Schema.organizations()[1]
+    org = DefaultSchema.organizations()[1]
 
     # Get the dataloader, and warm the cache for the organization key we're going
     # to try to access via graphql.
     dataloader =
-      Schema.dataloader()
+      DefaultSchema.batch_dataloader()
       |> Dataloader.put(:test, {:organization_id, %{pid: self()}}, %{organization_id: 1}, org)
 
     context = %{
       loader: dataloader
     }
 
-    assert {:ok, %{data: data}} = Absinthe.run(doc, Schema, context: context)
+    assert {:ok, %{data: data}} = Absinthe.run(doc, DefaultSchema, context: context)
     assert expected_data == data
 
     refute_receive(:loading)


### PR DESCRIPTION
**Description**
This PR fixes the default implementation of `Absinthe.Resolution.Helpers.dataloader` for loaders using `get_policy: :tuples`.

**Context**
`Absinthe.Resolution.Helpers.dataloader/3` takes a `callback` option which must return an ok/error tuple. The default callback assumes that `Dataloader.get/4` returns a raw value, and wraps it in an ok tuple. When the loader's `get_policy` is `:tuples`, however, the returned value is already wrapped in an ok/error tuple, so the default callback adds an extra `:ok`, which causes a `BadMapError` in `Absinthe.Middleware.MapGet` down the line.

The practical effect is that loaders using `get_policy: :tuples` must pass a custom callback do `dataloader/3`. They also can't use `dataloader/1` and `dataloader/2`, since those functions use the default callback.