### PR TITLE
Support self contained schemas using `import_types` from `__MODULE__`

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1457,9 +1457,15 @@ defmodule Absinthe.Schema.Notation do
     |> Absinthe.Utils.camelize()
   end
 
-  defp do_import_types({{:., _, [root_ast, :{}]}, _, modules_ast_list}, env, opts) do
-    {:__aliases__, _, root} = root_ast
+  defp do_import_types({{:., _, [{:__MODULE__, _, _}, :{}]}, _, modules_ast_list}, env, opts) do
+    for {_, _, leaf} <- modules_ast_list do
+      type_module = Module.concat([env.module | leaf])
 
+      do_import_types(type_module, env, opts)
+    end
+  end
+
+  defp do_import_types({{:., _, [{:__aliases__, _, root}, :{}]}, _, modules_ast_list}, env, opts) do
     root_module = Module.concat(root)
     root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)
 

--- a/test/absinthe/type/import_types_test.exs
+++ b/test/absinthe/type/import_types_test.exs
@@ -27,5 +27,11 @@ defmodule Absinthe.Type.ImportTypesTest do
     test "works with an alias, {} and scoped reference" do
       assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :avatar)
     end
+
+    test "works with __MODULE__ and {}" do
+      assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :decline_reasons)
+      assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :credit_card)
+      assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :credit_card_type)
+    end
   end
 end

--- a/test/support/fixtures/dynamic/import_types.ex
+++ b/test/support/fixtures/dynamic/import_types.ex
@@ -93,4 +93,39 @@ defmodule Absinthe.Fixtures.ImportTypes do
       field :customers, list_of(:customer)
     end
   end
+
+  defmodule SelfContainedSchema do
+    use Absinthe.Schema
+
+    defmodule PaymentTypes do
+      use Absinthe.Schema.Notation
+
+      object :credit_card do
+        field :number, non_null(:string)
+        field :type, non_null(:credit_card_type)
+        field :expiration_month, non_null(:integer)
+        field :expiration_year, non_null(:integer)
+        field :cvv, non_null(:string)
+      end
+    end
+
+    defmodule CardTypes do
+      use Absinthe.Schema.Notation
+
+      enum :credit_card_type, values: [:visa, :mastercard, :amex]
+    end
+
+    defmodule Errors.DeclineReasons do
+      use Absinthe.Schema.Notation
+
+      enum :decline_reasons, values: [:insufficient_funds, :invalid_card]
+    end
+
+    import_types __MODULE__.Errors.DeclineReasons
+    import_types __MODULE__.{PaymentTypes, CardTypes}
+
+    query do
+      field :credit_cards, list_of(:credit_card)
+    end
+  end
 end


### PR DESCRIPTION
[Closes #684]

Support using `import_types` using the `__MODULE__` special form.
According to #684, This was supported previously in 1.4, but since 1.5
it has been erroring out in compile time with the following:

```
== Compilation error in file lib/potion_web/schema.ex ==
** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2

    The following arguments were given to :elixir_aliases.do_concat/2:

        # 1
        [{:__MODULE__, [line: 56], nil}, :Types]

        # 2
        "Elixir"

    lib/absinthe/schema/notation.ex:1454: Absinthe.Schema.Notation.do_import_types/3
    expanding macro: Absinthe.Schema.Notation.import_types/1
    lib/potion_web/schema.ex:56: PotionWeb.Schema (module)
```

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
