### PR TITLE
Add telemetry flag to Absinthe.run and resolution

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -68,6 +68,7 @@ defmodule Absinthe do
   executing an operation.
   * `:max_complexity` -> An integer (or `:infinity`) for the maximum allowed
   complexity for the operation being executed.
+  * `:telemetry` -> A boolean whether to run telemetry. Defaults to true.
 
   ## Examples
 

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -11,6 +11,7 @@ defmodule Absinthe.Middleware.Telemetry do
   def call(%{telemetry: false} = resolution, _) do
     resolution
   end
+
   def call(resolution, _opts) do
     id = :erlang.unique_integer()
     start_time = System.system_time()

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -8,7 +8,10 @@ defmodule Absinthe.Middleware.Telemetry do
   @behaviour Absinthe.Middleware
 
   @impl Absinthe.Middleware
-  def call(resolution, _) do
+  def call(%{telemetry: false} = resolution, _) do
+    resolution
+  end
+  def call(resolution, _opts) do
     id = :erlang.unique_integer()
     start_time = System.system_time()
     start_time_mono = System.monotonic_time()

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -45,6 +45,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
     plugins = bp_root.schema.plugins()
     run_callbacks? = Keyword.get(options, :plugin_callbacks, true)
+    telemetry? = Keyword.get(options, :telemetry)
 
     exec = plugins |> run_callbacks(:before_resolution, exec, run_callbacks?)
 
@@ -58,7 +59,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
         parent_type: nil,
         middleware: nil,
         definition: nil,
-        arguments: nil
+        arguments: nil,
+        telemetry: telemetry?
       }
       |> Map.merge(common)
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -109,7 +109,8 @@ defmodule Absinthe.Pipeline do
       # Format Result
       Phase.Document.Result,
       {Phase.Telemetry, [:execute, :operation, :stop, options]}
-    ] |> skip_telemetry(Keyword.get(options, :telemetry))
+    ]
+    |> skip_telemetry(Keyword.get(options, :telemetry))
   end
 
   @default_prototype_schema Absinthe.Schema.Prototype

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -31,7 +31,8 @@ defmodule Absinthe.Pipeline do
     root_value: %{},
     validation_result_phase: Phase.Document.Validation.Result,
     result_phase: Phase.Document.Result,
-    jump_phases: true
+    jump_phases: true,
+    telemetry: true
   ]
 
   def options(overrides \\ []) do
@@ -108,7 +109,7 @@ defmodule Absinthe.Pipeline do
       # Format Result
       Phase.Document.Result,
       {Phase.Telemetry, [:execute, :operation, :stop, options]}
-    ]
+    ] |> skip_telemetry(Keyword.get(options, :telemetry))
   end
 
   @default_prototype_schema Absinthe.Schema.Prototype
@@ -400,5 +401,13 @@ defmodule Absinthe.Pipeline do
 
   defp phase_invocation(phase) do
     {phase, []}
+  end
+
+  defp skip_telemetry(pipeline, false) do
+    pipeline |> reject(~r/Phase.Telemetry/)
+  end
+
+  defp skip_telemetry(pipeline, true) do
+    pipeline
   end
 end

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -53,7 +53,8 @@ defmodule Absinthe.Resolution do
           acc: %{any => any},
           extensions: %{any => any},
           arguments: arguments,
-          fragments: [Absinthe.Blueprint.Document.Fragment.Named.t()]
+          fragments: [Absinthe.Blueprint.Document.Fragment.Named.t()],
+          telemetry: boolean
         }
 
   defstruct [
@@ -74,7 +75,8 @@ defmodule Absinthe.Resolution do
     path: [],
     state: :unresolved,
     fragments: [],
-    fields_cache: %{}
+    fields_cache: %{},
+    telemetry: true
   ]
 
   def resolver_spec(fun) do

--- a/test/support/fixtures/compiled_introspection_schema.ex
+++ b/test/support/fixtures/compiled_introspection_schema.ex
@@ -1,0 +1,5 @@
+defmodule Absinthe.Fixtures.CompiledIntrospectionSchema do
+
+  # Run introspection query on compile time without telemetry
+  Absinthe.Schema.introspect(Absinthe.Fixtures.ContactSchema, [telemetry: false])
+end

--- a/test/support/fixtures/compiled_introspection_schema.ex
+++ b/test/support/fixtures/compiled_introspection_schema.ex
@@ -1,5 +1,4 @@
 defmodule Absinthe.Fixtures.CompiledIntrospectionSchema do
-
   # Run introspection query on compile time without telemetry
-  Absinthe.Schema.introspect(Absinthe.Fixtures.ContactSchema, [telemetry: false])
+  Absinthe.Schema.introspect(Absinthe.Fixtures.ContactSchema, telemetry: false)
 end


### PR DESCRIPTION
See https://github.com/absinthe-graphql/absinthe/issues/807

The flag to Absinthe.run ensure the Telemetry phases are skipped in the
document pipeline.

Furthermore, the flag is passed on the
`Absinthe.Phase.Document.Execution.Resolution` phase where it sets
the (added) telemetry flag on the resolution struct. This is done so the
telemetry middleware can be skipped when the flag is set to false.

Let me know if this is the right approach :)