### PR TITLE
Fix SDL doc

### DIFF
--- a/lib/mix/tasks/absinthe.schema.sdl.ex
+++ b/lib/mix/tasks/absinthe.schema.sdl.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Sdl do
   @default_filename "./schema.graphql"
 
   @moduledoc """
-  Generate a schema.json file
+  Generate a schema.graphql file
 
   mix absinthe.schema.sdl --schema MySchema
 


### PR DESCRIPTION
Fixes what looks like a copy/paste error in the `absinthe.schema.sdl` documentation.