### PR TITLE
Use node_name/0 to check the node origin - 1.4

### DIFF
--- a/lib/absinthe/subscription/proxy.ex
+++ b/lib/absinthe/subscription/proxy.ex
@@ -20,23 +20,21 @@ defmodule Absinthe.Subscription.Proxy do
     {:ok, %__MODULE__{pubsub: pubsub}}
   end
 
-  def handle_info(%{node: src_node}, state) when src_node == node() do
-    {:noreply, state}
-  end
-
   def handle_info(payload, state) do
     # There's no meaningful form of backpressure to have here, and we can't
     # bottleneck execution inside each proxy process
 
-    # TODO: This should maybe be supervised? I feel like the linking here isn't
-    # what it should be.
-    Task.start_link(fn ->
-      Subscription.Local.publish_mutation(
-        state.pubsub,
-        payload.mutation_result,
-        payload.subscribed_fields
-      )
-    end)
+    unless payload.node == state.pubsub.node_name() do
+      # TODO: This should maybe be supervised? I feel like the linking here isn't
+      # what it should be.
+      Task.start_link(fn ->
+        Subscription.Local.publish_mutation(
+          state.pubsub,
+          payload.mutation_result,
+          payload.subscribed_fields
+        )
+      end)
+    end
 
     {:noreply, state}
   end


### PR DESCRIPTION
## Motivation

As reported on absinthe-graphql/absinthe_phoenix#63 the subscriptions messages are getting duplicated when using [Redis Pubsub adapter](https://github.com/phoenixframework/phoenix_pubsub_redis).

## Proposed solution

As pointed out by @benwilson512 the phoenix pubsub .... and the logic the code that performs this check was relying on a implementation detail of the PG2 adapter. This PR aims to change that verification to use the [`node_name` function exposed by phoenix pubsub](https://hexdocs.pm/phoenix_pubsub/Phoenix.PubSub.html#node_name/1) and [wrapped by `absinthe_phoenix`](https://github.com/absinthe-graphql/absinthe_phoenix/blob/master/lib/absinthe/phoenix/endpoint.ex#L11) for absinthe 1.4.

The implementation was manually tested against using this repo https://github.com/thiamsantos/subscription_test with both PG2 and redis as adapters.

## Related

- #815