### PR TITLE
Match latest spec and return single error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ For changes pre-v1.5 see the [v1.4](https://github.com/absinthe-graphql/absinthe
 - Feature: Output rendered SDL for a schema
 - Feature: Substantially lower subscription memory usage.
 - Documentation: Testing guide, numerous fixes and updates
-- Breaking Change: Scalar outputs are now type checked and will raise exceptions
-if the result tries to send the wrong data type in the result.
+- Breaking Change: Scalar outputs are now type checked and will raise exceptions if the result tries to send the wrong data type in the result.
 - Breaking Change: `telemetry` event names [changed](https://github.com/absinthe-graphql/absinthe/pull/782) from the `alpha` to match an emerging naming convention for tracing.
 - Breaking Change: Added phase to check validity of field names according to graphql spec. Might break existing schema's. Remove the `Absinthe.Phase.Schema.Validation.NamesMustBeValid` from the schema pipeline if you want to ignore this.
+- Breaking Change: To match the GraphQL spec, we [no longer](https://github.com/absinthe-graphql/absinthe/pull/816) add a non-null error when a resolver on a non-null field explicitly returns it's own error.
 
 ## v1.5.0 (Alpha)
 

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -272,7 +272,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
         _ -> nil
       end
 
-    errors = maybe_add_non_null_error(errors, value, full_type)
+    errors = maybe_add_non_null_error(errors, full_type)
 
     value
     |> to_result(bp_field, full_type, extensions)
@@ -281,11 +281,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> propagate_null_trimming
   end
 
-  defp maybe_add_non_null_error(errors, nil, %Type.NonNull{}) do
-    ["Cannot return null for non-nullable field" | errors]
+  defp maybe_add_non_null_error([], %Type.NonNull{}) do
+    ["Cannot return null for non-nullable field"]
   end
 
-  defp maybe_add_non_null_error(errors, _, _) do
+  defp maybe_add_non_null_error(errors, _) do
     errors
   end
 
@@ -353,8 +353,6 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp non_null_list_violation?(_) do
     false
   end
-
-  # defp maybe_add_non_null_error(errors, nil, %)
 
   defp add_errors(result, errors, fun) do
     Enum.reduce(errors, result, fun)

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -272,7 +272,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
         _ -> nil
       end
 
-    errors = maybe_add_non_null_error(errors, full_type)
+    errors = maybe_add_non_null_error(errors, value, full_type)
 
     value
     |> to_result(bp_field, full_type, extensions)
@@ -281,11 +281,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> propagate_null_trimming
   end
 
-  defp maybe_add_non_null_error([], %Type.NonNull{}) do
+  defp maybe_add_non_null_error([], nil, %Type.NonNull{}) do
     ["Cannot return null for non-nullable field"]
   end
 
-  defp maybe_add_non_null_error(errors, _) do
+  defp maybe_add_non_null_error(errors, _, _) do
     errors
   end
 

--- a/test/absinthe/phase/execution/non_null_test.exs
+++ b/test/absinthe/phase/execution/non_null_test.exs
@@ -119,11 +119,6 @@ defmodule Absinthe.Phase.Document.Execution.NonNullTest do
     errors = [
       %{
         locations: [%{column: 25, line: 2}],
-        message: "Cannot return null for non-nullable field",
-        path: ["nullable", "nullable", "nonNullErrorField"]
-      },
-      %{
-        locations: [%{column: 25, line: 2}],
         message: "boom",
         path: ["nullable", "nullable", "nonNullErrorField"]
       }
@@ -142,11 +137,6 @@ defmodule Absinthe.Phase.Document.Execution.NonNullTest do
     result = Absinthe.run(doc, Schema)
 
     errors = [
-      %{
-        locations: [%{column: 23, line: 2}],
-        message: "Cannot return null for non-nullable field",
-        path: ["nonNull", "nonNull", "nonNullErrorField"]
-      },
       %{
         locations: [%{column: 23, line: 2}],
         message: "boom",
@@ -168,11 +158,6 @@ defmodule Absinthe.Phase.Document.Execution.NonNullTest do
     path = ["nullable", "nonNull", "nonNull", "nonNull", "nonNull", "nonNullErrorField"]
 
     errors = [
-      %{
-        locations: [%{column: 54, line: 2}],
-        message: "Cannot return null for non-nullable field",
-        path: path
-      },
       %{locations: [%{column: 54, line: 2}], message: "boom", path: path}
     ]
 


### PR DESCRIPTION
The latest GraphQL spec states we should _not_ add an additional error when a resolver returns an explicit error.

https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability

closes #803 
@benwilson512 