### PR TITLE
Fix issue with sub_triggers

### DIFF
--- a/lib/absinthe/phase/schema/register_triggers.ex
+++ b/lib/absinthe/phase/schema/register_triggers.ex
@@ -43,7 +43,8 @@ defmodule Absinthe.Phase.Schema.RegisterTriggers do
     update_fields(mutation_object, fn mut_field ->
       triggers =
         for sub_field <- sub_fields,
-            sub_triggers = %{} <- Absinthe.Type.function(sub_field, :triggers),
+            sub_triggers = Absinthe.Type.function(sub_field, :triggers),
+            is_map(sub_triggers),
             Map.has_key?(sub_triggers, mut_field.identifier),
             do: sub_field.identifier
 


### PR DESCRIPTION
This PR fixes an issue introduced in this commit:

https://github.com/absinthe-graphql/absinthe/commit/522790fa870ab34fe041b43ad06f7d562bc0342b

Tests on `master` have been failing ever since.

I assume the change was intended to ensure that `sub_triggers` could  only ever be a Map, but looks like it was actually causing it to never get through that step in the `for` comprehension.

@benwilson512 