### PR TITLE
Fix infinite loop in interface covariance calculation

### DIFF
--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -146,6 +146,16 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
   end
 
   defp check_covariant(
+         %Blueprint.Schema.InterfaceTypeDefinition{identifier: interface_ident},
+         field_type,
+         field_ident,
+         types
+       ) do
+    %{interfaces: field_type_interfaces} = Map.get(types, field_type)
+    (interface_ident in field_type_interfaces && :ok) || {:error, field_ident}
+  end
+
+  defp check_covariant(
          %wrapper{of_type: inner_type1},
          %wrapper{of_type: inner_type2},
          field_ident,

--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -137,6 +137,15 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
   end
 
   defp check_covariant(
+         %Blueprint.Schema.InterfaceTypeDefinition{identifier: interface_ident},
+         interface_ident,
+         _field_ident,
+         _types
+       ) do
+    :ok
+  end
+
+  defp check_covariant(
          %wrapper{of_type: inner_type1},
          %wrapper{of_type: inner_type2},
          field_ident,

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -6,8 +6,6 @@ defmodule Absinthe.ResolutionTest do
 
     interface :named do
       field :name, :string
-      field :parent, :named
-      field :another_parent, :named
 
       resolve_type fn _, _ -> :user end
     end
@@ -16,8 +14,6 @@ defmodule Absinthe.ResolutionTest do
       interface :named
       field :id, :id
       field :name, :string
-      field :parent, :named
-      field :another_parent, :user
     end
 
     query do

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -7,6 +7,7 @@ defmodule Absinthe.ResolutionTest do
     interface :named do
       field :name, :string
       field :parent, :named
+      field :another_parent, :named
 
       resolve_type fn _, _ -> :user end
     end
@@ -16,6 +17,7 @@ defmodule Absinthe.ResolutionTest do
       field :id, :id
       field :name, :string
       field :parent, :named
+      field :another_parent, :user
     end
 
     query do

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -6,6 +6,7 @@ defmodule Absinthe.ResolutionTest do
 
     interface :named do
       field :name, :string
+      field :parent, :named
 
       resolve_type fn _, _ -> :user end
     end
@@ -14,6 +15,7 @@ defmodule Absinthe.ResolutionTest do
       interface :named
       field :id, :id
       field :name, :string
+      field :parent, :named
     end
 
     query do

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -7,6 +7,9 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     object :user do
       interface :named
       field :name, :string
+      field :id, :id
+      field :parent, :named
+      field :another_parent, :user
     end
   end
 
@@ -16,20 +19,36 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
 
     interface :named do
       field :name, :string
+      field :parent, :named
+      field :another_parent, :named
 
       resolve_type fn
-        %{type: :dog} -> :dog
-        %{type: :user} -> :user
-        _ -> nil
+        %{type: :dog}, _ -> :dog
+        %{type: :user}, _ -> :user
+        _, _ -> nil
       end
     end
 
     object :dog do
       field :name, :string
       interface :named
+      field :parent, :named
+      field :another_parent, :user
     end
 
     query do
+      field :user, :user do
+        resolve fn _, _ ->
+          {:ok,
+           %{
+             type: :user,
+             id: "abc-123",
+             name: "User Name",
+             parent: %{type: :user, id: "def-456", name: "Parent User"},
+             another_parent: %{type: :user, id: "ghi-789", name: "Another Parent"}
+           }}
+        end
+      end
     end
   end
 
@@ -54,5 +73,38 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
         phase: Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces
       }
     ])
+  end
+
+  test "Interfaces can contain fields of their own type" do
+    doc = """
+    {
+      user {
+        ... on User {
+          id
+          parent {
+            ... on Named {
+              name
+            }
+            ... on User {
+              id
+            }
+          }
+          anotherParent {
+            id
+          }
+        }
+        ... on Named {
+          name
+        }
+      }
+    }
+    """
+
+    {:ok, %{data: data}} = Absinthe.run(doc, Schema)
+
+    assert get_in(data, ["user", "id"]) == "abc-123"
+    assert get_in(data, ["user", "parent", "id"]) == "def-456"
+    assert get_in(data, ["user", "parent", "name"]) == "Parent User"
+    assert get_in(data, ["user", "anotherParent", "id"]) == "ghi-789"
   end
 end


### PR DESCRIPTION
A particular usage of interface fields led to an infinite loop in `check_covariant`

closes #597 
@benwilson512 