### PR TITLE
Add extend to macro defined schemas

### DIFF
--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -200,7 +200,8 @@ defmodule Absinthe.Blueprint.Schema do
          buff
        ) do
     obj = Map.update!(obj, :fields, &Enum.reverse/1)
-    build_types(rest, [push(schema, :type_definitions, obj) | stack], buff)
+    {schema, buff} = modify(schema, :type_definitions, obj, buff)
+    build_types(rest, [schema | stack], buff)
   end
 
   defp build_types(

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -164,6 +164,11 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [directive | stack], buff)
   end
 
+  defp build_types([{:types, types} | rest], [union | stack], buff) do
+    union = Map.update!(union, :types, &(types ++ &1))
+    build_types(rest, [union | stack], buff)
+  end
+
   defp build_types([{attr, value} | rest], [entity | stack], buff) do
     entity = %{entity | attr => value}
     build_types(rest, [entity | stack], buff)
@@ -215,7 +220,8 @@ defmodule Absinthe.Blueprint.Schema do
   end
 
   defp build_types([:close | rest], [%Schema.UnionTypeDefinition{} = union, schema | stack], buff) do
-    build_types(rest, [push(schema, :type_definitions, union) | stack], buff)
+    {schema, buff} = modify(schema, :type_definitions, union, buff)
+    build_types(rest, [schema | stack], buff)
   end
 
   defp build_types([:close | rest], [%Schema.DirectiveDefinition{} = dir, schema | stack], buff) do

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -191,11 +191,11 @@ defmodule Absinthe.Blueprint.Schema do
   # When extending, replace the object instead of adding it
   defp build_types(
          [:close | rest],
-         [%Schema.ObjectTypeDefinition{} = extended, schema | stack],
+         [%Schema.ObjectTypeDefinition{} = obj, schema | stack],
          [:extend | buff]
        ) do
-    extended = Map.update!(extended, :fields, &Enum.reverse/1)
-    build_types(rest, [replace_type(schema, extended) | stack], buff)
+    obj = Map.update!(obj, :fields, &Enum.reverse/1)
+    build_types(rest, [replace_type(schema, obj) | stack], buff)
   end
 
   defp build_types([:close | rest], [%Schema.ObjectTypeDefinition{} = obj, schema | stack], buff) do
@@ -210,6 +210,15 @@ defmodule Absinthe.Blueprint.Schema do
        ) do
     obj = Map.update!(obj, :fields, &Enum.reverse/1)
     build_types(rest, [push(schema, :type_definitions, obj) | stack], buff)
+  end
+
+  defp build_types(
+         [:close | rest],
+         [%Schema.InterfaceTypeDefinition{} = iface, schema | stack],
+         [:extend | buff]
+       ) do
+    iface = Map.update!(iface, :fields, &Enum.reverse/1)
+    build_types(rest, [replace_type(schema, iface) | stack], buff)
   end
 
   defp build_types(

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -156,7 +156,7 @@ defmodule Absinthe.Blueprint.Schema do
 
   defp build_types([{:sdl, sdl_definitions} | rest], [schema | stack], buff) do
     # TODO: Handle directives, etc
-    build_types(rest, [concat(schema, :type_definitions, sdl_definitions) | stack], buff)
+    build_types(rest, [push(schema, :type_definitions, sdl_definitions) | stack], buff)
   end
 
   defp build_types([{:locations, locations} | rest], [directive | stack], buff) do
@@ -188,19 +188,10 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [push(obj, :fields, field) | stack], buff)
   end
 
-  # When extending, replace the object instead of adding it
-  defp build_types(
-         [:close | rest],
-         [%Schema.ObjectTypeDefinition{} = obj, schema | stack],
-         [:extend | buff]
-       ) do
-    obj = Map.update!(obj, :fields, &Enum.reverse/1)
-    build_types(rest, [replace_type(schema, obj) | stack], buff)
-  end
-
   defp build_types([:close | rest], [%Schema.ObjectTypeDefinition{} = obj, schema | stack], buff) do
     obj = Map.update!(obj, :fields, &Enum.reverse/1)
-    build_types(rest, [push(schema, :type_definitions, obj) | stack], buff)
+    {schema, buff} = modify(schema, :type_definitions, obj, buff)
+    build_types(rest, [schema | stack], buff)
   end
 
   defp build_types(
@@ -215,19 +206,11 @@ defmodule Absinthe.Blueprint.Schema do
   defp build_types(
          [:close | rest],
          [%Schema.InterfaceTypeDefinition{} = iface, schema | stack],
-         [:extend | buff]
-       ) do
-    iface = Map.update!(iface, :fields, &Enum.reverse/1)
-    build_types(rest, [replace_type(schema, iface) | stack], buff)
-  end
-
-  defp build_types(
-         [:close | rest],
-         [%Schema.InterfaceTypeDefinition{} = iface, schema | stack],
          buff
        ) do
     iface = Map.update!(iface, :fields, &Enum.reverse/1)
-    build_types(rest, [push(schema, :type_definitions, iface) | stack], buff)
+    {schema, buff} = modify(schema, :type_definitions, iface, buff)
+    build_types(rest, [schema | stack], buff)
   end
 
   defp build_types([:close | rest], [%Schema.UnionTypeDefinition{} = union, schema | stack], buff) do
@@ -254,22 +237,32 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [bp], buff)
   end
 
+  def modify(entity, key, val, [:extend | buff]) do
+    {replace(entity, key, val), buff}
+  end
+
+  def modify(entity, key, val, buff) do
+    {push(entity, key, val), buff}
+  end
+
+  defp push(entity, key, value) when is_list(value) do
+    Map.update!(entity, key, &(&1 ++ value))
+  end
+
   defp push(entity, key, value) do
     Map.update!(entity, key, &[value | &1])
   end
 
-  defp concat(entity, key, value) do
-    Map.update!(entity, key, &(&1 ++ value))
-  end
-
-  defp replace_type(schema, %{identifier: identifier} = type) do
-    type_definitions =
-      Enum.map(schema.type_definitions, fn
+  defp replace(entity, key, %{identifier: identifier} = type) do
+    new_value =
+      entity
+      |> Map.get(key)
+      |> Enum.map(fn
         %{identifier: ^identifier} -> type
         other -> other
       end)
 
-    %{schema | type_definitions: type_definitions}
+    %{entity | key => new_value}
   end
 
   defp update_private(existing_private, private) do

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -222,14 +222,12 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [push(schema, :directive_definitions, dir) | stack], buff)
   end
 
-  @simple_close [
-    Schema.ScalarTypeDefinition,
-    Schema.EnumTypeDefinition
-  ]
+  defp build_types([:close | rest], [%Schema.ScalarTypeDefinition{} = type, schema | stack], buff) do
+    build_types(rest, [push(schema, :type_definitions, type) | stack], buff)
+  end
 
-  defp build_types([:close | rest], [%module{} = type, schema | stack], buff)
-       when module in @simple_close do
-    schema = push(schema, :type_definitions, type)
+  defp build_types([:close | rest], [%Schema.EnumTypeDefinition{} = type, schema | stack], buff) do
+    {schema, buff} = modify(schema, :type_definitions, type, buff)
     build_types(rest, [schema | stack], buff)
   end
 

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1146,6 +1146,16 @@ defmodule Absinthe.Schema.Notation do
     put_attr(__CALLER__.module, {:import_fields, {source_criteria, opts}})
   end
 
+  @placement {:extend, [toplevel: true]}
+  defmacro extend(identifier, do: block) do
+    put_attr(__CALLER__.module, {:extend, identifier})
+
+    [
+      block,
+      quote(do: unquote(__MODULE__).close_scope())
+    ]
+  end
+
   @placement {:import_types, [toplevel: true]}
   @doc """
   Import types from another module

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1145,6 +1145,29 @@ defmodule Absinthe.Schema.Notation do
     put_attr(__CALLER__.module, {:import_fields, {source_criteria, opts}})
   end
 
+  @doc """
+  Extend another type
+
+  ## Example
+  ```
+  object :person do
+    field :name, :string
+  end
+
+  extend :person do
+    field :age, :integer
+  end
+  ```
+
+  This results in a `Person` object which contains two fields, `name` and `age`.
+
+  A limited set of types can be extended:
+  * `object`
+  * `input_object`
+  * `enum`
+  * `interface`
+  * `union`
+  """
   @placement {:extend, [toplevel: true]}
   defmacro extend(identifier, do: block) do
     type = extendable!(__CALLER__.module, identifier)

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -104,6 +104,18 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
         "Invalid schema notation: `arg` must only be used within `directive`, `field`"
       )
     end
+
+    test "can't extend something that doesn't exist" do
+      assert_notation_error(
+        "NonExistant",
+        """
+        extend :non_existant_object do
+          field :bar, :string
+        end
+        """,
+        "Can't extend `non_existant_object` because it doesn't exist"
+      )
+    end
   end
 
   def assert_notation_error(name, text, message) do

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -30,11 +30,19 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     extend :my_input_object do
       field :bar, :string
     end
+
+    enum :my_enum do
+      value :one
+    end
+
+    extend :my_enum do
+      value :two
+    end
   end
 
   describe "extend" do
     test "object" do
-      assert %{identifier: :my_object, fields: fields} = lookup_type(Definition, :my_object)
+      assert %{fields: fields} = lookup_type(Definition, :my_object)
 
       field_identifiers = Enum.map(fields, & &1.identifier)
       assert :foo in field_identifiers
@@ -42,7 +50,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     end
 
     test "interface" do
-      assert %{identifier: :my_interface, fields: fields} = lookup_type(Definition, :my_interface)
+      assert %{fields: fields} = lookup_type(Definition, :my_interface)
 
       field_identifiers = Enum.map(fields, & &1.identifier)
       assert :foo in field_identifiers
@@ -50,12 +58,19 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     end
 
     test "input_object" do
-      assert %{identifier: :my_input_object, fields: fields} =
-               lookup_type(Definition, :my_input_object)
+      assert %{fields: fields} = lookup_type(Definition, :my_input_object)
 
       field_identifiers = Enum.map(fields, & &1.identifier)
       assert :foo in field_identifiers
       assert :bar in field_identifiers
+    end
+
+    test "enum" do
+      assert %{values: values} = lookup_type(Definition, :my_enum)
+
+      value_identifiers = Enum.map(values, & &1.identifier)
+      assert :one in value_identifiers
+      assert :two in value_identifiers
     end
 
     test "applies placement rules!" do

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -22,12 +22,19 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     extend :my_interface do
       field :bar, :string
     end
+
+    input_object :my_input_object do
+      field :foo, :string
+    end
+
+    extend :my_input_object do
+      field :bar, :string
+    end
   end
 
   describe "extend" do
     test "object" do
-      assert %{name: "MyObject", identifier: :my_object, fields: fields} =
-               lookup_type(Definition, :my_object)
+      assert %{identifier: :my_object, fields: fields} = lookup_type(Definition, :my_object)
 
       field_identifiers = Enum.map(fields, & &1.identifier)
       assert :foo in field_identifiers
@@ -35,8 +42,16 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     end
 
     test "interface" do
-      assert %{name: "MyInterface", identifier: :my_interface, fields: fields} =
-               lookup_type(Definition, :my_interface)
+      assert %{identifier: :my_interface, fields: fields} = lookup_type(Definition, :my_interface)
+
+      field_identifiers = Enum.map(fields, & &1.identifier)
+      assert :foo in field_identifiers
+      assert :bar in field_identifiers
+    end
+
+    test "input_object" do
+      assert %{identifier: :my_input_object, fields: fields} =
+               lookup_type(Definition, :my_input_object)
 
       field_identifiers = Enum.map(fields, & &1.identifier)
       assert :foo in field_identifiers

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -38,6 +38,14 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
     extend :my_enum do
       value :two
     end
+
+    union :my_union do
+      types [:one]
+    end
+
+    extend :my_union do
+      types [:two]
+    end
   end
 
   describe "extend" do
@@ -71,6 +79,13 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
       value_identifiers = Enum.map(values, & &1.identifier)
       assert :one in value_identifiers
       assert :two in value_identifiers
+    end
+
+    test "union" do
+      assert %{types: types} = lookup_type(Definition, :my_union)
+
+      assert :one in types
+      assert :two in types
     end
 
     test "applies placement rules!" do

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -116,6 +116,21 @@ defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
         "Can't extend `non_existant_object` because it doesn't exist"
       )
     end
+
+    test "can't extend a field" do
+      assert_notation_error(
+        "ExtendField",
+        """
+        object :my_object do
+          field :bar, :string do
+          end
+          extend :bar do
+          end
+        end
+        """,
+        "Can't extend a `field`"
+      )
+    end
   end
 
   def assert_notation_error(name, text, message) do

--- a/test/absinthe/schema/notation/experimental/extend_test.exs
+++ b/test/absinthe/schema/notation/experimental/extend_test.exs
@@ -1,0 +1,34 @@
+defmodule Absinthe.Schema.Notation.Experimental.ExtendTest do
+  use Absinthe.Case
+  import ExperimentalNotationHelpers
+
+  @moduletag :experimental
+
+  defmodule Definition do
+    use Absinthe.Schema.Notation
+
+    object :my_object do
+      field :foo, :string
+    end
+
+    extend :my_object do
+      field :bar, :string
+    end
+  end
+
+  describe "extend" do
+    test "my_object" do
+      assert %{name: "MyObject", identifier: :my_object, fields: fields} =
+               lookup_type(Definition, :my_object)
+
+      field_identifiers = Enum.map(fields, & &1.identifier)
+      assert :foo in field_identifiers
+      assert :bar in field_identifiers
+
+      %{schema_definitions: [%{type_definitions: type_definitions}]} =
+        Definition.__absinthe_blueprint__()
+
+      assert length(type_definitions) == 1
+    end
+  end
+end

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -106,7 +106,7 @@ defmodule Absinthe.Schema.NotationTest do
         """
         field :foo, :string
         """,
-        "Invalid schema notation: `field` must only be used within `input_object`, `interface`, `object`"
+        "Invalid schema notation: `field` must only be used within `input_object`, `interface`, `object`, `extend`"
       )
     end
   end

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -106,7 +106,7 @@ defmodule Absinthe.Schema.NotationTest do
         """
         field :foo, :string
         """,
-        "Invalid schema notation: `field` must only be used within `input_object`, `interface`, `object`, `extend`"
+        "Invalid schema notation: `field` must only be used within `input_object`, `interface`, `object`"
       )
     end
   end


### PR DESCRIPTION
This PR introduces an `extend` macro that behaves as the "extend" concept in the GraphQL spec:

* https://graphql.github.io/graphql-spec/draft/#sec-Object-Extensions

We can extend `object`, `input_object`, `enum`, `union`, and `interface`.

The GraphQL spec allows extending `schema` and `scalar` but that isn't supported here - there isn't a `schema` macro to extend and scalars can only be extended to have more directives which also isn't supported in macro schemas

For now this works with macro based schemas, but it should be possible to adapt this to SDL based schemas as well (see #772)