### PR TITLE
Remove unused function heads

### DIFF
--- a/lib/absinthe/adapter/language_conventions.ex
+++ b/lib/absinthe/adapter/language_conventions.ex
@@ -56,10 +56,6 @@ defmodule Absinthe.Adapter.LanguageConventions do
     "__" <> to_internal_name(camelized_name, role)
   end
 
-  def to_internal_name(camelized_name, :operation) when is_binary(camelized_name) do
-    camelized_name
-  end
-
   def to_internal_name(camelized_name, _role) when is_binary(camelized_name) do
     camelized_name
     |> Macro.underscore()
@@ -73,10 +69,6 @@ defmodule Absinthe.Adapter.LanguageConventions do
 
   def to_external_name("__" <> underscored_name, role) do
     "__" <> to_external_name(underscored_name, role)
-  end
-
-  def to_external_name(underscored_name, :operation) when is_binary(underscored_name) do
-    underscored_name
   end
 
   def to_external_name(<<c::utf8, _::binary>> = name, _) when c in ?A..?Z do

--- a/test/absinthe/adapters/language_conventions_test.exs
+++ b/test/absinthe/adapters/language_conventions_test.exs
@@ -12,10 +12,6 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
       assert "foo_bar" = LanguageConventions.to_internal_name("fooBar", :variable)
     end
 
-    test "preserves external operation names" do
-      assert "fooBar" = LanguageConventions.to_internal_name("fooBar", :operation)
-    end
-
     test "converts external field names that do not match internal name" do
       assert "foo_bar" = LanguageConventions.to_internal_name("foo_bar", :field)
       assert "foo_bar" = LanguageConventions.to_internal_name("FooBar", :field)
@@ -30,10 +26,6 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
 
     test "converts internal underscored variable names to camelcase external variable names" do
       assert "fooBar" = LanguageConventions.to_external_name("foo_bar", :variable)
-    end
-
-    test "preserves internal operation names" do
-      assert "foo_bar" = LanguageConventions.to_external_name("foo_bar", :operation)
     end
   end
 end

--- a/test/absinthe/adapters/strict_language_conventions_test.exs
+++ b/test/absinthe/adapters/strict_language_conventions_test.exs
@@ -16,10 +16,6 @@ defmodule Absinthe.Adapter.StrictLanguageConventionsTest do
       assert "foo_bar" = StrictLanguageConventions.to_internal_name("fooBar", :variable)
     end
 
-    test "preserves external operation names" do
-      assert "fooBar" = StrictLanguageConventions.to_internal_name("fooBar", :operation)
-    end
-
     test "nullifies external field names that do not match internal name" do
       assert is_nil(StrictLanguageConventions.to_internal_name("foo_bar", :field))
       assert is_nil(StrictLanguageConventions.to_internal_name("FooBar", :field))
@@ -34,10 +30,6 @@ defmodule Absinthe.Adapter.StrictLanguageConventionsTest do
 
     test "converts internal underscored variable names to camelcase external variable names" do
       assert "fooBar" = StrictLanguageConventions.to_external_name("foo_bar", :variable)
-    end
-
-    test "preserves internal operation names" do
-      assert "foo_bar" = StrictLanguageConventions.to_external_name("foo_bar", :operation)
     end
   end
 end


### PR DESCRIPTION
We never call these functions with `:operation` outside the tests...

Followup from #719 