### PR TITLE
Return error if operation name did not match single operation in document

### DIFF
--- a/lib/absinthe/phase/document/validation/selected_current_operation.ex
+++ b/lib/absinthe/phase/document/validation/selected_current_operation.ex
@@ -38,10 +38,9 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
     }
   end
 
-  @error_message "Must provide a valid operation name if query contains multiple operations."
   def error_message(nil, _) do
     """
-    #{@error_message}
+    Must provide a valid operation name if query contains multiple operations.
 
     No operation name was given.
     """
@@ -57,7 +56,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
 
   def error_message(operation_name, _) do
     """
-    #{@error_message}
+    Must provide a valid operation name if query contains multiple operations.
 
     The provided operation name was: #{inspect(operation_name)}
     """

--- a/lib/absinthe/phase/document/validation/selected_current_operation.ex
+++ b/lib/absinthe/phase/document/validation/selected_current_operation.ex
@@ -12,13 +12,15 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
   Run the validation.
   """
   @spec run(Blueprint.t(), Keyword.t()) :: Phase.result_t()
-  def run(input, _options \\ []) do
+  def run(input, options \\ []) do
     result =
       case {Blueprint.current_operation(input), length(input.operations)} do
-        {nil, count} when count > 1 ->
+        {nil, count} when count >= 1 ->
+          operation_name = Keyword.get(options, :operation_name)
+
           input
           |> flag_invalid(:no_current_operation)
-          |> put_error(error())
+          |> put_error(error(operation_name, count))
 
         _ ->
           input
@@ -28,15 +30,36 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
   end
 
   # Generate the error
-  @spec error :: Phase.Error.t()
-  defp error do
+  @spec error(String.t(), Integer.t()) :: Phase.Error.t()
+  defp error(operation_name, operation_count) do
     %Phase.Error{
       phase: __MODULE__,
-      message: error_message()
+      message: error_message(operation_name, operation_count)
     }
   end
 
-  def error_message do
-    ~s(Must provide a valid operation name if query contains multiple operations.)
+  @error_message "Must provide a valid operation name if query contains multiple operations."
+  def error_message(nil, _) do
+    """
+    #{@error_message}
+
+    No operation name was given.
+    """
+  end
+
+  def error_message(operation_name, 1) do
+    """
+    The provided operation name dit not match the operation in the query.
+
+    The provided operation name was: #{inspect(operation_name)}
+    """
+  end
+
+  def error_message(operation_name, _) do
+    """
+    #{@error_message}
+
+    The provided operation name was: #{inspect(operation_name)}
+    """
   end
 end

--- a/lib/absinthe/phase/document/validation/selected_current_operation.ex
+++ b/lib/absinthe/phase/document/validation/selected_current_operation.ex
@@ -49,7 +49,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperation do
 
   def error_message(operation_name, 1) do
     """
-    The provided operation name dit not match the operation in the query.
+    The provided operation name did not match the operation in the query.
 
     The provided operation name was: #{inspect(operation_name)}
     """

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -58,7 +58,7 @@ defmodule Absinthe.Pipeline do
       # Validate Document Structure
       {Phase.Document.Validation.NoFragmentCycles, options},
       Phase.Document.Validation.LoneAnonymousOperation,
-      Phase.Document.Validation.SelectedCurrentOperation,
+      {Phase.Document.Validation.SelectedCurrentOperation, options},
       Phase.Document.Validation.KnownFragmentNames,
       Phase.Document.Validation.NoUndefinedVariables,
       Phase.Document.Validation.NoUnusedVariables,

--- a/test/absinthe/integration/execution/operation_by_name_test.exs
+++ b/test/absinthe/integration/execution/operation_by_name_test.exs
@@ -106,7 +106,7 @@ defmodule Elixir.Absinthe.Integration.Execution.OperationByNameTest do
               errors: [
                 %{
                   message: """
-                  The provided operation name dit not match the operation in the query.
+                  The provided operation name did not match the operation in the query.
 
                   The provided operation name was: "Second"
                   """

--- a/test/absinthe/integration/execution/operation_by_name_test.exs
+++ b/test/absinthe/integration/execution/operation_by_name_test.exs
@@ -27,8 +27,11 @@ defmodule Elixir.Absinthe.Integration.Execution.OperationByNameTest do
             %{
               errors: [
                 %{
-                  message:
-                    "Must provide a valid operation name if query contains multiple operations."
+                  message: """
+                  Must provide a valid operation name if query contains multiple operations.
+
+                  No operation name was given.
+                  """
                 }
               ]
             }} == Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, [])
@@ -39,8 +42,11 @@ defmodule Elixir.Absinthe.Integration.Execution.OperationByNameTest do
             %{
               errors: [
                 %{
-                  message:
-                    "Must provide a valid operation name if query contains multiple operations."
+                  message: """
+                  Must provide a valid operation name if query contains multiple operations.
+
+                  The provided operation name was: "invalid"
+                  """
                 }
               ]
             }} ==
@@ -80,6 +86,30 @@ defmodule Elixir.Absinthe.Integration.Execution.OperationByNameTest do
                   locations: [%{column: 3, line: 7}],
                   message: "Custom Error",
                   path: ["second"]
+                }
+              ]
+            }} ==
+             Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, operation_name: "Second")
+  end
+
+  @query """
+  mutation First($id: ID!, $thing: InputThing!) {
+    updateThing(id: $id thing: $thing) {
+      id
+    }
+  }
+  """
+
+  test "return error when single operation in document does not match given operation name" do
+    assert {:ok,
+            %{
+              errors: [
+                %{
+                  message: """
+                  The provided operation name dit not match the operation in the query.
+
+                  The provided operation name was: "Second"
+                  """
                 }
               ]
             }} ==

--- a/test/absinthe/phase/document/validation/selected_current_operation_test.exs
+++ b/test/absinthe/phase/document/validation/selected_current_operation_test.exs
@@ -7,10 +7,10 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperationTest do
 
   alias Absinthe.Blueprint
 
-  defp no_current_operation do
+  defp no_current_operation(operation_name, count) do
     bad_value(
       Blueprint,
-      @phase.error_message,
+      @phase.error_message(operation_name, count),
       nil
     )
   end
@@ -30,6 +30,18 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperationTest do
       )
     end
 
+    test "fails when single operation in document does not match given operation name" do
+      assert_fails_validation(
+        """
+        query Bar {
+          name
+        }
+        """,
+        [operation_name: "Nothere"],
+        no_current_operation("Nothere", 1)
+      )
+    end
+
     test "fails when the operation is not provided" do
       assert_fails_validation(
         """
@@ -41,7 +53,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperationTest do
         }
         """,
         [operation_name: "Nothere"],
-        no_current_operation()
+        no_current_operation("Nothere", 2)
       )
     end
   end
@@ -80,7 +92,7 @@ defmodule Absinthe.Phase.Document.Validation.SelectedCurrentOperationTest do
         }
         """,
         [],
-        no_current_operation()
+        no_current_operation(nil, 2)
       )
     end
   end


### PR DESCRIPTION
In https://github.com/absinthe-graphql/absinthe/blob/2d423f6ad45cb3e1c194d3cb0843fd358d298b2d/lib/absinthe/phase/document/current_operation.ex#L26
there is the edge case that when only one operation was set in the input
and it did not match the `:operation_name` in the options, there would be
no current operation.

In `Absinthe.Phase.Document.Validation.SelectedCurrentOperation` it would
usually be caught that there is no current operation set. However, it was
assumed this would be happen when there were more than 1 operations in the
document. https://github.com/absinthe-graphql/absinthe/blob/2d423f6ad45cb3e1c194d3cb0843fd358d298b2d/lib/absinthe/phase/document/validation/selected_current_operation.ex#L18

This was changed, when there is 1 operation in the document but no
current operation is found an error is returned.

I've also expanded on the error messages that may be returned as to
better discern what happens in these cases

 * No operation name given but multiple in document
 * Operation name given but did not match any of the multiple in the document
 * Operation name given but did not match the single operation in the document

Another approach could have been to ignore the `:operation_name` when
only one operation is given in the document, and set this operation as
the current operation. I think this hides the error.

Fixes https://github.com/absinthe-graphql/absinthe/issues/726

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
