### PR TITLE
Convert argument name in SDL to camelCase

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -88,9 +88,10 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
     )
   end
 
+  @adapter Absinthe.Adapter.LanguageConventions
   defp render(%Blueprint.Schema.InputValueDefinition{} = input_value, type_definitions) do
     concat([
-      string(input_value.name),
+      string(@adapter.to_external_name(input_value.name, :argument)),
       ": ",
       render(input_value.type, type_definitions),
       default(input_value.default_value_blueprint)
@@ -98,7 +99,6 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
     |> description(input_value.description)
   end
 
-  @adapter Absinthe.Adapter.LanguageConventions
   defp render(%Blueprint.Schema.FieldDefinition{} = field, type_definitions) do
     concat([
       string(@adapter.to_external_name(field.name, :field)),

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -179,6 +179,7 @@ defmodule SdlRenderTest do
     query do
       field :echo, :string do
         arg :times, :integer, default_value: 10, description: "The number of times"
+        arg :time_interval, :integer
       end
     end
 
@@ -205,6 +206,8 @@ defmodule SdlRenderTest do
 
              type RootQueryType {
                echo(
+                 timeInterval: Int
+
                  "The number of times"
                  times: Int
                ): String


### PR DESCRIPTION
When creating SDL from a schema the argument name was used
literally instead of converting it to camelCase as how it is exposed
in Absinthe.

This PR uses the same method as was done for FieldDefinition names
to convert the value using the LanguageConventions adapter.