### PR TITLE
Fix typo in module name

### DIFF
--- a/lib/absinthe/phase/schema/validation/input_output_types_correctly_placed.ex
+++ b/lib/absinthe/phase/schema/validation/input_output_types_correctly_placed.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Phase.Schema.Validation.InputOuputTypesCorrectlyPlaced do
+defmodule Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -142,7 +142,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.Arguments.Data,
       Phase.Schema.Directives,
       Phase.Schema.Validation.DefaultEnumValuePresent,
-      Phase.Schema.Validation.InputOuputTypesCorrectlyPlaced,
+      Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced,
       Phase.Schema.Validation.InterfacesMustResolveTypes,
       Phase.Schema.Validation.ObjectInterfacesMustBeValid,
       Phase.Schema.Validation.ObjectMustImplementInterfaces,

--- a/lib/absinthe/schema/rule.ex
+++ b/lib/absinthe/schema/rule.ex
@@ -29,7 +29,7 @@ defmodule Absinthe.Schema.Rule do
     Rule.ObjectInterfacesMustBeValid,
     Rule.ObjectMustImplementInterfaces,
     Rule.InterfacesMustResolveTypes,
-    Rule.InputOuputTypesCorrectlyPlaced,
+    Rule.InputOutputTypesCorrectlyPlaced,
     Rule.DefaultEnumValuePresent
   ]
 

--- a/test/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
+++ b/test/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
@@ -1,4 +1,4 @@
-defmodule Absinthe.Schema.Rule.InputOuputTypesCorrectlyPlacedTest do
+defmodule Absinthe.Schema.Rule.InputOutputTypesCorrectlyPlacedTest do
   use Absinthe.Case, async: true
 
   describe "rule" do
@@ -17,7 +17,7 @@ defmodule Absinthe.Schema.Rule.InputOuputTypesCorrectlyPlacedTest do
               line: 11
             }
           ],
-          phase: Absinthe.Phase.Schema.Validation.InputOuputTypesCorrectlyPlaced
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
         },
         %{
           extra: %{
@@ -31,7 +31,7 @@ defmodule Absinthe.Schema.Rule.InputOuputTypesCorrectlyPlacedTest do
               line: 16
             }
           ],
-          phase: Absinthe.Phase.Schema.Validation.InputOuputTypesCorrectlyPlaced
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
         }
       ])
     end
@@ -51,7 +51,7 @@ defmodule Absinthe.Schema.Rule.InputOuputTypesCorrectlyPlacedTest do
               line: 8
             }
           ],
-          phase: Absinthe.Phase.Schema.Validation.InputOuputTypesCorrectlyPlaced
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
         }
       ])
     end


### PR DESCRIPTION
`InputOuputTypesCorrectlyPlaced` -> `InputOutputTypesCorrectlyPlaced`