### PR TITLE
Fix skipped list_of validation

### DIFF
--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -72,6 +72,11 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     build_value(normalized, inner_type, context)
   end
 
+  defp build_value(%{__struct__: struct} = _normalized, _not_scalar, _context)
+       when struct in [Input.Boolean, Input.Float, Input.Integer, Input.String] do
+    {:error, :bad_parse}
+  end
+
   defp build_value(_, _, _) do
     :not_leaf_node
   end

--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -72,7 +72,7 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     build_value(normalized, inner_type, context)
   end
 
-  defp build_value(%{__struct__: struct} = _normalized, _not_scalar, _context)
+  defp build_value(%{__struct__: struct}, %Type.InputObject{}, _)
        when struct in [Input.Boolean, Input.Float, Input.Integer, Input.String] do
     {:error, :bad_parse}
   end

--- a/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
@@ -802,6 +802,37 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectTypeTest do
       )
     end
 
+    test "Partial object, list with correct value" do
+      assert_passes_validation(
+        """
+        {
+          complicatedArgs {
+            complexArgField(complexArgList: [{ requiredField: true }])
+          }
+        }
+        """,
+        []
+      )
+    end
+
+    test "Partial object, list with bad value" do
+      assert_fails_validation(
+        """
+        {
+          complicatedArgs {
+            complexArgField(complexArgList: [2])
+          }
+        }
+        """,
+        [],
+        [
+          bad_argument("complexArgList", "[ComplexInput]", "[2]", 3, [
+            @phase.value_error_message(0, "ComplexInput", "2")
+          ])
+        ]
+      )
+    end
+
     test "Full object" do
       assert_passes_validation(
         """

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -157,6 +157,7 @@ defmodule Absinthe.Fixtures.PetsSchema do
 
     field :complex_arg_field, :string do
       arg :complex_arg, :complex_input
+      arg :complex_arg_list, list_of(:complex_input)
     end
 
     field :multiple_reqs, :string do


### PR DESCRIPTION
This PR adds in a missing validation inside of `Absinthe.Phase.Document.Arguments.Parse`

The validation catches cases when a Scalar value is provided for a `schema_node` that is an Input Object.

This fixes an issue that caused Absinthe to allow invalid arguments as described in #752 

fixes #752 