### PR TITLE
Remove duplicate keys in structs

### DIFF
--- a/lib/absinthe/blueprint/schema/enum_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_value_definition.ex
@@ -12,7 +12,6 @@ defmodule Absinthe.Blueprint.Schema.EnumValueDefinition do
     directives: [],
     source_location: nil,
     description: nil,
-    source_location: nil,
     # Added by phases
     flags: %{},
     module: nil,

--- a/lib/absinthe/blueprint/schema/field_definition.ex
+++ b/lib/absinthe/blueprint/schema/field_definition.ex
@@ -18,7 +18,6 @@ defmodule Absinthe.Blueprint.Schema.FieldDefinition do
     directives: [],
     complexity: nil,
     source_location: nil,
-    description: nil,
     middleware: [],
     function_ref: nil,
     flags: %{},

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -75,8 +75,7 @@ defmodule Absinthe.Type.Interface do
             resolve_type: nil,
             __private__: [],
             definition: nil,
-            __reference__: nil,
-            resolve_type: nil
+            __reference__: nil
 
   @doc false
   defdelegate functions, to: Absinthe.Blueprint.Schema.InterfaceTypeDefinition


### PR DESCRIPTION
Compiling with elixir 1.10.0-rc.0 returned these warnings.

```
warning: duplicate key :source_location found in struct
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  lib/absinthe/blueprint/schema/enum_value_definition.ex:7: (module)
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:60: :elixir_compiler.compile/3

warning: duplicate key :resolve_type found in struct
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  lib/absinthe/type/interface.ex:71: (module)
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:60: :elixir_compiler.compile/3

warning: duplicate key :description found in struct
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:119: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.10.0-rc.0) lib/kernel/utils.ex:98: Kernel.Utils.defstruct/2
  lib/absinthe/blueprint/schema/field_definition.ex:7: (module)
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
  (elixir 1.10.0-rc.0) src/elixir_compiler.erl:60: :elixir_compiler.compile/3

```

This PR fixes them
