### PR TITLE
allow hydrating builtins

### DIFF
--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -35,15 +35,9 @@ defmodule Absinthe.Phase.Schema.Hydrate do
 
   defp handle_node(%node_module{} = node, ancestors, schema, hydrator)
        when node_module in @hydrate do
-    case Absinthe.Type.built_in_module?(node.module) do
-      true ->
-        {:halt, node}
-
-      false ->
-        node
-        |> hydrate_node(ancestors, schema, hydrator)
-        |> set_children(ancestors, schema, hydrator)
-    end
+    node
+    |> hydrate_node(ancestors, schema, hydrator)
+    |> set_children(ancestors, schema, hydrator)
   end
 
   defp handle_node(node, ancestors, schema, hydrator) do

--- a/test/absinthe/schema/hydrate_builtins_test.exs
+++ b/test/absinthe/schema/hydrate_builtins_test.exs
@@ -1,0 +1,30 @@
+defmodule HydrateBuiltinsTest do
+  use ExUnit.Case, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    query do
+      field :value, :float do
+        # intentionally a float
+        resolve fn _, _, _ -> {:ok, 1} end
+      end
+    end
+
+    def hydrate(%Absinthe.Blueprint.Schema.ScalarTypeDefinition{identifier: :float}, _) do
+      {:serialize, &__MODULE__.serialize_float/1}
+    end
+
+    def hydrate(_, _) do
+      []
+    end
+
+    def serialize_float(number) when is_number(number) do
+      number * 1.0
+    end
+  end
+
+  test "we can override the builtin scalars" do
+    assert {:ok, %{data: %{"value" => 1.0}}} == Absinthe.run("{ value }", Schema)
+  end
+end


### PR DESCRIPTION
@bruce @binaryseed Hydration right now excludes builtins, but I'm inclined to say that we should allow people to mess with them. This starts from a concrete use case on our end (we need to patch the scalar serialization functions to be more lenient). More generally, I think it's just generally powerful to let users really have complete control over their schema.