### PR TITLE
Add referenced flag

### DIFF
--- a/lib/absinthe/blueprint/schema/directive_definition.ex
+++ b/lib/absinthe/blueprint/schema/directive_definition.ex
@@ -15,6 +15,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
     source_location: nil,
     expand: nil,
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -25,6 +26,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
           arguments: [Blueprint.Schema.InputValueDefinition.t()],
           locations: [String.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
+          referenced: boolean,
           errors: [Absinthe.Phase.Error.t()]
         }
 
@@ -36,6 +38,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
       args: Blueprint.Schema.ObjectTypeDefinition.build_args(type_def, schema),
       locations: type_def.locations |> Enum.sort(),
       definition: type_def.module,
+      referenced: type_def.referenced,
       expand: type_def.expand
     }
   end

--- a/lib/absinthe/blueprint/schema/enum_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_type_definition.ex
@@ -15,6 +15,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
     # Added by phases,
     flags: %{},
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -26,6 +27,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
           identifier: atom,
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -36,6 +38,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
       values: values_by(type_def, :identifier),
       values_by_internal_value: values_by(type_def, :value),
       values_by_name: values_by(type_def, :name),
+      referenced: type_def.referenced,
       definition: type_def.module,
       description: type_def.description
     }

--- a/lib/absinthe/blueprint/schema/input_object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/input_object_type_definition.ex
@@ -16,6 +16,7 @@ defmodule Absinthe.Blueprint.Schema.InputObjectTypeDefinition do
     # Added by phases,
     flags: %{},
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -27,6 +28,7 @@ defmodule Absinthe.Blueprint.Schema.InputObjectTypeDefinition do
           directives: [Blueprint.Directive.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -37,6 +39,7 @@ defmodule Absinthe.Blueprint.Schema.InputObjectTypeDefinition do
       name: type_def.name,
       fields: build_fields(type_def, schema),
       description: type_def.description,
+      referenced: type_def.referenced,
       definition: type_def.module
     }
   end

--- a/lib/absinthe/blueprint/schema/interface_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/interface_type_definition.ex
@@ -18,6 +18,7 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
     errors: [],
     resolve_type: nil,
     imports: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -29,6 +30,7 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
           directives: [Blueprint.Directive.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -40,6 +42,7 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
       fields: Blueprint.Schema.ObjectTypeDefinition.build_fields(type_def, schema),
       identifier: type_def.identifier,
       resolve_type: type_def.resolve_type,
+      referenced: type_def.referenced,
       definition: type_def.module
     }
   end

--- a/lib/absinthe/blueprint/schema/object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/object_type_definition.ex
@@ -19,6 +19,7 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
     flags: %{},
     imports: [],
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -33,6 +34,7 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
           directives: [Blueprint.Directive.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()],
           __private__: Keyword.t()
@@ -49,6 +51,7 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
       fields: build_fields(type_def, schema),
       interfaces: type_def.interfaces,
       definition: type_def.module,
+      referenced: type_def.referenced,
       is_type_of: type_def.is_type_of
     }
   end

--- a/lib/absinthe/blueprint/schema/scalar_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/scalar_type_definition.ex
@@ -16,6 +16,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
     # Added by phases
     flags: %{},
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -26,6 +27,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
           directives: [Blueprint.Directive.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -36,6 +38,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
       name: type_def.name,
       description: type_def.description,
       definition: type_def.module,
+      referenced: type_def.referenced,
       serialize: type_def.serialize,
       parse: type_def.parse
     }

--- a/lib/absinthe/blueprint/schema/union_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/union_type_definition.ex
@@ -17,6 +17,7 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
     # Added by phases
     flags: %{},
     errors: [],
+    referenced: false,
     __reference__: nil,
     __private__: []
   ]
@@ -28,6 +29,7 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
           types: [Blueprint.TypeReference.Name.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
+          referenced: boolean,
           flags: Blueprint.flags_t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -40,6 +42,7 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
       types: type_def.types |> Enum.sort(),
       fields: build_fields(type_def, schema),
       definition: type_def.module,
+      referenced: type_def.referenced,
       resolve_type: type_def.resolve_type
     }
   end

--- a/lib/absinthe/phase/schema/mark_used.ex
+++ b/lib/absinthe/phase/schema/mark_used.ex
@@ -31,7 +31,7 @@ defmodule Absinthe.Phase.Schema.MarkUsed do
 
     for type <- type_defs do
       if type.identifier in referenced_type_ids do
-        put_in(type.__private__[:__absinthe_used__], true)
+        put_in(type.referenced, true)
       else
         type
       end

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -528,6 +528,16 @@ defmodule Absinthe.Schema do
   end
 
   @doc """
+  Get all types that are referenced in a schema
+  """
+  @spec used_types(t) :: [Type.t()]
+  def used_types(schema) do
+    schema
+    |> types()
+    |> Enum.filter(&(!Type.introspection?(&1) && &1.referenced))
+  end
+
+  @doc """
   List all directives on a schema
   """
   @spec directives(t) :: [Type.Directive.t()]
@@ -597,12 +607,12 @@ defmodule Absinthe.Schema do
   end
 
   @doc """
-  Get all types that are referenced in a schema
+  Get all types that are introspectable
   """
-  @spec used_types(t) :: [Type.t()]
-  def used_types(schema) do
+  @spec introspection_types(t) :: [Type.t()]
+  def introspectable_types(schema) do
     schema
     |> types()
-    |> Enum.filter(&(!Type.introspection?(&1) && &1.referenced))
+    |> Enum.filter(& &1.referenced)
   end
 end

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -49,8 +49,11 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
     all_type_definitions =
       type_definitions
       |> Enum.reject(&(&1.__struct__ == Blueprint.Schema.SchemaDeclaration))
+      |> Enum.filter(& &1.referenced)
 
-    types_to_render = Enum.reject(all_type_definitions, &(&1.module in @skip_modules))
+    types_to_render =
+      all_type_definitions
+      |> Enum.reject(&(&1.module in @skip_modules))
 
     ([schema_declaration] ++ directive_definitions ++ types_to_render)
     |> Enum.map(&render(&1, all_type_definitions))

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :types, list_of(:__type) do
       resolve fn _, %{schema: schema} ->
-        {:ok, Absinthe.Schema.used_types(schema) ++ Absinthe.Schema.introspection_types(schema)}
+        {:ok, Absinthe.Schema.introspectable_types(schema)}
       end
     end
 

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -28,6 +28,7 @@ defmodule Absinthe.Type.Directive do
           locations: [location],
           expand: (map, Absinthe.Blueprint.node_t() -> atom),
           definition: module,
+          referenced: boolean,
           __private__: Keyword.t(),
           __reference__: Type.Reference.t()
         }
@@ -42,6 +43,7 @@ defmodule Absinthe.Type.Directive do
             locations: [],
             expand: nil,
             definition: nil,
+            referenced: false,
             __private__: [],
             __reference__: nil
 

--- a/lib/absinthe/type/enum.ex
+++ b/lib/absinthe/type/enum.ex
@@ -72,6 +72,7 @@ defmodule Absinthe.Type.Enum do
           description: binary,
           values: %{binary => Type.Enum.Value.t()},
           identifier: atom,
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -83,6 +84,7 @@ defmodule Absinthe.Type.Enum do
             values: %{},
             values_by_internal_value: %{},
             values_by_name: %{},
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -51,6 +51,7 @@ defmodule Absinthe.Type.InputObject do
           description: binary,
           fields: map,
           identifier: atom,
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -60,6 +61,7 @@ defmodule Absinthe.Type.InputObject do
             description: nil,
             fields: %{},
             identifier: nil,
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -63,6 +63,7 @@ defmodule Absinthe.Type.Interface do
           description: binary,
           fields: map,
           identifier: atom,
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -73,6 +74,7 @@ defmodule Absinthe.Type.Interface do
             fields: nil,
             identifier: nil,
             resolve_type: nil,
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -89,6 +89,7 @@ defmodule Absinthe.Type.Object do
           description: binary,
           fields: map,
           interfaces: [Absinthe.Type.Interface.t()],
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -99,6 +100,7 @@ defmodule Absinthe.Type.Object do
             description: nil,
             fields: nil,
             interfaces: [],
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil,

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -66,6 +66,7 @@ defmodule Absinthe.Type.Scalar do
           name: binary,
           description: binary,
           identifier: atom,
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -74,6 +75,7 @@ defmodule Absinthe.Type.Scalar do
   defstruct name: nil,
             description: nil,
             identifier: nil,
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil,

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -44,6 +44,7 @@ defmodule Absinthe.Type.Union do
           types: [Type.identifier_t()],
           identifier: atom,
           fields: map,
+          referenced: boolean,
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -55,6 +56,7 @@ defmodule Absinthe.Type.Union do
             resolve_type: nil,
             types: [],
             fields: nil,
+            referenced: false,
             __private__: [],
             definition: nil,
             __reference__: nil

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -50,6 +50,8 @@ defmodule SdlRenderTest do
       defaultInputArg(input: ComplexInput = {foo: "bar"}): String
       defaultListArg(things: [String] = ["ThisThing"]): [String]
       defaultEnumArg(category: Category = NEWS): Category
+      pets: [Pet]
+      animals: [Animal]
     }
 
     type Dog implements Pet & Animal {
@@ -104,8 +106,7 @@ defmodule SdlRenderTest do
   end
 
   test "Render SDL from blueprint defined with SDL" do
-    assert Absinthe.Schema.to_sdl(SdlTestSchema, include_disconnected: true) ==
-             SdlTestSchema.sdl()
+    assert Absinthe.Schema.to_sdl(SdlTestSchema) == SdlTestSchema.sdl()
   end
 
   describe "Render SDL" do


### PR DESCRIPTION
* Remove the option, always stick to rendering just referenced types
* Add `referenced` flag to structs instead of using `__private__`
* Add `introspectable_types` and use it in introspection (avoid going over schema twice!)

@benwilson512 PR into your PR :) #848 