### PR TITLE
Serialize Int result into Float

### DIFF
--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -39,6 +39,7 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   end
 
   def serialize_float(n) when is_float(n), do: n
+  def serialize_float(n) when is_integer(n), do: n * 1.0
 
   def serialize_float(n) do
     raise Absinthe.SerializationError, """

--- a/test/absinthe/integration/execution/serialization_test.exs
+++ b/test/absinthe/integration/execution/serialization_test.exs
@@ -10,7 +10,7 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
       end
 
       field :bad_float, :float do
-        resolve fn _, _, _ -> {:ok, 1} end
+        resolve fn _, _, _ -> {:ok, "1"} end
       end
 
       field :bad_boolean, :boolean do


### PR DESCRIPTION
The strict validation on results goes a bit further than what I can tell from this spec language:

> GraphQL servers may coerce non‐floating‐point internal values to Float when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning 1.0 for the integer number 1, or 123.0 for the string "123".

https://spec.graphql.org/draft/#sec-Float

@benwilson512 