### PR TITLE
Optimize schema introspection type list

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -534,9 +534,8 @@ defmodule Absinthe.Schema do
   """
   @spec used_types(t) :: [Type.t()]
   def used_types(schema) do
-    schema.__absinthe_types__
-    |> Map.keys()
-    |> Enum.map(&Schema.lookup_type(schema, &1))
+    schema
+    |> Schema.types()
     |> Enum.filter(&(!Type.introspection?(&1)))
   end
 

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -574,17 +574,6 @@ defmodule Absinthe.Schema do
     # successfully compile the schema.
     {:ok, bp, _} = Absinthe.Pipeline.run(schema.__absinthe_blueprint__, pipeline)
 
-    bp =
-      Map.update!(bp, :schema_definitions, fn schema_defs ->
-        for schema_def <- schema_defs do
-          Map.update!(schema_def, :type_definitions, fn type_defs ->
-            Enum.filter(type_defs, fn type_def ->
-              type_def.__private__[:__absinthe_referenced__]
-            end)
-          end)
-        end
-      end)
-
     inspect(bp, pretty: true)
   end
 

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -532,8 +532,17 @@ defmodule Absinthe.Schema do
   @doc """
   Get all types that are used by an operation
   """
+  @deprecated "Use Absinthe.Schema.referenced_types/1 instead"
   @spec used_types(t) :: [Type.t()]
   def used_types(schema) do
+    referenced_types(schema)
+  end
+
+  @doc """
+  Get all types that are referenced by an operation
+  """
+  @spec referenced_types(t) :: [Type.t()]
+  def referenced_types(schema) do
     schema
     |> Schema.types()
     |> Enum.filter(&(!Type.introspection?(&1)))

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -50,7 +50,10 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       type_definitions
       |> Enum.reject(&(&1.__struct__ == Blueprint.Schema.SchemaDeclaration))
 
-    types_to_render = Enum.reject(all_type_definitions, &(&1.module in @skip_modules))
+    types_to_render =
+      all_type_definitions
+      |> Enum.reject(&(&1.module in @skip_modules))
+      |> Enum.filter(& &1.__private__[:__absinthe_referenced__])
 
     ([schema_declaration] ++ directive_definitions ++ types_to_render)
     |> Enum.map(&render(&1, all_type_definitions))

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :types, list_of(:__type) do
       resolve fn _, %{schema: schema} ->
-        {:ok, Absinthe.Schema.used_types(schema) ++ Absinthe.Schema.introspection_types(schema)}
+        {:ok, Absinthe.Schema.types(schema)}
       end
     end
 

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -435,9 +435,9 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     end
   end
 
-  describe "Absinthe.Schema.used_types/1" do
+  describe "Absinthe.Schema.referenced_types/1" do
     test "works" do
-      assert Absinthe.Schema.used_types(Definition)
+      assert Absinthe.Schema.referenced_types(Definition)
     end
   end
 

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -198,10 +198,10 @@ defmodule Absinthe.SchemaTest do
     end
   end
 
-  describe "used_types" do
+  describe "referenced_types" do
     test "does not contain introspection types" do
       assert !Enum.any?(
-               Schema.used_types(ThirdSchema),
+               Schema.referenced_types(ThirdSchema),
                &Type.introspection?/1
              )
     end
@@ -209,7 +209,7 @@ defmodule Absinthe.SchemaTest do
     test "contains enums" do
       types =
         ThirdSchema
-        |> Absinthe.Schema.used_types()
+        |> Absinthe.Schema.referenced_types()
         |> Enum.map(& &1.identifier)
 
       assert :some_enum in types
@@ -219,7 +219,7 @@ defmodule Absinthe.SchemaTest do
     test "contains interfaces" do
       types =
         ThirdSchema
-        |> Absinthe.Schema.used_types()
+        |> Absinthe.Schema.referenced_types()
         |> Enum.map(& &1.identifier)
 
       assert :named in types
@@ -228,7 +228,7 @@ defmodule Absinthe.SchemaTest do
     test "contains types only connected via interfaces" do
       types =
         ThirdSchema
-        |> Absinthe.Schema.used_types()
+        |> Absinthe.Schema.referenced_types()
         |> Enum.map(& &1.identifier)
 
       assert :person in types
@@ -237,7 +237,7 @@ defmodule Absinthe.SchemaTest do
     test "contains types only connected via union" do
       types =
         ThirdSchema
-        |> Absinthe.Schema.used_types()
+        |> Absinthe.Schema.referenced_types()
         |> Enum.map(& &1.identifier)
 
       assert :dog in types


### PR DESCRIPTION
Now that we know "referenced" types upfront (https://github.com/absinthe-graphql/absinthe/pull/848), we can avoid traversing the complete list 2 times in the Introspection query for `__schema.types`. This should help for schemas with lots of types!

Also a little tweak to avoid mutating the blueprint before we render it's SDL
