### PR TITLE
Keyword extend not yet supported

### DIFF
--- a/lib/absinthe/language/type_extension_definition.ex
+++ b/lib/absinthe/language/type_extension_definition.ex
@@ -1,7 +1,7 @@
 defmodule Absinthe.Language.TypeExtensionDefinition do
   @moduledoc false
 
-  alias Absinthe.Language
+  alias Absinthe.{Language, Blueprint}
 
   defstruct definition: nil,
             loc: %{line: nil}
@@ -10,4 +10,16 @@ defmodule Absinthe.Language.TypeExtensionDefinition do
           definition: Language.ObjectTypeDefinition.t(),
           loc: Language.loc_t()
         }
+
+  defimpl Blueprint.Draft do
+    def convert(node, _doc) do
+      raise Absinthe.Schema.Notation.Error,
+            """
+            \n
+            SDL Compilation failed:
+            -----------------------
+            Keyword `extend` is not yet supported (#{inspect(node.loc)})
+            """
+    end
+  end
 end

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -484,6 +484,30 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     end
   end
 
+  test "Keyword extend not yet supported" do
+    schema = """
+    defmodule KeywordExtend do
+      use Absinthe.Schema
+
+      import_sdl "
+      type Movie {
+        title: String!
+      }
+
+      extend type Movie {
+        year: Int
+      }
+      "
+    end
+    """
+
+    error = ~r/Keyword `extend` is not yet supported/
+
+    assert_raise(Absinthe.Schema.Notation.Error, error, fn ->
+      Code.eval_string(schema)
+    end)
+  end
+
   def handle_event(event, measurements, metadata, config) do
     send(self(), {event, measurements, metadata, config})
   end


### PR DESCRIPTION
Keyword `extend` can be parsed, but we don't yet support it's functionality.

This PR raises an explicit error if it's used instead of a unexpected failure.

Support is intended to come in the future

closes #844