### PR TITLE
Hydrate enum values dynamically

### DIFF
--- a/lib/absinthe/phase/schema/hydrate.ex
+++ b/lib/absinthe/phase/schema/hydrate.ex
@@ -66,11 +66,18 @@ defmodule Absinthe.Phase.Schema.Hydrate do
 
   @impl Absinthe.Schema.Hydrator
 
-  def apply_hydration(node, {:meta, keyword_list}) when is_list(keyword_list) do
+  def apply_hydration(
+        node,
+        {:meta, keyword_list}
+      )
+      when is_list(keyword_list) do
     %{node | __private__: Keyword.put(node.__private__, :meta, keyword_list)}
   end
 
-  def apply_hydration(node, {:description, text}) do
+  def apply_hydration(
+        node,
+        {:description, text}
+      ) do
     %{node | description: text}
   end
 
@@ -126,6 +133,13 @@ defmodule Absinthe.Phase.Schema.Hydrate do
       )
       when is_function(is_type_of) do
     %{node | is_type_of: is_type_of}
+  end
+
+  def apply_hydration(
+        %Blueprint.Schema.EnumValueDefinition{} = node,
+        {:as, value}
+      ) do
+    %{node | value: value}
   end
 
   @hydration_level1 [

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1366,10 +1366,21 @@ defmodule Absinthe.Schema.Notation do
   end
 
   def handle_enum_value_attrs(identifier, raw_attrs) do
+    value =
+      case Keyword.get(raw_attrs, :as, identifier) do
+        value when is_tuple(value) ->
+          raise Absinthe.Schema.Notation.Error,
+                "Invalid Enum value for #{inspect(identifier)}. " <>
+                  "Must be a literal term, dynamic values must use `hydrate`"
+
+        value ->
+          value
+      end
+
     raw_attrs
     |> expand_ast(raw_attrs)
     |> Keyword.put(:identifier, identifier)
-    |> Keyword.put(:value, Keyword.get(raw_attrs, :as, identifier))
+    |> Keyword.put(:value, value)
     |> Keyword.put_new(:name, String.upcase(to_string(identifier)))
     |> Keyword.delete(:as)
     |> handle_deprecate

--- a/test/absinthe/schema/hydrate_dynamic_values.exs
+++ b/test/absinthe/schema/hydrate_dynamic_values.exs
@@ -1,0 +1,56 @@
+defmodule HydrateDynamicValuesTest do
+  use ExUnit.Case, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    enum :color do
+      value :red
+      value :blue
+      value :green
+    end
+
+    query do
+      field :all, list_of(:color) do
+        resolve fn _, _, _ -> {:ok, [1, 2, 3]} end
+      end
+    end
+
+    def hydrate(%Absinthe.Blueprint.Schema.EnumValueDefinition{identifier: identifier}, [])
+        when identifier in [:red, :blue, :green] do
+      {:as, color_map(identifier)}
+    end
+
+    def hydrate(_, _) do
+      []
+    end
+
+    defp color_map(:red), do: 1
+    defp color_map(:blue), do: 2
+    defp color_map(:green), do: 3
+  end
+
+  test "can hydrate enum values dynamically" do
+    assert {:ok, %{data: %{"all" => ["RED", "BLUE", "GREEN"]}}} == Absinthe.run("{ all }", Schema)
+  end
+
+  test "can't call functions to configure enum values dynamically" do
+    schema = """
+    defmodule KeywordExtend do
+      use Absinthe.Schema
+
+      enum :color do
+        value :red
+        value :blue, as: color_map(:blue)
+        value :green
+      end
+    end
+    """
+
+    error = ~r/Invalid Enum value/
+
+    assert_raise(Absinthe.Schema.Notation.Error, error, fn ->
+      Code.eval_string(schema)
+    end)
+  end
+end


### PR DESCRIPTION
* raise when calling a function in enum value `:as`
* enable hydrating an enum value to configure it directly

@benwilson512 open to feedback on the approach for this one...

closes #843