### PR TITLE
Updating Subscription Docs

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -27,6 +27,18 @@ config :my_app, MyAppWeb.Endpoint,
 In your application supervisor add a line _after_ your existing endpoint supervision
 line:
 
+Elxir >= 1.5.0:
+```elixir
+[
+  # other children ...
+  MyAppWeb.Endpoint, # this line should already exist
+  {Absinthe.Subscription, MyAppWeb.Endpoint}, # add this line
+  # other children ...
+]
+
+```
+
+Elixir < 1.4.x:
 ```elixir
 [
   # other children ...
@@ -45,7 +57,7 @@ In Phoenix v1.4, the supervisor children are mounted like so:
       MyAppWeb.Repo,
       # Start the endpoint when the application starts
       MyAppWeb.Endpoint,
-      {Absinthe.Subscription, [MyAppWeb.Endpoint]}
+      {Absinthe.Subscription, MyAppWeb.Endpoint}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
As I was implementing `Absinthe.Subscription` I kept running into a runtime error (using version `1.5.0-rc.2`:
```
[info] Application rapid_clustering_protocol exited: MyAppWeb.Application.start(:normal, []) returned an error: shutdown: failed to start child: Absinthe.Subscription
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2
            (elixir) src/elixir_aliases.erl:130: :elixir_aliases.do_concat([[MyAppWeb.Endpoint], :Registry], "Elixir")
            (elixir) src/elixir_aliases.erl:118: :elixir_aliases.concat/1
            (absinthe) lib/absinthe/subscription/supervisor.ex:11: Absinthe.Subscription.Supervisor.init/1
            (stdlib) supervisor.erl:295: :supervisor.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
** (Mix) Could not start application rapid_clustering_protocol: MyAppWeb.Application.start(:normal, []) returned an error: shutdown: failed to start child: Absinthe.Subscription
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2
            (elixir) src/elixir_aliases.erl:130: :elixir_aliases.do_concat([[ç.Endpoint], :Registry], "Elixir")
            (elixir) src/elixir_aliases.erl:118: :elixir_aliases.concat/1
            (absinthe) lib/absinthe/subscription/supervisor.ex:11: Absinthe.Subscription.Supervisor.init/1
            (stdlib) supervisor.erl:295: :supervisor.init/1
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

After looking at the API for the `Subscription.Supervisor`, I think we can pass in our Endpoint Module not in a list and have it work as intended.

The functionality is working as intended, the docs just need to reflect the argument not being passed in as a list.

Thank you for maintaining this awesome project!!

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
