### PR TITLE
Update Endpoint config for Subscriptions in 1.5

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -31,7 +31,7 @@ line:
 [
   # other children ...
   supervisor(MyAppWeb.Endpoint, []), # this line should already exist
-  supervisor(Absinthe.Subscription, [MyAppWeb.Endpoint]), # add this line
+  supervisor(Absinthe.Subscription, MyAppWeb.Endpoint), # add this line
   # other children ...
 ]
 ```
@@ -45,7 +45,7 @@ In Phoenix v1.4, the supervisor children are mounted like so:
       MyAppWeb.Repo,
       # Start the endpoint when the application starts
       MyAppWeb.Endpoint,
-      {Absinthe.Subscription, [MyAppWeb.Endpoint]}
+      {Absinthe.Subscription, MyAppWeb.Endpoint}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
With current config which was for (1.4) the following occurs in `1.5.0-rc.2`:

```elixir
 ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2
            (elixir) src/elixir_aliases.erl:130: :elixir_aliases.do_concat([[MyApp.Endpoint], :Registry], "Elixir")
            (elixir) src/elixir_aliases.erl:118: :elixir_aliases.concat/1
            (absinthe) lib/absinthe/subscription/supervisor.ex:11: Absinthe.Subscription.Supervisor.init/1
```

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
