### PR TITLE
Add missing type to the dataloader options

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -129,7 +129,10 @@ defmodule Absinthe.Resolution.Helpers do
              Absinthe.Resolution.arguments(),
              Absinthe.Resolution.t() ->
                {any, map})
-    @type dataloader_opt :: {:args, map} | {:use_parent, true | false}
+    @type dataloader_opt ::
+            {:args, map}
+            | {:use_parent, true | false}
+            | {:callback, (map(), map(), map() -> any())}
 
     @doc """
     Resolve a field with a dataloader source.


### PR DESCRIPTION
The `:callback` key in the options list is used here: https://github.com/absinthe-graphql/absinthe/blob/396e6c99b9fc2e26c683be840d1e5deea35adcea/lib/absinthe/resolution/helpers.ex#L292 and is described in the documentation, too.

This key is missing from the type specification, so using it causes dialyzer warnings.
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
