### PR TITLE
Support "batching" type imports relative to __MODULE__

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1542,6 +1542,20 @@ defmodule Absinthe.Schema.Notation do
     end
   end
 
+  defp do_import_types(
+         {{:., _, [{:__aliases__, _, [{:__MODULE__, _, _} | tail]}, :{}]}, _, modules_ast_list},
+         env,
+         opts
+       ) do
+    root_module = Module.concat([env.module | tail])
+
+    for {_, _, leaf} <- modules_ast_list do
+      type_module = Module.concat([root_module | leaf])
+
+      do_import_types(type_module, env, opts)
+    end
+  end
+
   defp do_import_types({{:., _, [{:__aliases__, _, root}, :{}]}, _, modules_ast_list}, env, opts) do
     root_module = Module.concat(root)
     root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)

--- a/test/absinthe/type/import_types_test.exs
+++ b/test/absinthe/type/import_types_test.exs
@@ -29,9 +29,14 @@ defmodule Absinthe.Type.ImportTypesTest do
     end
 
     test "works with __MODULE__ and {}" do
+      assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :flag)
+      assert Absinthe.Schema.lookup_type(ImportTypes.Schema, :value_type_enum)
+
       assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :decline_reasons)
       assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :credit_card)
       assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :credit_card_type)
+      assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :category)
+      assert Absinthe.Schema.lookup_type(ImportTypes.SelfContainedSchema, :role_enum)
     end
   end
 end

--- a/test/support/fixtures/dynamic/import_types.ex
+++ b/test/support/fixtures/dynamic/import_types.ex
@@ -77,6 +77,22 @@ defmodule Absinthe.Fixtures.ImportTypes do
     end
   end
 
+  defmodule Schema.Types.Flag do
+    use Absinthe.Schema.Notation
+
+    object :flag do
+      field :name, non_null(:string)
+      field :key, non_null(:string)
+      field :enabled, non_null(:boolean)
+    end
+  end
+
+  defmodule Schema.Types.Enum.ValueType do
+    use Absinthe.Schema.Notation
+
+    enum :value_type_enum, values: [:number, :boolean, :string]
+  end
+
   defmodule Schema do
     use Absinthe.Schema
 
@@ -86,6 +102,8 @@ defmodule Absinthe.Fixtures.ImportTypes do
     alias Absinthe.Fixtures.ImportTypes
     import_types ImportTypes.ScheduleTypes
     import_types ImportTypes.{ProfileTypes, AuthTypes, Shared.AvatarTypes}
+
+    import_types __MODULE__.Types.{Flag, Enum.ValueType}
 
     query do
       field :orders, list_of(:order)
@@ -121,8 +139,25 @@ defmodule Absinthe.Fixtures.ImportTypes do
       enum :decline_reasons, values: [:insufficient_funds, :invalid_card]
     end
 
+    defmodule Types.Category do
+      use Absinthe.Schema.Notation
+
+      object :category do
+        field :name, non_null(:string)
+        field :slug, non_null(:string)
+        field :description, :string
+      end
+    end
+
+    defmodule Types.Enums.Role do
+      use Absinthe.Schema.Notation
+
+      enum :role_enum, values: [:admin, :client]
+    end
+
     import_types __MODULE__.Errors.DeclineReasons
     import_types __MODULE__.{PaymentTypes, CardTypes}
+    import_types __MODULE__.Types.{Category, Enums.Role}
 
     query do
       field :credit_cards, list_of(:credit_card)


### PR DESCRIPTION
This PR should fix #864 by adding a clause for `do_import_types/3` that handles imports like this:

``` elixir
import_types __MODULE__.Types.{Category, OtherType}
```

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
