### PR TITLE
Handle empty types in SDL renderer

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -243,10 +243,12 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
         false -> [seperator]
       end
 
+    start = empty()
+
     items
     |> Enum.reverse()
-    |> Enum.reduce(:start, fn
-      item, :start -> render(item, type_definitions)
+    |> Enum.reduce(start, fn
+      item, ^start -> render(item, type_definitions)
       item, acc -> concat([render(item, type_definitions)] ++ splitter ++ [acc])
     end)
   end

--- a/test/mix/tasks/absinthe.schema.sdl_test.exs
+++ b/test/mix/tasks/absinthe.schema.sdl_test.exs
@@ -20,6 +20,23 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
 
   @test_schema "Mix.Tasks.Absinthe.Schema.SdlTest.TestSchema"
 
+  defmodule TestSchemaWithEmpty do
+    use Absinthe.Schema
+
+    @behaviour Absinthe.Schema
+
+    query do
+      field :hello_world, :empty do
+        arg :name, non_null(:string)
+      end
+    end
+
+    object :empty do
+    end
+  end
+
+  @test_empty_schema "Mix.Tasks.Absinthe.Schema.SdlTest.TestSchemaWithEmpty"
+
   describe "absinthe.schema.sdl" do
     test "parses options" do
       argv = ["output.graphql", "--schema", @test_schema]
@@ -50,6 +67,15 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
 
       {:ok, schema} = Task.generate_schema(opts)
       assert schema =~ "helloWorld(name: String!): String"
+    end
+
+    test "Generate schema with empty object" do
+      argv = ["--schema", @test_empty_schema]
+      opts = Task.parse_options(argv)
+
+      {:ok, schema} = Task.generate_schema(opts)
+      assert schema =~ "helloWorld(name: String!): Empty"
+      assert schema =~ "type Empty {"
     end
   end
 end


### PR DESCRIPTION
The (excellent) new SDL renderer runs into trouble when there's an empty type in the GraphQL schema. As far as I can tell from reading the SDL docs, it's not actually legal to have an empty type (which it is in GraphQL, I think) so it's understandable that it wouldn't be happy. The failure mode, however, is extremely opaque (dumping a function clause error into the output file with the whole blueprint attached).

This change allows the SDL renderer to produce empty objects, even though they're probably technically not valid SDL (since, valid or not, it's an extremely useful tool for producing pretty-printed schemas for us). I'm happy to gate this functionality behind a flag (say `--allow-empty-types`) or something so that the default behaviour still only produces valid output if you think that's a good idea. I left it out for now because I didn't want to over-complicate things unnecessarily.

Perhaps @binaryseed would like to weigh in as well, since he wrote the functionality in the first place (thanks!).