### PR TITLE
Clarify hydrate enum test

### DIFF
--- a/test/absinthe/schema/hydrate_dynamic_values.exs
+++ b/test/absinthe/schema/hydrate_dynamic_values.exs
@@ -16,8 +16,10 @@ defmodule HydrateDynamicValuesTest do
       end
     end
 
-    def hydrate(%Absinthe.Blueprint.Schema.EnumValueDefinition{identifier: identifier}, [])
-        when identifier in [:red, :blue, :green] do
+    def hydrate(
+          %Absinthe.Blueprint.Schema.EnumValueDefinition{identifier: identifier},
+          [%Absinthe.Blueprint.Schema.EnumTypeDefinition{identifier: :color}]
+        ) do
       {:as, color_map(identifier)}
     end
 


### PR DESCRIPTION
This provides a better example of hydrating an enum value by matching on the ancestors more directly to target just one enum

thanks @bgentry for pointing this out in https://github.com/absinthe-graphql/absinthe/pull/859/files#r382307071