### PR TITLE
Update Ecto guides

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -290,4 +290,4 @@ up with dozens and dozens of single purpose data loading functions.
 ## Formatting Ecto.Changeset Errors
 
 You may want to look at the [errors](errors.html) guide and
-the [kronky](https://hex.pm/packages/kronky) package.
+the [Absinthe ErrorPayload](https://hex.pm/packages/absinthe_error_payload) package.


### PR DESCRIPTION
A little doc fix. Kronky is no longer maintained, Absinthe ErrorPayload is its successor.

Cheers!