### PR TITLE
Input type validation bug

### DIFF
--- a/lib/absinthe/phase/document/validation/variables_are_input_types.ex
+++ b/lib/absinthe/phase/document/validation/variables_are_input_types.ex
@@ -20,19 +20,22 @@ defmodule Absinthe.Phase.Document.Validation.VariablesAreInputTypes do
 
   # Find variable definitions
   @spec handle_node(Blueprint.node_t(), Schema.t()) :: Blueprint.node_t()
-  defp handle_node(%Blueprint.Document.VariableDefinition{schema_node: nil} = node, _) do
-    node
-  end
-
   defp handle_node(%Blueprint.Document.VariableDefinition{} = node, schema) do
-    type = Schema.lookup_type(schema, node.schema_node)
+    schema
+    |> Schema.lookup_type(node.schema_node)
+    |> Type.unwrap()
+    |> case do
+      nil ->
+        node
 
-    if Type.input_type?(Type.unwrap(type)) do
-      node
-    else
-      node
-      |> flag_invalid(:non_input_type)
-      |> put_error(error(node, Type.name(node.schema_node)))
+      type ->
+        if Type.input_type?(type) do
+          node
+        else
+          node
+          |> flag_invalid(:non_input_type)
+          |> put_error(error(node, Type.name(node.schema_node)))
+        end
     end
   end
 

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -275,7 +275,7 @@ defmodule Absinthe.Type do
   def wrapped?(_), do: false
 
   @doc "Unwrap a type from a List or NonNull"
-  @spec unwrap(custom_t | wrapping_t | map) :: custom_t | map
+  @spec unwrap(custom_t | wrapping_t | map) :: custom_t | map | nil
   def unwrap(%{of_type: t}), do: unwrap(t)
   def unwrap(type), do: type
 

--- a/test/absinthe/phase/document/validation/variables_are_input_types_test.exs
+++ b/test/absinthe/phase/document/validation/variables_are_input_types_test.exs
@@ -43,5 +43,16 @@ defmodule Absinthe.Phase.Document.Validation.VariablesAreInputTypesTest do
         ]
       )
     end
+
+    test "unknown types don't blow up this validation" do
+      assert_passes_validation(
+        """
+        query Foo($a: Number!) {
+          field(a: $a)
+        }
+        """,
+        []
+      )
+    end
   end
 end


### PR DESCRIPTION
Fix a bug in `Validation.VariablesAreInputTypes` that happens when an unknown type is provided as a variable type. 

If a variable is defined "wrapped" - like a non-null, then we pass `%Absinthe.Type.NonNull{of_type: nil}` to `Type.name` and it eventually gets down to the `nil` and blows up.