### PR TITLE
Do not allow nested non_null

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1081,6 +1081,12 @@ defmodule Absinthe.Schema.Notation do
 
   See `field/3` for examples
   """
+
+  defmacro non_null({:non_null, _, _}) do
+    raise Absinthe.Schema.Notation.Error,
+          "Invalid schema notation: `non_null` must not be nested"
+  end
+
   defmacro non_null(type) do
     %Absinthe.Blueprint.TypeReference.NonNull{of_type: expand_ast(type, __CALLER__)}
   end

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -534,6 +534,18 @@ defmodule Absinthe.Schema.NotationTest do
     end
   end
 
+  test "No nested non_null" do
+    assert_notation_error(
+      "NestedNonNull",
+      """
+      object :really_null do
+        field :foo, non_null(non_null(:string))
+      end
+      """,
+      "Invalid schema notation: `non_null` must not be nested"
+    )
+  end
+
   @doc """
   Assert a notation error occurs.
 


### PR DESCRIPTION
Do not allow nested `non_null`, as that doesn't make sense, and is not allowed in the spec:

http://spec.graphql.org/draft/#sec-Type-System.Non-Null.Type-Validation

Fixes #877 