### PR TITLE
[1.4] Allowing valid ISO8601 DateTimes to be converted to UTC.

### DIFF
--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -19,7 +19,7 @@ defmodule Absinthe.Type.Custom do
     The `DateTime` scalar type represents a date and time in the UTC
     timezone. The DateTime appears in a JSON response as an ISO8601 formatted
     string, including UTC timezone ("Z"). The parsed date and time string will
-    be converted to UTC and any UTC offset other than 0 will be rejected.
+    be converted to UTC if there is an offset.
     """
 
     serialize &DateTime.to_iso8601/1
@@ -74,8 +74,7 @@ defmodule Absinthe.Type.Custom do
   @spec parse_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
   defp parse_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
     case DateTime.from_iso8601(value) do
-      {:ok, datetime, 0} -> {:ok, datetime}
-      {:ok, _datetime, _offset} -> :error
+      {:ok, datetime, _} -> {:ok, datetime}
       _error -> :error
     end
   end

--- a/test/absinthe/type/custom_test.exs
+++ b/test/absinthe/type/custom_test.exs
@@ -56,9 +56,12 @@ defmodule Absinthe.Type.CustomTest do
                parse(:datetime, %Input.String{value: "2017-01-27T20:31:55+00:00"})
     end
 
-    test "cannot be parsed when a non-zero UTC offset is included" do
-      assert :error == parse(:datetime, %Input.String{value: "2017-01-27T20:31:55-02:30"})
-      assert :error == parse(:datetime, %Input.String{value: "2017-01-27T20:31:55+04:00"})
+    test "can be parsed when a non-zero UTC offset is included" do
+      assert {:ok, @datetime} ==
+               parse(:datetime, %Input.String{value: "2017-01-27T18:01:55-02:30"})
+
+      assert {:ok, @datetime} ==
+               parse(:datetime, %Input.String{value: "2017-01-28T00:31:55+04:00"})
     end
 
     test "cannot be parsed without UTC timezone marker" do


### PR DESCRIPTION
 Fixing: https://github.com/absinthe-graphql/absinthe/issues/700
 Backport from: https://github.com/absinthe-graphql/absinthe/pull/879

Not sure how far master is from release where you'd prefer it. 
Feel free to close this if no releases are pending for `1.4`. 