### PR TITLE
Correct spec for Pipeline.replace

### DIFF
--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -227,7 +227,7 @@ defmodule Absinthe.Pipeline do
       [A, {X, [name: "Nope"]}, C]
 
   """
-  @spec replace(t, Phase.t(), t | {Phase.t(), list}) :: t
+  @spec replace(t, Phase.t(), phase_config_t) :: t
   def replace(pipeline, phase, replacement) do
     Enum.map(pipeline, fn candidate ->
       case match_phase?(phase, candidate) do

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -25,7 +25,7 @@ defmodule Absinthe.Pipeline.BatchResolver do
         result: nil
     }
 
-    resolution_phase = [{Execution.Resolution, [plugin_callbacks: false] ++ options}]
+    resolution_phase = {Execution.Resolution, [plugin_callbacks: false] ++ options}
     phases = initial_phases ++ [resolution_phase]
 
     do_resolve(blueprints, phases, exec, plugins, resolution_phase, options)


### PR DESCRIPTION
I _think_ this is the correct spec - the third argument is a phase, not a pipeline (the `t` is `Pipeline.t` here)