### PR TITLE
return dataloader/3 use_parent to default false

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -234,10 +234,11 @@ defmodule Absinthe.Resolution.Helpers do
     the first argument, and the parent and args as second and third. Can be used
     to e.g. compute fields on the return value of the loader. Should return an
     ok or error tuple.
-    - `:use_parent` default: `true`. This option affects whether or not the `dataloader/2`
+    - `:use_parent` default: `false`. This option affects whether or not the `dataloader/2`
     helper will use any pre-existing value on the parent. IE if you return
     `%{author: %User{...}}` from a blog post the helper will by default simply use
-    the pre-existing author. Set it to false if you always want it to load it fresh.
+    the pre-existing author. Set it to true if you want to opt into using the
+    pre-existing value instead of loading it fresh.
 
     Ultimately, this helper calls `Dataloader.load/4`
     using the loader in your context, the source you provide, the tuple `{resource, args}`
@@ -274,7 +275,7 @@ defmodule Absinthe.Resolution.Helpers do
     end
 
     defp use_parent(loader, source, resource, parent, args, opts) when is_map(parent) do
-      with true <- Keyword.get(opts, :use_parent, true),
+      with true <- Keyword.get(opts, :use_parent, false),
            {:ok, val} <- parent |> Map.fetch(resource) |> check_assoc_loaded() do
         Dataloader.put(loader, source, {resource, args}, parent, val)
       else

--- a/test/absinthe/middleware/dataloader_test.exs
+++ b/test/absinthe/middleware/dataloader_test.exs
@@ -70,13 +70,12 @@ defmodule Absinthe.Middleware.DataloaderTest do
                       :test,
                       fn _, _, %{context: %{test_pid: pid}} ->
                         {:organization, %{pid: pid}}
-                      end,
-                      use_parent: false
+                      end
                     )
           end
 
           field :bar_organization, :organization do
-            resolve dataloader(:test, :organization, args: %{pid: self()})
+            resolve dataloader(:test, :organization, args: %{pid: self()}, use_parent: true)
           end
         end
 
@@ -250,7 +249,7 @@ defmodule Absinthe.Middleware.DataloaderTest do
     refute_receive(:loading)
   end
 
-  test "use parent's pre-existing value when use_parent is true (default)" do
+  test "use parent's pre-existing value when use_parent is true" do
     doc = """
     {
       usersWithOrganization {
@@ -275,7 +274,7 @@ defmodule Absinthe.Middleware.DataloaderTest do
     refute_receive(:loading)
   end
 
-  test "ignore parent's pre-existing value when use_parent is false" do
+  test "ignore parent's pre-existing value when use_parent is false (default)" do
     doc = """
     {
       usersWithOrganization {


### PR DESCRIPTION
In #882, some changes were made which not only fixed the behavior of `use_parent` when explicitly specified, but also changed the default value from `false` to `true`. While this was always documented as `true`, that wasn't actually the behavior until that PR. This is a breaking change which can result in some surprising and dangerous issues for users that were relying on the pre-existing behavior.

Rather than break those existing apps, and because defaulting to `false` is safer and less surprising, we return the default to `false` and correct the documentation to reflect how it has always worked. This was the conclusion of @benwilson512 in https://github.com/absinthe-graphql/absinthe/pull/882#issuecomment-605324628.

Side note: I think this was the last remaining issue for me getting our app on v1.5 🤞