### PR TITLE
don't pass introspection fields or objects to the def middleware callback

### DIFF
--- a/lib/absinthe/blueprint/schema/object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/object_type_definition.ex
@@ -49,7 +49,8 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
       fields: build_fields(type_def, schema),
       interfaces: type_def.interfaces,
       definition: type_def.module,
-      is_type_of: type_def.is_type_of
+      is_type_of: type_def.is_type_of,
+      __private__: type_def.__private__
     }
   end
 

--- a/lib/absinthe/middleware.ex
+++ b/lib/absinthe/middleware.ex
@@ -298,10 +298,21 @@ defmodule Absinthe.Middleware do
 
   @doc false
   def expand(schema, middleware, field, object) do
-    middleware
-    |> Enum.flat_map(&get_functions/1)
-    |> Absinthe.Schema.Notation.__ensure_middleware__(field, object)
-    |> schema.middleware(field, object)
+    expanded =
+      middleware
+      |> Enum.flat_map(&get_functions/1)
+      |> Absinthe.Schema.Notation.__ensure_middleware__(field, object)
+
+    case middleware do
+      [{:ref, Absinthe.Phase.Schema.Introspection, _}] ->
+        expanded
+
+      [{:ref, Absinthe.Type.BuiltIns.Introspection, _}] ->
+        expanded
+
+      _ ->
+        schema.middleware(expanded, field, object)
+    end
   end
 
   defp get_functions({:ref, module, identifier}) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Mixfile do
   use Mix.Project
 
-  @version "1.5.0-rc.4"
+  @version "1.5.0-rc.5"
 
   def project do
     [

--- a/test/absinthe/integration/execution/introspection/full_test.exs
+++ b/test/absinthe/integration/execution/introspection/full_test.exs
@@ -97,4 +97,19 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.FullTest do
     {:ok, %{data: %{"__schema" => schema}}} = result
     assert !is_nil(schema)
   end
+
+  defmodule MiddlewareSchema do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    def middleware(_, _, _) do
+      raise "this should not be called when introspecting"
+    end
+  end
+
+  test "middleware callback does not apply to introspection fields" do
+    assert Absinthe.run(@query, MiddlewareSchema, [])
+  end
 end


### PR DESCRIPTION
Fixes #565
Fixes https://github.com/absinthe-graphql/absinthe_plug/issues/159