### PR TITLE
Adapt to telemetry span convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ For changes pre-v1.5 see the [v1.4](https://github.com/absinthe-graphql/absinthe
 ## v1.5.0 (Rc)
 
 - Feature (Experimental): `:persistent_term` based schema backend
+- Breaking Change: `telemetry` event keys [changed]() since the beta release.
 
 ## v1.5.0 (Beta)
 - Feature: SDL directives, other improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ For changes pre-v1.5 see the [v1.4](https://github.com/absinthe-graphql/absinthe
 ## v1.5.0 (Rc)
 
 - Feature (Experimental): `:persistent_term` based schema backend
-- Breaking Change: `telemetry` event keys [changed]() since the beta release.
+- Breaking Change: `telemetry` event keys [changed](https://github.com/absinthe-graphql/absinthe/pull/901) since the beta release.
 
 ## v1.5.0 (Beta)
 - Feature: SDL directives, other improvements

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -10,16 +10,13 @@ defmodule Absinthe.Middleware.Telemetry do
   @impl Absinthe.Middleware
   def call(resolution, _) do
     id = :erlang.unique_integer()
-    start_time = System.system_time()
+    system_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
     :telemetry.execute(
       @field_start,
-      %{start_time: start_time},
-      %{
-        id: id,
-        resolution: resolution
-      }
+      %{system_time: system_time},
+      %{id: id, resolution: resolution}
     )
 
     %{
@@ -30,7 +27,6 @@ defmodule Absinthe.Middleware.Telemetry do
               {{__MODULE__, :on_complete},
                %{
                  id: id,
-                 start_time: start_time,
                  start_time_mono: start_time_mono,
                  middleware: resolution.middleware
                }}
@@ -42,7 +38,6 @@ defmodule Absinthe.Middleware.Telemetry do
         %{state: :resolved} = resolution,
         %{
           id: id,
-          start_time: start_time,
           start_time_mono: start_time_mono,
           middleware: middleware
         }
@@ -54,7 +49,6 @@ defmodule Absinthe.Middleware.Telemetry do
       %{duration: end_time_mono - start_time_mono},
       %{
         id: id,
-        start_time: start_time,
         middleware: middleware,
         resolution: resolution
       }

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -17,63 +17,49 @@ defmodule Absinthe.Phase.Telemetry do
 
   defp do_run(blueprint, [:execute, :operation, :start], options) do
     id = :erlang.unique_integer()
-    start_time = System.system_time()
+    system_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
-    :telemetry.execute(@operation_start, %{start_time: start_time}, %{
-      id: id,
-      blueprint: blueprint,
-      options: options
-    })
+    :telemetry.execute(
+      @operation_start,
+      %{system_time: system_time},
+      %{id: id, blueprint: blueprint, options: options}
+    )
 
     {:ok,
      %{
        blueprint
        | source: blueprint.input,
-         telemetry: %{
-           id: id,
-           start_time: start_time,
-           start_time_mono: start_time_mono
-         }
+         telemetry: %{id: id, start_time_mono: start_time_mono}
      }}
   end
 
   defp do_run(blueprint, [:subscription, :publish, :start], options) do
     id = :erlang.unique_integer()
-    start_time = System.system_time()
+    system_time = System.system_time()
     start_time_mono = System.monotonic_time()
 
-    :telemetry.execute(@subscription_start, %{start_time: start_time}, %{
-      id: id,
-      blueprint: blueprint,
-      options: options
-    })
+    :telemetry.execute(
+      @subscription_start,
+      %{system_time: system_time},
+      %{id: id, blueprint: blueprint, options: options}
+    )
 
     {:ok,
      %{
        blueprint
-       | telemetry: %{
-           id: id,
-           start_time: start_time,
-           start_time_mono: start_time_mono
-         }
+       | telemetry: %{id: id, start_time_mono: start_time_mono}
      }}
   end
 
   defp do_run(blueprint, [:subscription, :publish, :stop], options) do
     end_time_mono = System.monotonic_time()
 
-    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
-           blueprint.telemetry do
+    with %{id: id, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(
         @subscription_stop,
         %{duration: end_time_mono - start_time_mono},
-        %{
-          id: id,
-          start_time: start_time,
-          blueprint: blueprint,
-          options: options
-        }
+        %{id: id, blueprint: blueprint, options: options}
       )
     end
 
@@ -83,17 +69,11 @@ defmodule Absinthe.Phase.Telemetry do
   defp do_run(blueprint, [:execute, :operation, :stop], options) do
     end_time_mono = System.monotonic_time()
 
-    with %{id: id, start_time: start_time, start_time_mono: start_time_mono} <-
-           blueprint.telemetry do
+    with %{id: id, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(
         @operation_stop,
         %{duration: end_time_mono - start_time_mono},
-        %{
-          id: id,
-          start_time: start_time,
-          blueprint: blueprint,
-          options: options
-        }
+        %{id: id, blueprint: blueprint, options: options}
       )
     end
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -587,7 +587,9 @@ defmodule Absinthe.Execution.SubscriptionTest do
                context: %{pubsub: PubSub}
              )
 
-    assert_receive {[:absinthe, :execute, :operation, :start], _, %{id: id} = _meta, _config}
+    assert_receive {[:absinthe, :execute, :operation, :start], measurements, %{id: id}, _config}
+    assert System.convert_time_unit(measurements[:system_time], :native, :millisecond)
+
     assert_receive {[:absinthe, :execute, :operation, :stop], _, %{id: ^id} = _meta, _config}
 
     Absinthe.Subscription.publish(PubSub, "foo", thing: client_id)
@@ -599,8 +601,9 @@ defmodule Absinthe.Execution.SubscriptionTest do
              topic: topic
            } == msg
 
-    assert_receive {[:absinthe, :subscription, :publish, :start], _, %{id: id} = _meta, _config}
-    assert_receive {[:absinthe, :subscription, :publish, :stop], _, %{id: ^id} = _meta, _config}
+    # Subscription events
+    assert_receive {[:absinthe, :subscription, :publish, :start], _, %{id: id}, _config}
+    assert_receive {[:absinthe, :subscription, :publish, :stop], _, %{id: ^id}, _config}
 
     :telemetry.detach(context.test)
   end

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -590,7 +590,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
     assert_receive {[:absinthe, :execute, :operation, :start], measurements, %{id: id}, _config}
     assert System.convert_time_unit(measurements[:system_time], :native, :millisecond)
 
-    assert_receive {[:absinthe, :execute, :operation, :stop], _, %{id: ^id} = _meta, _config}
+    assert_receive {[:absinthe, :execute, :operation, :stop], _, %{id: ^id}, _config}
 
     Absinthe.Subscription.publish(PubSub, "foo", thing: client_id)
     assert_receive({:broadcast, msg})

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -581,15 +581,13 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
                Absinthe.run(@query, Definition)
 
       assert_receive {[:absinthe, :execute, :operation, :start], _, %{id: id}, _config}
-
-      assert_receive {[:absinthe, :execute, :operation, :stop], measurements, %{id: ^id} = meta,
-                      _config}
+      assert_receive {[:absinthe, :execute, :operation, :stop], measurements, %{id: ^id}, _config}
 
       assert_receive {[:absinthe, :resolve, :field, :start], measurements,
-                      %{resolution: %{definition: %{name: "posts"}}} = meta, config}
+                      %{resolution: %{definition: %{name: "posts"}}}, config}
 
       assert_receive {[:absinthe, :resolve, :field, :stop], measurements,
-                      %{resolution: %{definition: %{name: "posts"}}} = meta, config}
+                      %{resolution: %{definition: %{name: "posts"}}}, config}
     end
   end
 end


### PR DESCRIPTION
To align with the emerging convention for "span" events, this PR tweaks one of the measurements we collect, changing `start_time` to `system_time` to match which "kind" of time it is.

* https://github.com/beam-telemetry/telemetry/issues/57

Also, it drops `start_time` from the "stop" events, since it's redundant information and now doesn't match the `system_time` key from the "start" event.

I'd like to sneak this in before 1.5 so it's not a breaking change for non-early-adopters

@benwilson512 