### PR TITLE
Add behaviour attribute in injected Absinthe.Schema code

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -113,6 +113,8 @@ defmodule Absinthe.Schema do
         __absinthe_type__(name)
       end
 
+      @behaviour Absinthe.Schema
+
       @doc false
       def middleware(middleware, _field, _object) do
         middleware


### PR DESCRIPTION
The `@behaviour` attribute got removed from `Absinthe.Schema` `__using__` macro generated code.

Fixes #906 