### PR TITLE
Handle negative enum value

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1049,9 +1049,11 @@ defmodule Absinthe.Schema.Notation do
   #{Utils.placement_docs(@placement)}
   """
   defmacro value(identifier, raw_attrs \\ []) do
+    attrs = expand_ast(raw_attrs, __CALLER__)
+
     __CALLER__
     |> recordable!(:value, @placement[:value])
-    |> record_value!(identifier, raw_attrs)
+    |> record_value!(identifier, attrs)
   end
 
   # GENERAL ATTRIBUTES

--- a/test/absinthe/type/enum_test.exs
+++ b/test/absinthe/type/enum_test.exs
@@ -42,6 +42,12 @@ defmodule Absinthe.Type.EnumTest do
     enum :color_channel3,
       values: [:red, :green, :blue, :alpha],
       description: "The selected color channel"
+
+    enum :negative_value do
+      value :positive_one, as: 1
+      value :zero, as: 0
+      value :negative_one, as: -1
+    end
   end
 
   describe "enums" do


### PR DESCRIPTION
Negative numbers are not represented in AST as literals so they need to be expanded.

Fixes #908 
