### PR TITLE
Pass tests for var type mismatch

### DIFF
--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -8,7 +8,6 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
   use Absinthe.Phase
 
   def run(input, options \\ []) do
-    IO.puts("running")
     result = Blueprint.prewalk(input, &handle_node(&1, options[:context] || %{}))
     {:ok, result}
   end
@@ -18,10 +17,7 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
   end
 
   defp handle_node(%Input.Value{normalized: normalized} = node, context) do
-    IO.inspect(node, label: :blah)
-
-    with :ok <- validate_type(node),
-         {:ok, value} <- build_value(normalized, node.schema_node, context) do
+    with {:ok, value} <- build_value(normalized, node.schema_node, context) do
       %{node | data: value}
     else
       :not_leaf_node ->
@@ -33,11 +29,6 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
   end
 
   defp handle_node(node, _context), do: node
-
-  defp validate_type(%{normalized: %{schema_node: value_type}, schema_node: arg_type} = node) do
-    binding |> IO.inspect()
-    :ok
-  end
 
   defp build_value(%Input.Null{}, %Type.NonNull{}, _) do
     {:error, :non_null}

--- a/lib/absinthe/phase/document/arguments/variable_types_match.ex
+++ b/lib/absinthe/phase/document/arguments/variable_types_match.ex
@@ -44,12 +44,12 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
 
   def check_variable_types(%Operation{} = op) do
     variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
-    Blueprint.prewalk(op, &check_var_type(&1, op, variable_defs))
+    Blueprint.prewalk(op, &check_var_type(&1, op.name, variable_defs))
   end
 
   def check_variable_types(%Operation{} = op, %Fragment.Named{} = fragment) do
     variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
-    Blueprint.prewalk(fragment, &check_var_type(&1, op, variable_defs))
+    Blueprint.prewalk(fragment, &check_var_type(&1, op.name, variable_defs))
   end
 
   defp check_var_type(%{schema_node: nil} = node, _, _) do
@@ -61,7 +61,7 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
            raw: %{content: %Blueprint.Input.Variable{} = var},
            schema_node: schema_node
          } = node,
-         %Operation{} = op,
+         op_name,
          variable_defs
        ) do
     case Map.fetch(variable_defs, var.name) do
@@ -76,7 +76,7 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
             put_error(var, %Absinthe.Phase.Error{
               phase: __MODULE__,
               message:
-                error_message(op.name, var.name, var_schema_type.name, arg_schema_type.name),
+                error_message(op_name, var.name, var_schema_type.name, arg_schema_type.name),
               locations: [var.source_location]
             })
 

--- a/lib/absinthe/phase/document/arguments/variable_types_match.ex
+++ b/lib/absinthe/phase/document/arguments/variable_types_match.ex
@@ -1,45 +1,103 @@
 defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
+  # Partially implements: 5.8.5. All Variable Usages are Allowed
+  # Specifically, it implements "Variable usages must be compatible with the arguments they are passed to."
+  # See relevant counter-example: https://spec.graphql.org/draft/#example-2028e
+
   use Absinthe.Phase
-  alias Absinthe.{Blueprint, Type}
-  alias Absinthe.Blueprint.Input
 
-  def run(bp, _) do
-    bp =
-      Blueprint.update_current(bp, fn op ->
-        fragments = bp.fragments |> Map.new(&{&1.name, &1})
-        check_variable_types(op, fragments)
-      end)
+  alias Absinthe.Blueprint
+  alias Absinthe.Blueprint.Document.{Operation, Fragment}
 
-    {:ok, bp}
+  def run(blueprint, _) do
+    blueprint =
+      blueprint
+      |> check_operations()
+      |> check_fragments()
+
+    {:ok, blueprint}
   end
 
-  def check_variable_types(op, fragments) do
+  def check_operations(%Blueprint{} = blueprint) do
+    blueprint.operations
+    |> Enum.reduce(blueprint, fn operation, blueprint ->
+      update_operation(blueprint, operation, &check_variable_types/1)
+    end)
+  end
+
+  def check_fragments(%Blueprint{} = blueprint) do
+    blueprint.fragments
+    |> Enum.reduce(blueprint, fn fragment, blueprint ->
+      blueprint.operations
+      |> Enum.filter(&Operation.uses?(&1, fragment))
+      |> Enum.reduce(blueprint, fn operation, blueprint ->
+        update_fragment(blueprint, fragment, &check_variable_types(operation, &1))
+      end)
+    end)
+  end
+
+  defp update_operation(%Blueprint{} = blueprint, %Operation{name: name} = operation, fun) do
+    operations =
+      blueprint.operations
+      |> Enum.map(fn
+        # operations are unique by name
+        %{name: ^name} -> fun.(operation)
+        other -> other
+      end)
+
+    %{blueprint | operations: operations}
+  end
+
+  defp update_fragment(%Blueprint{} = blueprint, %Fragment.Named{name: name} = fragment, fun) do
+    fragments =
+      blueprint.fragments
+      |> Enum.map(fn
+        # named_fragments are unique by name
+        %{name: ^name} -> fun.(fragment)
+        other -> other
+      end)
+
+    %{blueprint | fragments: fragments}
+  end
+
+  def check_variable_types(%Operation{} = op) do
     variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
-    Blueprint.prewalk(op, &check_var_type(&1, variable_defs, fragments))
+    Blueprint.prewalk(op, &check_var_type(&1, op, variable_defs))
+  end
+
+  def check_variable_types(%Operation{} = op, %Fragment.Named{} = fragment) do
+    variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
+    Blueprint.prewalk(fragment, &check_var_type(&1, op, variable_defs))
   end
 
   defp check_var_type(%{schema_node: nil} = node, _, _) do
     {:halt, node}
   end
 
-  defp check_var_type(%Blueprint.Document.Fragment.Spread{name: name}, variables, fragments) do
-    # TODO: handle this
-    raise "not handled yet"
-  end
-
   defp check_var_type(
-         %Input.Value{raw: %{content: %Input.Variable{} = var}, schema_node: schema_node} = node,
+         %Blueprint.Input.Value{
+           raw: %{content: %Blueprint.Input.Variable{} = var},
+           schema_node: schema_node
+         } = node,
+         %Operation{} = op,
          variable_defs
        ) do
     case Map.fetch(variable_defs, var.name) do
       {:ok, %{schema_node: var_schema_type}} when not is_nil(var_schema_type) ->
         # null vs not null is handled elsewhere
-        var_schema_type = Type.unwrap(var_schema_type)
-        arg_schema_type = Type.unwrap(schema_node)
+        var_schema_type = Absinthe.Type.unwrap(var_schema_type)
+        arg_schema_type = Absinthe.Type.unwrap(schema_node)
 
         if var_schema_type.name != arg_schema_type.name do
           # error
-          node
+          var_with_error =
+            put_error(var, %Absinthe.Phase.Error{
+              phase: __MODULE__,
+              message:
+                error_message(op.name, var.name, var_schema_type.name, arg_schema_type.name),
+              locations: [var.source_location]
+            })
+
+          {:halt, put_in(node.raw.content, var_with_error)}
         else
           node
         end
@@ -49,7 +107,13 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
     end
   end
 
-  defp check_var_type(node, _) do
+  defp check_var_type(node, _, _) do
     node
+  end
+
+  def error_message(op, var_name, var_type, arg_type) do
+    "In operation `#{op}`, variable `#{var_name}` of type `#{var_type}` found as input to argument of type `#{
+      arg_type
+    }`."
   end
 end

--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -183,8 +183,6 @@ defmodule Absinthe.Phase.Schema do
   end
 
   defp set_schema_node(%Blueprint.Input.Value{} = node, parent, schema, _) do
-    binding() |> IO.inspect(label: :set_schema_node)
-
     case parent.schema_node do
       %Type.Argument{type: type} ->
         %{node | schema_node: type |> Type.expand(schema)}

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -50,7 +50,6 @@ defmodule Absinthe.Pipeline do
       {Phase.Parse, options},
       # Convert to Blueprint
       {Phase.Blueprint, options},
-      Phase.Debug,
       # Find Current Operation (if any)
       {Phase.Document.Validation.ProvidedAnOperation, options},
       {Phase.Document.CurrentOperation, options},

--- a/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
@@ -1008,38 +1008,4 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectTypeTest do
       )
     end
   end
-
-  describe "Variables" do
-    test "types of variables match types of arguments" do
-      assert_fails_validation(
-        """
-        query test($intArg: Int!) {
-          complicatedArgs {
-            stringArgField(stringArg: $intArg)
-          }
-        }
-        """,
-        [variables: %{"intArg" => 5}],
-        [
-          bad_argument("stringArg", "String", "1", 3, [])
-        ]
-      )
-    end
-
-    test "types of variables match types of arguments even when the value is null" do
-      assert_fails_validation(
-        """
-        query test($intArg: Int) {
-          complicatedArgs {
-            stringArgField(stringArg: $intArg)
-          }
-        }
-        """,
-        [variables: %{"intArg" => nil}],
-        [
-          bad_argument("stringArg", "String", "1", 3, [])
-        ]
-      )
-    end
-  end
 end

--- a/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
@@ -1,0 +1,81 @@
+defmodule Absinthe.Phase.Document.Validation.VariablesOfCorrectTypeTest do
+  @phase Absinthe.Phase.Document.Arguments.VariableTypesMatch
+
+  use Absinthe.ValidationPhaseCase, async: true, phase: @phase
+
+  defp bad_argument(op_name, var_name, expected_type, inspected_type, line, verbose_errors) do
+    bad_value(
+      Blueprint.Input.Argument,
+      error_message(op_name, var_name, expected_type, inspected_type, verbose_errors),
+      line,
+      name: var_name
+    )
+  end
+
+  defp error_message(op_name, var_name, expected_type, inspected_type, []) do
+    @phase.error_message(op_name, var_name, expected_type, inspected_type)
+  end
+
+  defp error_message(op_name, var_name, expected_type, inspected_type, verbose_errors) do
+    @phase.error_message(op_name, var_name, expected_type, inspected_type) <>
+      " " <> Enum.join(verbose_errors, " ")
+  end
+
+  test "types of variables match types of arguments" do
+    assert_fails_validation(
+      """
+      query test($intArg: Int!) {
+        complicatedArgs {
+          stringArgField(stringArg: $intArg)
+        }
+      }
+      """,
+      [variables: %{"intArg" => 5}],
+      [
+        bad_argument("test", "intArg", "Int", "String", 3, [
+          "(from line [%Absinthe.Blueprint.SourceLocation{column: 31, line: 3}])"
+        ])
+      ]
+    )
+  end
+
+  test "types of variables match types of arguments even when the value is null" do
+    assert_fails_validation(
+      """
+      query test($intArg: Int) {
+        complicatedArgs {
+          stringArgField(stringArg: $intArg)
+        }
+      }
+      """,
+      [variables: %{"intArg" => nil}],
+      [
+        bad_argument("test", "intArg", "Int", "String", 3, [
+          "(from line [%Absinthe.Blueprint.SourceLocation{column: 31, line: 3}])"
+        ])
+      ]
+    )
+  end
+
+  test "types of variables match types of arguments in named fragments" do
+    assert_fails_validation(
+      """
+      query test($intArg: Int) {
+        complicatedArgs {
+          ...Fragment
+        }
+      }
+
+      fragment Fragment on ComplicatedArgs {
+        stringArgField(stringArg: $intArg)
+      }
+      """,
+      [variables: %{"intArg" => 5}],
+      [
+        bad_argument("test", "intArg", "Int", "String", 8, [
+          "(from line [%Absinthe.Blueprint.SourceLocation{column: 29, line: 8}])"
+        ])
+      ]
+    )
+  end
+end

--- a/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/variables_of_correct_type_test.exs
@@ -3,79 +3,61 @@ defmodule Absinthe.Phase.Document.Validation.VariablesOfCorrectTypeTest do
 
   use Absinthe.ValidationPhaseCase, async: true, phase: @phase
 
-  defp bad_argument(op_name, var_name, expected_type, inspected_type, line, verbose_errors) do
-    bad_value(
-      Blueprint.Input.Argument,
-      error_message(op_name, var_name, expected_type, inspected_type, verbose_errors),
-      line,
-      name: var_name
-    )
-  end
-
-  defp error_message(op_name, var_name, expected_type, inspected_type, []) do
-    @phase.error_message(op_name, var_name, expected_type, inspected_type)
-  end
-
-  defp error_message(op_name, var_name, expected_type, inspected_type, verbose_errors) do
-    @phase.error_message(op_name, var_name, expected_type, inspected_type) <>
-      " " <> Enum.join(verbose_errors, " ")
-  end
-
   test "types of variables match types of arguments" do
-    assert_fails_validation(
-      """
-      query test($intArg: Int!) {
-        complicatedArgs {
-          stringArgField(stringArg: $intArg)
+    {:ok, %{errors: errors}} =
+      Absinthe.run(
+        """
+        query test($intArg: Int!) {
+          complicatedArgs {
+            stringArgField(stringArg: $intArg)
+          }
         }
-      }
-      """,
-      [variables: %{"intArg" => 5}],
-      [
-        bad_argument("test", "intArg", "Int", "String", 3, [
-          "(from line [%Absinthe.Blueprint.SourceLocation{column: 31, line: 3}])"
-        ])
-      ]
-    )
+        """,
+        Absinthe.Fixtures.PetsSchema,
+        variables: %{"intArg" => 5}
+      )
+
+    expected_error_msg = @phase.error_message("test", "intArg", "Int", "String")
+    assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 
   test "types of variables match types of arguments even when the value is null" do
-    assert_fails_validation(
-      """
-      query test($intArg: Int) {
-        complicatedArgs {
-          stringArgField(stringArg: $intArg)
+    {:ok, %{errors: errors}} =
+      Absinthe.run(
+        """
+        query test($intArg: Int) {
+          complicatedArgs {
+            stringArgField(stringArg: $intArg)
+          }
         }
-      }
-      """,
-      [variables: %{"intArg" => nil}],
-      [
-        bad_argument("test", "intArg", "Int", "String", 3, [
-          "(from line [%Absinthe.Blueprint.SourceLocation{column: 31, line: 3}])"
-        ])
-      ]
-    )
+        """,
+        Absinthe.Fixtures.PetsSchema,
+        variables: %{"intArg" => nil}
+      )
+
+    expected_error_msg = @phase.error_message("test", "intArg", "Int", "String")
+    assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 
   test "types of variables match types of arguments in named fragments" do
-    assert_fails_validation(
-      """
-      query test($intArg: Int) {
-        complicatedArgs {
-          ...Fragment
+    {:ok, %{errors: errors}} =
+      Absinthe.run(
+        """
+        query test($intArg: Int) {
+          complicatedArgs {
+            ...Fragment
+          }
         }
-      }
 
-      fragment Fragment on ComplicatedArgs {
-        stringArgField(stringArg: $intArg)
-      }
-      """,
-      [variables: %{"intArg" => 5}],
-      [
-        bad_argument("test", "intArg", "Int", "String", 8, [
-          "(from line [%Absinthe.Blueprint.SourceLocation{column: 29, line: 8}])"
-        ])
-      ]
-    )
+        fragment Fragment on ComplicatedArgs {
+          stringArgField(stringArg: $intArg)
+        }
+        """,
+        Absinthe.Fixtures.PetsSchema,
+        variables: %{"intArg" => 5}
+      )
+
+    expected_error_msg = @phase.error_message("test", "intArg", "Int", "String")
+    assert expected_error_msg in (errors |> Enum.map(& &1.message))
   end
 end


### PR DESCRIPTION
## 📝 Description

This is intended to get the tests found in `test/absinthe/phase/document/validation/variables_of_correct_type_test.exs` to pass.

## 🎶 Notes

Notably, there are a number of tests that are now not passing. E.g.:

```
 ##) test scenario #1 (Absinthe.Integration.Execution.OperationByNameTest)
     test/absinthe/integration/execution/operation_by_name_test.exs:17
     Assertion with == failed
     code:  assert {:ok, %{data: %{"thing" => %{"name" => "Foo"}}}} == Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, operation_name: "ThingFoo", variables: %{"id" => "foo"})
     left:  {:ok, %{data: %{"thing" => %{"name" => "Foo"}}}}
     right: {
              :ok,
              %{
                errors: [%{locations: [%{column: 13, line: 2}], message: "In operation `ThingFoo`, variable `id` of type `ID` found as input to argument of type `String`."}]
              }
            }
     stacktrace:
       test/absinthe/integration/execution/operation_by_name_test.exs:18: (test)
```

It appears there were several tests which were accidentally violating the Spec. I imagine that this change will break a lot of queries out there.

There are also a few tests of this form:

```
##) test scenario #3 (Absinthe.Integration.Execution.OperationByNameTest)
     test/absinthe/integration/execution/operation_by_name_test.exs:40
     ** (FunctionClauseError) no function clause matching in Absinthe.Phase.Document.Arguments.Parse.flag_invalid/2

     The following arguments were given to Absinthe.Phase.Document.Arguments.Parse.flag_invalid/2:

         # 1
         nil

         # 2
         :bad_parse

     Attempted function clauses (showing 1 out of 1):

         def flag_invalid(%{flags: _} = node, flag)

     stacktrace:
       (absinthe 1.5.0-rc.5) lib/absinthe/phase/document/arguments/parse.ex:8: Absinthe.Phase.Document.Arguments.Parse.flag_invalid/2
       (absinthe 1.5.0-rc.5) lib/absinthe/phase/document/arguments/parse.ex:27: Absinthe.Phase.Document.Arguments.Parse.handle_node/2
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:16: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.walk/4
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
       (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
       (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
       (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
       (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe 1.5.0-rc.5) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
```

I'm not sure what these are about yet, exactly.

However, as the intention of this particular PR was to get the _relevant_ tests to pass, I think it might be worth merging it into `fix-arg-variables` and sorting out the larger implications in that main branch.