### PR TITLE
Fix/allow null as default

### DIFF
--- a/lib/absinthe/blueprint/input/argument.ex
+++ b/lib/absinthe/blueprint/input/argument.ex
@@ -36,14 +36,7 @@ defmodule Absinthe.Blueprint.Input.Argument do
       %__MODULE__{input_value: %{normalized: %Blueprint.Input.Null{}}, value: nil} ->
         true
 
-      %__MODULE__{
-        input_value: %{
-          normalized: %Absinthe.Blueprint.Input.Generated{
-            by: Absinthe.Phase.Document.MissingVariables
-          }
-        },
-        value: nil
-      } ->
+      %__MODULE__{input_value: %{normalized: %Blueprint.Input.Generated{}}, value: nil} ->
         true
 
       %__MODULE__{value: nil} ->

--- a/lib/absinthe/blueprint/input/argument.ex
+++ b/lib/absinthe/blueprint/input/argument.ex
@@ -49,6 +49,9 @@ defmodule Absinthe.Blueprint.Input.Argument do
       %__MODULE__{value: nil} ->
         false
 
+      %__MODULE__{value: %Absinthe.Type.UndefinedDefault{}} ->
+        false
+
       arg ->
         arg
     end)

--- a/lib/absinthe/blueprint/input/argument.ex
+++ b/lib/absinthe/blueprint/input/argument.ex
@@ -36,6 +36,16 @@ defmodule Absinthe.Blueprint.Input.Argument do
       %__MODULE__{input_value: %{normalized: %Blueprint.Input.Null{}}, value: nil} ->
         true
 
+      %__MODULE__{
+        input_value: %{
+          normalized: %Absinthe.Blueprint.Input.Generated{
+            by: Absinthe.Phase.Document.MissingVariables
+          }
+        },
+        value: nil
+      } ->
+        true
+
       %__MODULE__{value: nil} ->
         false
 

--- a/lib/absinthe/blueprint/schema/input_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/input_value_definition.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Blueprint.Schema.InputValueDefinition do
     # definition
     placement: :argument_definition,
     description: nil,
-    default_value: nil,
+    default_value: Macro.escape(%Absinthe.Type.UndefinedDefault{}),
     default_value_blueprint: nil,
     directives: [],
     source_location: nil,
@@ -29,7 +29,7 @@ defmodule Absinthe.Blueprint.Schema.InputValueDefinition do
           name: String.t(),
           description: nil | String.t(),
           type: Blueprint.TypeReference.t(),
-          default_value: Blueprint.Input.t(),
+          default_value: Blueprint.Input.t() | Absinthe.Type.UndefinedDefault.t(),
           default_value_blueprint: Blueprint.Draft.t(),
           directives: [Blueprint.Directive.t()],
           source_location: nil | Blueprint.SourceLocation.t(),

--- a/lib/absinthe/blueprint/schema/input_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/input_value_definition.ex
@@ -13,6 +13,7 @@ defmodule Absinthe.Blueprint.Schema.InputValueDefinition do
     # definition
     placement: :argument_definition,
     description: nil,
+    # default_value: nil,
     default_value: Macro.escape(%Absinthe.Type.UndefinedDefault{}),
     default_value_blueprint: nil,
     directives: [],

--- a/lib/absinthe/phase/document/missing_variables.ex
+++ b/lib/absinthe/phase/document/missing_variables.ex
@@ -16,6 +16,7 @@ defmodule Absinthe.Phase.Document.MissingVariables do
   @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
   def run(input, _options \\ []) do
     node = Blueprint.prewalk(input, &handle_node/1)
+    # IO.inspect node
     {:ok, node}
   end
 
@@ -36,7 +37,10 @@ defmodule Absinthe.Phase.Document.MissingVariables do
 
   defp handle_defaults(node, schema_node) do
     case schema_node do
-      %{default_value: val} when not is_nil(val) ->
+      %{default_value: %Absinthe.Type.UndefinedDefault{}}  ->
+        node
+
+      %{default_value: val}  ->
         fill_default(node, val)
 
       %{deprecation: %{}} ->

--- a/lib/absinthe/phase/document/missing_variables.ex
+++ b/lib/absinthe/phase/document/missing_variables.ex
@@ -16,7 +16,6 @@ defmodule Absinthe.Phase.Document.MissingVariables do
   @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
   def run(input, _options \\ []) do
     node = Blueprint.prewalk(input, &handle_node/1)
-    # IO.inspect node
     {:ok, node}
   end
 

--- a/lib/absinthe/phase/document/missing_variables.ex
+++ b/lib/absinthe/phase/document/missing_variables.ex
@@ -37,17 +37,17 @@ defmodule Absinthe.Phase.Document.MissingVariables do
 
   defp handle_defaults(node, schema_node) do
     case schema_node do
-      %{default_value: %Absinthe.Type.UndefinedDefault{}}  ->
+      %{deprecation: %{}, default_value: %Absinthe.Type.UndefinedDefault{}} ->
         node
 
-      %{default_value: val}  ->
-        fill_default(node, val)
-
-      %{deprecation: %{}} ->
-        node
-
-      %{type: %Type.NonNull{}} ->
+      %{type: %Type.NonNull{}, default_value: %Absinthe.Type.UndefinedDefault{}} ->
         node |> flag_invalid(:missing)
+
+      %{default_value: %Absinthe.Type.UndefinedDefault{}} ->
+        node
+
+      %{default_value: val} ->
+        fill_default(node, val)
 
       _ ->
         node

--- a/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
+++ b/lib/absinthe/phase/schema/validation/default_enum_value_present.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Phase.Schema.Validation.DefaultEnumValuePresent do
 
   def validate_schema(node), do: node
 
-  def validate_defaults(%{default_value: nil} = node, _) do
+  def validate_defaults(%{default_value: %Absinthe.Type.UndefinedDefault{}} = node, _) do
     node
   end
 

--- a/lib/absinthe/type/undefined_default.ex
+++ b/lib/absinthe/type/undefined_default.ex
@@ -9,5 +9,5 @@ defmodule Absinthe.Type.UndefinedDefault do
     empty: binary
   }
 
-  defstruct empty: "defined"
+  defstruct empty: "undefined"
 end

--- a/lib/absinthe/type/undefined_default.ex
+++ b/lib/absinthe/type/undefined_default.ex
@@ -1,13 +1,18 @@
 defmodule Absinthe.Type.UndefinedDefault do
   @moduledoc false
 
+  use Absinthe.Introspection.Kind
+  use Absinthe.Type.Fetch
+
   @typedoc """
   Definition to undefined default values.
+
+  ## Options
+
+  * `:of_type` -- the underlying type to wrap
   """
+  defstruct of_type: nil
 
-  @type t :: %__MODULE__{
-    empty: binary
-  }
-
-  defstruct empty: "undefined"
+  @type t :: %__MODULE__{of_type: Absinthe.Type.nullable_t()}
+  @type t(x) :: %__MODULE__{of_type: x}
 end

--- a/lib/absinthe/type/undefined_default.ex
+++ b/lib/absinthe/type/undefined_default.ex
@@ -1,0 +1,13 @@
+defmodule Absinthe.Type.UndefinedDefault do
+  @moduledoc false
+
+  @typedoc """
+  Definition to undefined default values.
+  """
+
+  @type t :: %__MODULE__{
+    empty: binary
+  }
+
+  defstruct empty: "defined"
+end

--- a/test/absinthe/execution/arguments/input_object_test.exs
+++ b/test/absinthe/execution/arguments/input_object_test.exs
@@ -203,4 +203,24 @@ defmodule Absinthe.Execution.Arguments.InputObjectTest do
       run(@graphql, @schema, variables: %{"contact" => %{"mail" => "bubba@joe.com"}})
     )
   end
+
+  @graphql """
+  query ($name: String) {
+    company(name: $name)
+  }
+  """
+  @tag dev: true
+  test "return nil when default_value is nil for simple input" do
+    assert_data(
+      %{"company" => nil},
+      run(
+        @graphql,
+        @schema,
+        variables: %{}
+      )
+    )
+  end
+
+  # TODO: test nil as default for lists
+  # TODO: test nil as default for complex objects
 end

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -160,7 +160,8 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
 
       resolve fn
         %{name: name}, _ -> {:ok, name}
-        _args, _ -> {:error, "could not find your default nil arg"}
+        _args, _ ->
+          {:error, "could not find your default nil arg"}
      end
     end
   end

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -45,6 +45,10 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
     field :email, non_null(:string)
   end
 
+  input_object :company_input do
+    field :name, :string, default_value: "Absinthe CO"
+  end
+
   enum :contact_type do
     value :email, name: "Email", as: "Email"
     value :phone
@@ -149,6 +153,15 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
 
     field :raising_thing, :string do
       arg :name, :input_name_raising
+    end
+
+    field :company, :string do
+      arg :name, :string, default_value: nil
+
+      resolve fn
+        %{name: name}, _ -> {:ok, name}
+        _args, _ -> {:error, "could not find your default nil arg"}
+     end
     end
   end
 end


### PR DESCRIPTION
This issue is a Draft to solve #656. 

The problem as described on the issue happens because absinthe is using `nil` with an emptiness meaning. In this scenario, Absinthe always interprets `default_value: nil` as something to be removed, even when the user defines it. 

My current approach to the solution is to create a new `%UndefinedDefault{}` type and start it with this value. My current solution has some regressions which I couldn't solve at this moment: 

1. Some phase is trying to use the value when the `default_value` to `value` and `data` when the `default_value: %Type.UndefinedDefault{}`. And it's the root of current regressions.
2. I couldn't identify what is the best place to create a new type. My current guesses are `Absinthe.Blueprint.Schema` once `Absinthe.Type` is used only to deal with types who concern the users. 
3. Should I prevent undefined default from being set on `data`? If positive, where it happens?
4. Should the new type support some protocol/behavior? If positive, which ones? 

Opening as a draft, if we have a better way to do this or some refactor is necessary before implementing the feature itself we can close this one and start again. 