### PR TITLE
Fix enum default value to work properly with list values.

### DIFF
--- a/test/absinthe/schema/rule/default_enum_value_present_test.exs
+++ b/test/absinthe/schema/rule/default_enum_value_present_test.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Schema.Rule.DefaultEnumValuePresentTest do
   use Absinthe.Case, async: true
 
   describe "rule" do
-    test "is enforced when the defaultValue is not in the enum" do
+    test "is enforced when the default_value is not in the enum" do
       schema = """
       defmodule BadColorSchema do
         use Absinthe.Schema
@@ -14,14 +14,14 @@ defmodule Absinthe.Schema.Rule.DefaultEnumValuePresentTest do
         query do
 
           field :info,
-          type: :channel_info,
-          args: [
-            channel: [type: non_null(:channel), default_value: :OTHER],
-          ],
-          resolve: fn
-            %{channel: channel}, _ ->
-            {:ok, %{name: @names[channel]}}
-          end
+            type: :channel_info,
+            args: [
+              channel: [type: non_null(:channel), default_value: :OTHER],
+            ],
+            resolve: fn
+              %{channel: channel}, _ ->
+              {:ok, %{name: @names[channel]}}
+            end
 
         end
 
@@ -41,6 +41,75 @@ defmodule Absinthe.Schema.Rule.DefaultEnumValuePresentTest do
       assert_raise(Absinthe.Schema.Error, error, fn ->
         Code.eval_string(schema)
       end)
+    end
+
+    test "is enforced when the default_value is a list of enums and some items are not in the enum" do
+      schema = """
+      defmodule MovieSchema do
+        use Absinthe.Schema
+
+        query do
+
+          field :movies,
+            type: non_null(list_of(non_null(:movie_genre))),
+            args: [
+              genres: [type: non_null(list_of(non_null(:movie_genre))), default_value: [:action, :OTHER]],
+            ],
+            resolve: fn
+              %{genres: _}, _ -> {:ok, []}
+            end
+
+        end
+
+        enum :movie_genre do
+          value :action, as: :action
+          value :comedy, as: :comedy
+          value :sf, as: :sf
+        end
+
+        object :movie do
+          field :name, :string
+        end
+      end
+      """
+
+      error = ~r/The default_value for an enum must be present in the enum values/
+
+      assert_raise(Absinthe.Schema.Error, error, fn ->
+        Code.eval_string(schema)
+      end)
+    end
+
+    test "passes when the default_value is a list and that list is a valid enum value" do
+      schema = """
+      defmodule CorrectCatSchema do
+        use Absinthe.Schema
+
+        query do
+
+          field :cats,
+            type: non_null(list_of(non_null(:cat))),
+            args: [
+              order_by: [type: non_null(:cat_order_by), default_value: [{:asc, :name}]],
+            ],
+            resolve: fn
+              %{order_by: _}, _ -> {:ok, []}
+            end
+
+        end
+
+        enum :cat_order_by do
+          value :name_asc, as: [{:asc, :name}]
+          value :name_desc_inserted_at_asc, as: [{:desc, :name}, {:asc, :inserted_at}]
+        end
+
+        object :cat do
+          field :name, :string
+        end
+      end
+      """
+
+      assert Code.eval_string(schema)
     end
   end
 end


### PR DESCRIPTION
An attempt to fix #941.

### The problem

The current `default_value` for enum looks like this:

```ex
default_valid? =
  List.wrap(default_value)
  |> Enum.all?(fn default -> default in values end)
```

It's quite limited as doesn't really take type structure into consideration. Most importantly it breaks when enum values are defined to be lists.

### Example

```ex
defmodule CorrectCatSchema do
  use Absinthe.Schema

  query do

    field :cats,
      type: non_null(list_of(non_null(:cat))),
      args: [
        order_by: [type: non_null(:cat_order_by), default_value: [{:asc, :name}]],
      ],
      resolve: fn
        %{order_by: _}, _ -> {:ok, []}
      end

  end

  enum :cat_order_by do
    value :name_asc, as: [{:asc, :name}]
    value :name_desc_inserted_at_asc, as: [{:desc, :name}, {:asc, :inserted_at}]
  end

  object :cat do
    field :name, :string
  end
end
```

What the mentioned code does is checking `{:asc, :name} in enum_values` instead of the expected `[{:asc, :name}] in enum_values`.

### Solution

With type definition at hand we can analyze the given `default_value` and figure out which inner values *should actually* be enum values.

In the example above we immediately see it's the enum type `non_null(:cat_order_by)`, so we check if `[{:asc, :name}]]` is a valid enum value.

Let's consider a nested case:

```ex
args: [
  genres: [type: non_null(list_of(non_null(:movie_genre))), default_value: [:action, :OTHER]],
],
```

Here we first see a **list type** and a `default_value` of `[:action, :OTHER]`, so we can dive deeper into the structure and check:
- `non_null(:movie_genre)` against `:action`
- `non_null(:movie_genre)` against `:OTHER`

In both cases we reached the inner enum type, so we can simply check if `:action` is within valid values and if `:OTHER` is within valid values.