### PR TITLE
Preserve order of enum values in schema in SDL rendering

### DIFF
--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -214,13 +214,13 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(rest, [push(schema, :directive_definitions, dir) | stack], buff)
   end
 
-  @simple_close [
-    Schema.ScalarTypeDefinition,
-    Schema.EnumTypeDefinition
-  ]
+  defp build_types([:close | rest], [%Schema.EnumTypeDefinition{} = type, schema | stack], buff) do
+    type = Map.update!(type, :values, &Enum.reverse/1)
+    schema = push(schema, :type_definitions, type)
+    build_types(rest, [schema | stack], buff)
+  end
 
-  defp build_types([:close | rest], [%module{} = type, schema | stack], buff)
-       when module in @simple_close do
+  defp build_types([:close | rest], [%Schema.ScalarTypeDefinition{} = type, schema | stack], buff) do
     schema = push(schema, :type_definitions, type)
     build_types(rest, [schema | stack], buff)
   end

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -191,9 +191,16 @@ defmodule SdlRenderTest do
       field :search, :search_result
     end
 
+    enum :order_status do
+      value :delivered
+      value :processing
+      value :picking
+    end
+
     object :order do
       field :id, :id
       field :name, :string
+      field :status, :order_status
       import_fields :imported_fields
     end
 
@@ -233,10 +240,17 @@ defmodule SdlRenderTest do
 
              union SearchResult = Order | Category
 
+             enum OrderStatus {
+               DELIVERED
+               PROCESSING
+               PICKING
+             }
+
              type Order {
                imported: Boolean!
                id: ID
                name: String
+               status: OrderStatus
              }
              """
   end


### PR DESCRIPTION
More or less a followup to https://github.com/absinthe-graphql/absinthe/pull/951 

The SDL rendering now uses the same order as the declaration of
the enum values in the macro schema.

