### PR TITLE
Ensure types are consistently sorted in introspection result

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -593,6 +593,7 @@ defmodule Absinthe.Schema do
   def directives(schema) do
     schema.__absinthe_directives__
     |> Map.keys()
+    |> Enum.sort()
     |> Enum.map(&lookup_directive(schema, &1))
   end
 
@@ -645,6 +646,7 @@ defmodule Absinthe.Schema do
   def types(schema) do
     schema.__absinthe_types__
     |> Map.keys()
+    |> Enum.sort()
     |> Enum.map(&lookup_type(schema, &1))
   end
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -131,7 +131,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
               end
             end)
 
-          {:ok, result}
+          {:ok, Enum.sort_by(result, & &1.identifier)}
 
         _, _ ->
           {:ok, nil}


### PR DESCRIPTION
Wanted to get some feedback on how we're sorting these.

The reason for this change is because we have had issues using [graphql-code-generator](https://graphql-code-generator.com/), which would output different order when the order of introspection changed (which happens when recompiling, I think because of how ParallelCompiler might randomize the order in which types are compiled). When considering which library to change, I considered Absinthe to be the best place, since one might expect the order of introspection to define the order of type generation, and that seems like it's generally a good practice.

I chose to add sorting to `Absinthe.Schema.types/1` rather than to introspection alone, as I assumed sorting it there would be the most performant (as we're sorting just the keys, not the types themselves), but I can change this behaviour if this is a hot code path or if there are unwanted side effects to this.

I also considered trying to keep the order in which they are defined/imported in the schema, but because maps with > 32 keys are not sorted, this would require additional work.