### PR TITLE
Add spec for dataloader/2

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -298,6 +298,7 @@ defmodule Absinthe.Resolution.Helpers do
     """
     def dataloader(source, fun, opts \\ [])
 
+    @spec dataloader(Dataloader.source_name(), any) :: dataloader_key_fun
     @spec dataloader(Dataloader.source_name(), dataloader_key_fun | any, [dataloader_opt]) ::
             dataloader_key_fun
     def dataloader(source, fun, opts) when is_function(fun, 3) do


### PR DESCRIPTION
Hello! Thank you for the project.

I encountered the following dialyzer error:

```elixir
lib/exchanger_web/types/wallet.ex:13:call
The function call will not succeed.

Absinthe.Resolution.Helpers.dataloader(Exchanger.Accounts, :user)

breaks the contract
(Dataloader.source_name(), [dataloader_opt()]) :: :dataloader_key_

________________________________________________________________________________
```

when calling dataloader in the following code:

```elixir
defmodule ExchangerWeb.Types.Wallet do
  @moduledoc "Wallet types for Absinthe"
  use Absinthe.Schema.Notation
  import Absinthe.Resolution.Helpers, only: [dataloader: 2]

  @desc "A users wallet, can hold one type of currency"
  object :wallet do
    field :id, :id
    field :user_id, :id
    field :currency, :string
    field :balance, :integer

    field :user, :user, resolve: dataloader(Exchanger.Accounts, :user)
  end
end
```

I think there is a typespec missing for `dataloader/2` where the second argument in the resource.

I hope this spec helps!
