### PR TITLE
File uploads guide improvements

### DIFF
--- a/guides/file-uploads.md
+++ b/guides/file-uploads.md
@@ -32,10 +32,10 @@ To send a mutation that includes a file upload, you need to
 use the `multipart/form-data` content type. For example, using `cURL`:
 
 ```shell
-$ curl -X POST \\
--F query="mutation { uploadFile(users: \"users_csv\", metadata: \"metadata_json\")}" \\
--F users_csv=@users.csv \\
--F metadata_json=@metadata.json \\
+$ curl -X POST \
+-F query="mutation { uploadFile(users: \"users_csv\", metadata: \"metadata_json\")}" \
+-F users_csv=@users.csv \
+-F metadata_json=@metadata.json \
 localhost:4000/graphql
 ```
 

--- a/guides/file-uploads.md
+++ b/guides/file-uploads.md
@@ -68,9 +68,9 @@ defmodule API.UploadFileMutationTest do
 
   test "mutation: uploadFile returns file URL when CSV is attached", %{conn: conn} do
     path =
-      ["test", "fixtures", "users.csv"]
+      [__DIR__, "..", "..", "test", "fixtures", "users.csv"]
       |> Path.join()
-      |> (fn subpath -> Application.app_dir(:api, subpath) end).()
+      |> Path.expand()
 
     conn =
       post(conn, "/api/graphql", %{


### PR DESCRIPTION
This PR fixes cURL example in [File uploads guide](https://hexdocs.pm/absinthe/file-uploads.html) by replacing `\\` with '\`. 

Additionally it adds a short section on testing file uploads.