### PR TITLE
Remove :inets dependency

### DIFF
--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -279,7 +279,7 @@ defmodule Absinthe.Lexer do
 
   defp unescape_unicode(_rest, content, context, _loc, _) do
     code = content |> Enum.reverse()
-    value = :httpd_util.hexlist_to_integer(code)
+    value = :erlang.list_to_integer(code, 16)
     binary = :unicode.characters_to_binary([value])
     {[binary], context}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Absinthe.Mixfile do
       ],
       deps: deps(),
       dialyzer: [
-        plt_add_apps: [:mix, :dataloader, :decimal, :ex_unit, :inets],
+        plt_add_apps: [:mix, :dataloader, :decimal, :ex_unit],
         plt_file: {:no_warn, "priv/plts/absinthe.plt"}
       ]
     ]


### PR DESCRIPTION
There's an implicit dependency on `:inets` when using `:httpd_util` while parsing documents with unicode characters.  Our distillery release does not include `:inets` by default so `:httpd_util` functions are unavailable at runtime. 

This PR *should* remove the dependency on `:inets` altogether.