### PR TITLE
Allow :meta on field

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -354,6 +354,20 @@ defmodule Absinthe.Schema.Notation do
         end
       end
 
+    block =
+      case Keyword.get(attrs, :meta) do
+        nil ->
+          block
+
+        meta ->
+          meta_ast =
+            quote do
+              meta unquote(meta)
+            end
+
+          [meta_ast, block]
+      end
+
     {func_ast, attrs} = Keyword.pop(attrs, :resolve)
 
     block =
@@ -371,6 +385,7 @@ defmodule Absinthe.Schema.Notation do
       attrs
       |> expand_ast(caller)
       |> Keyword.delete(:args)
+      |> Keyword.delete(:meta)
       |> handle_deprecate
 
     {attrs, block}

--- a/test/absinthe/schema/manipulation_test.exs
+++ b/test/absinthe/schema/manipulation_test.exs
@@ -152,8 +152,7 @@ defmodule Absinthe.Schema.ManipulationTest do
         meta :some_string_meta, "non_dyn_integer meta"
       end
 
-      field :non_dyn_string, :string do
-        meta :some_string_meta, "non_dyn_string meta"
+      field :non_dyn_string, :string, meta: [some_string_meta: "non_dyn_string meta"] do
         resolve fn _, _ -> {:ok, "some_string_val"} end
       end
     end


### PR DESCRIPTION
As mentioned on Slack and in issue #958, inline meta does not work.
I think this add that ability back.
