### PR TITLE
Support Decimal v2

### DIFF
--- a/lib/absinthe/type/custom/decimal.ex
+++ b/lib/absinthe/type/custom/decimal.ex
@@ -9,6 +9,9 @@ if Code.ensure_loaded?(Decimal) do
     @spec parse(any) :: {:ok, Decimal.t()} | {:ok, nil} | :error
     def parse(%Input.String{value: value}) when is_binary(value) do
       case Decimal.parse(value) do
+        # Decimal V2
+        {decimal, ""} -> {:ok, decimal}
+        # Decimal V1
         {:ok, decimal} -> {:ok, decimal}
         _ -> :error
       end

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Absinthe.Mixfile do
       {:nimble_parsec, "~> 0.5"},
       {:telemetry, "~> 0.4.0"},
       {:dataloader, "~> 1.0.0", optional: true},
-      {:decimal, "~> 1.0", optional: true},
+      {:decimal, "~> 1.0 or ~> 2.0" , optional: true},
       {:ex_doc, "~> 0.21.0", only: :dev},
       {:benchee, ">= 1.0.0", only: :dev},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
   "dataloader": {:hex, :dataloader, "1.0.4", "7c2345c53c9e5b61420013fc53c8463ba347a938b61f66677eb47d9c4a53ac5d", [:mix], [{:ecto, ">= 0.0.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm", "6558d3a3e6c9f5019a68eb7cc53384dc8a1d74977c6e41b48b126dd3bfa9d0b0"},
-  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm", "130926580655f34d759dd25f5d723fd233c9bbe0399cde57e2a1adea9ed92e08"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], [], "hexpm"},

--- a/test/absinthe/type/custom_test.exs
+++ b/test/absinthe/type/custom_test.exs
@@ -169,17 +169,17 @@ defmodule Absinthe.Type.CustomTest do
 
     test "can be parsed from a numeric string" do
       assert {:ok, decimal} = parse(:decimal, %Input.String{value: "-3.49"})
-      assert Decimal.cmp(@decimal, decimal) == :eq
+      assert Decimal.compare(@decimal, decimal) == :eq
     end
 
     test "can be parsed from a float" do
       assert {:ok, decimal} = parse(:decimal, %Input.Float{value: -3.49})
-      assert Decimal.cmp(@decimal, decimal) == :eq
+      assert Decimal.compare(@decimal, decimal) == :eq
     end
 
     test "can be parsed from an integer" do
       assert {:ok, decimal} = parse(:decimal, %Input.Integer{value: 3})
-      assert Decimal.cmp(@decimal_int, decimal) == :eq
+      assert Decimal.compare(@decimal_int, decimal) == :eq
     end
 
     test "cannot be parsed from alphanumeric string" do


### PR DESCRIPTION
Mostly minor changes

* match on the new return type for `Decimal.parse/1`
* Swap `Decimal.cmp/2` for `Decimal.compare/2` as former is deprecated
* Use decimal v2 for local development

---

I was going through updating our dependencies and sadly Absinthe was requiring v1. Not sure what your preference is on allowing multiple major versions of dependencies or which one is preferred in the `mix.lock` file, so I made a broad assumption to stick the latest in there.