### PR TITLE
Fix deprecation warnings in Elixir 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ otp_release:
   - 20.3
   - 21.3
   - 22.3
+  - 23.1
 elixir:
   - 1.8.2
   - 1.9.4
   - 1.10.2
+  - 1.11.1
 matrix:
   include:
     - elixir: 1.10.2

--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -175,7 +175,7 @@ defmodule Absinthe.Blueprint do
   end
 
   def extend_fields(blueprint, ext_blueprint) when is_atom(ext_blueprint) do
-    extend_fields(blueprint, ext_blueprint.__absinthe_blueprint__)
+    extend_fields(blueprint, ext_blueprint.__absinthe_blueprint__())
   end
 
   def add_field(blueprint = %Blueprint{}, type_def_name, new_field) do
@@ -212,7 +212,7 @@ defmodule Absinthe.Blueprint do
   end
 
   def types_by_name(module) when is_atom(module) do
-    types_by_name(module.__absinthe_blueprint__)
+    types_by_name(module.__absinthe_blueprint__())
   end
 
   defimpl Inspect do

--- a/lib/absinthe/pipeline/batch_resolver.ex
+++ b/lib/absinthe/pipeline/batch_resolver.ex
@@ -93,7 +93,7 @@ defmodule Absinthe.Pipeline.BatchResolver do
     {:ok, blueprint}
   rescue
     e ->
-      pipeline_error(e, System.stacktrace())
+      pipeline_error(e, __STACKTRACE__)
       :error
   end
 

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -70,7 +70,7 @@ defmodule Absinthe.Subscription.Local do
         :ok = pubsub.publish_subscription(topic, data)
       rescue
         e ->
-          BatchResolver.pipeline_error(e, System.stacktrace())
+          BatchResolver.pipeline_error(e, __STACKTRACE__)
       end
     end
   end

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -53,7 +53,7 @@ defmodule Absinthe.Type do
   @doc false
   # this is just for debugging
   def expand(%module{} = type) do
-    module.functions
+    module.functions()
     |> Enum.reduce(type, fn
       :middleware, type ->
         type

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
     Application.ensure_all_started(:absinthe)
 
     Mix.Task.run("loadpaths", argv)
-    Mix.Project.compile(argv)
+    Mix.Task.run("compile", argv)
 
     opts = parse_options(argv)
 

--- a/lib/mix/tasks/absinthe.schema.sdl.ex
+++ b/lib/mix/tasks/absinthe.schema.sdl.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Sdl do
     Application.ensure_all_started(:absinthe)
 
     Mix.Task.run("loadpaths", argv)
-    Mix.Project.compile(argv)
+    Mix.Task.run("compile", argv)
 
     opts = parse_options(argv)
 

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Absinthe.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:crypto, :logger]]
   end
 
   defp deps do

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -42,7 +42,7 @@ defmodule Absinthe.LexerTest do
                 {:"(", {2, 8}},
                 {:name, {2, 9}, 'bar'},
                 {:":", {2, 12}},
-                {:string_value, {2, 14}, ~S("\\FOO") |> String.to_char_list()},
+                {:string_value, {2, 14}, ~S("\\FOO") |> String.to_charlist()},
                 {:")", {2, 23}},
                 {:"}", {2, 25}},
                 {:"}", {3, 1}}

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -602,13 +602,13 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
                Absinthe.run(@query, Definition)
 
       assert_receive {[:absinthe, :execute, :operation, :start], _, %{id: id}, _config}
-      assert_receive {[:absinthe, :execute, :operation, :stop], measurements, %{id: ^id}, _config}
+      assert_receive {[:absinthe, :execute, :operation, :stop], _measurements, %{id: ^id}, _config}
 
-      assert_receive {[:absinthe, :resolve, :field, :start], measurements,
-                      %{resolution: %{definition: %{name: "posts"}}}, config}
+      assert_receive {[:absinthe, :resolve, :field, :start], _measurements,
+                      %{resolution: %{definition: %{name: "posts"}}}, _config}
 
       assert_receive {[:absinthe, :resolve, :field, :stop], measurements,
-                      %{resolution: %{definition: %{name: "posts"}}}, config}
+                      %{resolution: %{definition: %{name: "posts"}}}, _config}
     end
   end
 end


### PR DESCRIPTION
When compiling with Elixir 1.11, you get the following deprecation warnings which I've fixed:

```

warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead
  lib/absinthe/pipeline/batch_resolver.ex:96

warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead
  lib/absinthe/subscription/local.ex:73

warning: :crypto.hash/2 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto]] to your "def project" in mix.exs

  lib/absinthe/phase/subscription/subscribe_self.ex:159: Absinthe.Phase.Subscription.SubscribeSelf.get_document_id/3

warning: :httpd_util.hexlist_to_integer/1 defined in application :inets is used by the current application but the current application does not directly depend on :inets. To fix this, you must do one of:

  1. If :inets is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :inets is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :inets, you may optionally skip this warning by adding [xref: [exclude: :httpd_util]] to your "def project" in mix.exs

  lib/absinthe/lexer.ex:282: Absinthe.Lexer.unescape_unicode/5

warning: incompatible types:

    map() !~ atom()

in expression:

    # lib/absinthe/blueprint.ex:215
    module.__absinthe_blueprint__

where "module" was given the type atom() in:

    # lib/absinthe/blueprint.ex:214
    is_atom(module)

where "module" was given the type map() (due to calling var.field) in:

    # lib/absinthe/blueprint.ex:215
    module.__absinthe_blueprint__

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/absinthe/blueprint.ex:215: Absinthe.Blueprint.types_by_name/1

warning: incompatible types:

    map() !~ atom()

in expression:

    # lib/absinthe/blueprint.ex:178
    ext_blueprint.__absinthe_blueprint__

where "ext_blueprint" was given the type atom() in:

    # lib/absinthe/blueprint.ex:177
    is_atom(ext_blueprint)

where "ext_blueprint" was given the type map() (due to calling var.field) in:

    # lib/absinthe/blueprint.ex:178
    ext_blueprint.__absinthe_blueprint__

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/absinthe/blueprint.ex:178: Absinthe.Blueprint.extend_fields/2

warning: incompatible types:

    map() !~ atom()

in expression:

    # lib/absinthe/type.ex:56
    module.functions

where "module" was given the type atom() in:

    # lib/absinthe/type.ex:55
    %module{}

where "module" was given the type map() (due to calling var.field) in:

    # lib/absinthe/type.ex:56
    module.functions

HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

Conflict found at
  lib/absinthe/type.ex:56: Absinthe.Type.expand/1

warning: Mix.Project.compile/1 is deprecated. Use Mix.Task.run("compile", args) instead
  lib/mix/tasks/absinthe.schema.json.ex:81: Mix.Tasks.Absinthe.Schema.Json.run/1

warning: Mix.Project.compile/1 is deprecated. Use Mix.Task.run("compile", args) instead
  lib/mix/tasks/absinthe.schema.sdl.ex:50: Mix.Tasks.Absinthe.Schema.Sdl.run/1
```