### PR TITLE
Fix compilation bug with persistent_term backend

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -110,6 +110,18 @@ defmodule Absinthe.Schema do
 
       @schema_provider Absinthe.Schema.Compiled
 
+      @on_load :__on_load__
+      def __on_load__ do
+        if __absinthe_schema_provider__() == Absinthe.Schema.PersistentTerm do
+          Absinthe.Phase.Schema.PopulatePersistentTerm.run(__absinthe_blueprint__(),
+            prototype_schema: __absinthe_prototype_schema__(),
+            schema: __MODULE__
+          )
+        end
+
+        :ok
+      end
+
       def __absinthe_lookup__(name) do
         __absinthe_type__(name)
       end
@@ -140,6 +152,7 @@ defmodule Absinthe.Schema do
     end
   end
 
+  @deprecated "`Absinthe.Schema` process no longer needed, please remove it from your supervision tree."
   def child_spec(schema) do
     %{
       id: {__MODULE__, schema},

--- a/lib/absinthe/schema/manager.ex
+++ b/lib/absinthe/schema/manager.ex
@@ -5,24 +5,7 @@ defmodule Absinthe.Schema.Manager do
     GenServer.start_link(__MODULE__, schema, [])
   end
 
-  def init(schema_module) do
-    prototype_schema = schema_module.__absinthe_prototype_schema__
-
-    pipeline =
-      schema_module
-      |> Absinthe.Pipeline.for_schema(prototype_schema: prototype_schema)
-      |> Absinthe.Schema.apply_modifiers(schema_module)
-
-    schema_module.__absinthe_blueprint__
-    |> Absinthe.Pipeline.run(pipeline)
-    |> case do
-      {:ok, _, _} ->
-        []
-
-      {:error, errors, _} ->
-        raise Absinthe.Schema.Error, phase_errors: List.wrap(errors)
-    end
-
-    {:ok, schema_module}
+  def init(_schema_module) do
+    :ignore
   end
 end

--- a/lib/absinthe/schema/persistent_term.ex
+++ b/lib/absinthe/schema/persistent_term.ex
@@ -23,26 +23,13 @@ if Code.ensure_loaded?(:persistent_term) do
     ```
     @schema_provider Absinthe.Schema.PersistentTerm
     ```
-
-    In your application's supervision tree, prior to anywhere where you'd use
-    the schema:
-    ```
-    {Absinthe.Schema, MyAppWeb.Schema}
-    ```
-
-    where MyAppWeb.Schema is the name of your schema.
     """
 
     @behaviour Absinthe.Schema.Provider
 
     def pipeline(pipeline) do
-      Enum.map(pipeline, fn
-        {Absinthe.Phase.Schema.Compile, options} ->
-          {Absinthe.Phase.Schema.PopulatePersistentTerm, options}
-
-        phase ->
-          phase
-      end)
+      pipeline
+      |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.Compile)
     end
 
     def __absinthe_type__(schema_mod, name) do

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Absinthe.Mixfile do
       {:nimble_parsec, "~> 0.5"},
       {:telemetry, "~> 0.4.0"},
       {:dataloader, "~> 1.0.0", optional: true},
-      {:decimal, "~> 1.0 or ~> 2.0" , optional: true},
+      {:decimal, "~> 1.0 or ~> 2.0", optional: true},
       {:ex_doc, "~> 0.21.0", only: :dev},
       {:benchee, ">= 1.0.0", only: :dev},
       {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This PR fixes a compile time bug with the `persistent_term` schema backend.

`PopulatePersistentTerm.run/2` was only getting called during compilation. So if another file changes but not the schema module, it doesn't get re-compiled and thus it's not populated - this can cause compile-time references to the schema to fail.

This is fixed by populating the `persistent_term` backend upon `@on_load`. This also means we don't need to startup a GenServer in the user's app to populate, which paves the way for easier adoption of this in the future.

@benwilson512 
