### PR TITLE
Stable introspection ordering

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -593,7 +593,6 @@ defmodule Absinthe.Schema do
   def directives(schema) do
     schema.__absinthe_directives__
     |> Map.keys()
-    |> Enum.sort()
     |> Enum.map(&lookup_directive(schema, &1))
   end
 
@@ -646,7 +645,6 @@ defmodule Absinthe.Schema do
   def types(schema) do
     schema.__absinthe_types__
     |> Map.keys()
-    |> Enum.sort()
     |> Enum.map(&lookup_type(schema, &1))
   end
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -8,7 +8,11 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :types, list_of(:__type) do
       resolve fn _, %{schema: schema} ->
-        {:ok, Absinthe.Schema.types(schema)}
+        types =
+          Absinthe.Schema.types(schema)
+          |> Enum.sort_by(& &1.identifier)
+
+        {:ok, types}
       end
     end
 
@@ -33,7 +37,11 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :directives,
       type: list_of(:__directive),
       resolve: fn _, %{schema: schema} ->
-        {:ok, Absinthe.Schema.directives(schema)}
+        directives =
+          Absinthe.Schema.directives(schema)
+          |> Enum.sort_by(& &1.identifier)
+
+        {:ok, directives}
       end
   end
 
@@ -47,8 +55,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :args,
       type: list_of(:__inputvalue),
       resolve: fn _, %{source: source} ->
-        structs = source.args |> Map.values()
-        {:ok, structs}
+        args =
+          source.args
+          |> Map.values()
+          |> Enum.sort_by(& &1.identifier)
+
+        {:ok, args}
       end
 
     field :on_operation,
@@ -130,8 +142,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
                   []
               end
             end)
+            |> Enum.sort_by(& &1.identifier)
 
-          {:ok, Enum.sort_by(result, & &1.identifier)}
+          {:ok, result}
 
         _, _ ->
           {:ok, nil}
@@ -142,13 +155,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       type: list_of(:__type),
       resolve: fn
         _, %{schema: schema, source: %{interfaces: interfaces}} ->
-          structs =
+          interfaces =
             interfaces
-            |> Enum.map(fn ident ->
-              Absinthe.Schema.lookup_type(schema, ident)
-            end)
+            |> Enum.map(&Absinthe.Schema.lookup_type(schema, &1))
+            |> Enum.sort_by(& &1.identifier)
 
-          {:ok, structs}
+          {:ok, interfaces}
 
         _, _ ->
           {:ok, nil}
@@ -158,8 +170,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       type: list_of(:__type),
       resolve: fn
         _, %{schema: schema, source: %{types: types}} ->
-          structs = types |> Enum.map(&Absinthe.Schema.lookup_type(schema, &1))
-          {:ok, structs}
+          possible_types =
+            types
+            |> Enum.map(&Absinthe.Schema.lookup_type(schema, &1))
+            |> Enum.sort_by(& &1.identifier)
+
+          {:ok, possible_types}
 
         _, %{schema: schema, source: %Absinthe.Type.Interface{identifier: ident}} ->
           {:ok, Absinthe.Schema.implementors(schema, ident)}
@@ -187,6 +203,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
                 []
               end
             end)
+            |> Enum.sort_by(& &1.value)
 
           {:ok, result}
 
@@ -198,8 +215,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       type: list_of(:__inputvalue),
       resolve: fn
         _, %{source: %Absinthe.Type.InputObject{fields: fields}} ->
-          structs = fields |> Map.values()
-          {:ok, structs}
+          input_fields =
+            fields
+            |> Map.values()
+            |> Enum.sort_by(& &1.identifier)
+
+          {:ok, input_fields}
 
         _, %{source: _} ->
           {:ok, nil}
@@ -227,8 +248,13 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :args,
       type: list_of(:__inputvalue),
-      resolve: fn _, %{source: source} ->
-        {:ok, Map.values(source.args)}
+      resolve: fn _, %{source: %{args: args}} ->
+        args =
+          args
+          |> Map.values()
+          |> Enum.sort_by(& &1.identifier)
+
+        {:ok, args}
       end
 
     field :type,

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -94,7 +94,6 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
         json_codec: json_codec
       }) do
     with {:ok, result} <- Absinthe.Schema.introspect(schema) do
-      result = sort(result)
       content = json_codec.encode!(result, pretty: pretty)
       {:ok, content}
     else
@@ -140,20 +139,4 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
     create_directory(Path.dirname(filename))
     create_file(filename, content, force: true)
   end
-
-  defp sort(map) when is_map(map) do
-    Map.new(map, fn {key, val} -> {key, sort(val)} end)
-  end
-
-  defp sort(list) when is_list(list) do
-    list
-    |> Enum.sort_by(&list_sorting_value/1)
-    |> Enum.map(&sort/1)
-  end
-
-  defp sort(value), do: value
-
-  defp list_sorting_value(%{name: name}), do: name
-  defp list_sorting_value(%{"name" => name}), do: name
-  defp list_sorting_value(value), do: value
 end

--- a/test/absinthe/integration/execution/introspection/schema_types_test.exs
+++ b/test/absinthe/integration/execution/introspection/schema_types_test.exs
@@ -5,15 +5,33 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.SchemaTypesTest do
   query { __schema { types { name } } }
   """
 
+  @expected [
+    "__Directive",
+    "__DirectiveLocation",
+    "__EnumValue",
+    "__Field",
+    "__InputValue",
+    "__Schema",
+    "__Type",
+    "Boolean",
+    "Business",
+    "Contact",
+    "Int",
+    "RootMutationType",
+    "NamedEntity",
+    "Person",
+    "ProfileInput",
+    "RootQueryType",
+    "SearchResult",
+    "String",
+    "RootSubscriptionType"
+  ]
+
   test "scenario #1" do
     result = Absinthe.run(@query, Absinthe.Fixtures.ContactSchema, [])
     assert {:ok, %{data: %{"__schema" => %{"types" => types}}}} = result
-    names = types |> Enum.map(& &1["name"]) |> Enum.sort()
+    names = types |> Enum.map(& &1["name"])
 
-    expected =
-      ~w(Int String Boolean Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType RootSubscriptionType __Schema __Directive __DirectiveLocation __EnumValue __Field __InputValue __Type)
-      |> Enum.sort()
-
-    assert expected == names
+    assert @expected == names
   end
 end

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -60,7 +60,7 @@ defmodule Absinthe.IntrospectionTest do
                  "isDeprecated" => false,
                  "deprecationReason" => nil
                }
-             ] == values |> Enum.sort_by(& &1["name"])
+             ] == values
     end
 
     test "can use __type and value information without deprecations" do


### PR DESCRIPTION
This PR extends #959 to make sure lists (ex: `types`, `fields`, etc) are returned in a stable ordering in introspection queries.