### PR TITLE
Fix partial default value input type

### DIFF
--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -353,7 +353,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     case Absinthe.Schema.lookup_type(schema, type, unwrap: false) do
       %Absinthe.Type.InputObject{fields: fields} ->
         object_values =
-          Map.values(fields)
+          fields
+          |> Map.take(Map.keys(value))
+          |> Map.values()
           |> Enum.map(&render_default_value(schema, adapter, &1, value))
           |> Enum.join(", ")
 

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -545,4 +545,36 @@ defmodule Absinthe.IntrospectionTest do
       result
     )
   end
+
+  test "properly render partial default value input objects" do
+    {:ok, result} =
+      """
+      {
+        __schema {
+          queryType {
+            fields {
+              name
+              args {
+                name
+                defaultValue
+              }
+            }
+          }
+        }
+      }
+      """
+      |> run(Absinthe.Fixtures.ArgumentsSchema)
+
+    fields = get_in(result, [:data, "__schema", "queryType", "fields"])
+
+    assert %{
+             "args" => [
+               %{"defaultValue" => "{exclude: [2, 3], include: [1]}", "name" => "filterAll"},
+               %{"defaultValue" => "{}", "name" => "filterEmpty"},
+               %{"defaultValue" => "{exclude: [1, 2, 3]}", "name" => "filterExclude"},
+               %{"defaultValue" => "{include: [1, 2, 3]}", "name" => "filterInclude"}
+             ],
+             "name" => "filterNumbers"
+           } in fields
+  end
 end

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -56,6 +56,11 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
     field :non_null_field, non_null(:string)
   end
 
+  input_object :filter do
+    field :include, list_of(:integer)
+    field :exclude, list_of(:integer)
+  end
+
   query do
     field :stuff, :integer do
       arg :stuff, non_null(:input_stuff)
@@ -63,6 +68,13 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
       resolve fn _, _ ->
         {:ok, 14}
       end
+    end
+
+    field :filter_numbers, list_of(:integer) do
+      arg :filter_empty, :filter, default_value: %{}
+      arg :filter_include, :filter, default_value: %{include: [1, 2, 3]}
+      arg :filter_exclude, :filter, default_value: %{exclude: [1, 2, 3]}
+      arg :filter_all, :filter, default_value: %{include: [1], exclude: [2, 3]}
     end
 
     field :test_boolean_input_object, :boolean do


### PR DESCRIPTION
This PR fixes the default value rendering in cases when the default value contains just a subset of all the fields of an input type.

Fixes #939