### PR TITLE
Add support for repeatable directives

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -32,6 +32,7 @@ locals_without_parens = [
   object: 3,
   on: 1,
   parse: 1,
+  repeatable: 1,
   resolve: 1,
   resolve_type: 1,
   scalar: 2,

--- a/lib/absinthe/blueprint/schema/directive_definition.ex
+++ b/lib/absinthe/blueprint/schema/directive_definition.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
     directives: [],
     arguments: [],
     locations: [],
+    repeatable: false,
     source_location: nil,
     expand: nil,
     errors: [],
@@ -24,6 +25,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
           description: nil,
           arguments: [Blueprint.Schema.InputValueDefinition.t()],
           locations: [String.t()],
+          repeatable: boolean(),
           source_location: nil | Blueprint.SourceLocation.t(),
           errors: [Absinthe.Phase.Error.t()]
         }
@@ -36,6 +38,7 @@ defmodule Absinthe.Blueprint.Schema.DirectiveDefinition do
       args: Blueprint.Schema.ObjectTypeDefinition.build_args(type_def, schema),
       locations: type_def.locations |> Enum.sort(),
       definition: type_def.module,
+      repeatable: type_def.repeatable,
       expand: type_def.expand
     }
   end

--- a/lib/absinthe/language.ex
+++ b/lib/absinthe/language.ex
@@ -9,6 +9,7 @@ defmodule Absinthe.Language do
           Language.Argument.t()
           | Language.BooleanValue.t()
           | Language.Directive.t()
+          | Language.DirectiveDefinition.t()
           | Language.Document.t()
           | Language.EnumTypeDefinition.t()
           | Language.EnumValue.t()

--- a/lib/absinthe/language/directive_definition.ex
+++ b/lib/absinthe/language/directive_definition.ex
@@ -8,7 +8,8 @@ defmodule Absinthe.Language.DirectiveDefinition do
             arguments: [],
             directives: [],
             locations: [],
-            loc: %{line: nil}
+            loc: %{line: nil},
+            repeatable: false
 
   @type t :: %__MODULE__{
           name: String.t(),
@@ -16,7 +17,8 @@ defmodule Absinthe.Language.DirectiveDefinition do
           directives: [Language.Directive.t()],
           arguments: [Language.Argument.t()],
           locations: [String.t()],
-          loc: Language.loc_t()
+          loc: Language.loc_t(),
+          repeatable: boolean()
         }
 
   defimpl Blueprint.Draft do
@@ -28,6 +30,7 @@ defmodule Absinthe.Language.DirectiveDefinition do
         arguments: Absinthe.Blueprint.Draft.convert(node.arguments, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         locations: node.locations,
+        repeatable: node.repeatable,
         source_location: source_location(node)
       }
     end

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -302,6 +302,7 @@ defmodule Absinthe.Lexer do
     on
     ON
     query
+    repeatable
     scalar
     schema
     subscription

--- a/lib/absinthe/phase/document/validation/repeatable_directives.ex
+++ b/lib/absinthe/phase/document/validation/repeatable_directives.ex
@@ -1,0 +1,86 @@
+defmodule Absinthe.Phase.Document.Validation.RepeatableDirectives do
+  @moduledoc false
+
+  alias Absinthe.{Blueprint, Phase}
+
+  use Absinthe.Phase
+  use Absinthe.Phase.Validation
+
+  @doc """
+  Run the validation.
+  """
+  @spec run(Blueprint.t(), Keyword.t()) :: Phase.result_t()
+  def run(input, _options \\ []) do
+    result = Blueprint.postwalk(input, &handle_node/1)
+    {:ok, result}
+  end
+
+  defp handle_node(%Blueprint.Directive{} = node) do
+    node
+  end
+
+  defp handle_node(%{directives: []} = node) do
+    node
+  end
+
+  defp handle_node(%{directives: _} = node) do
+    node
+    |> check_directives
+    |> inherit_invalid(node.directives, :bad_directive)
+  end
+
+  defp handle_node(node) do
+    node
+  end
+
+  defp check_directives(node) do
+    directives =
+      for directive <- node.directives do
+        case directive do
+          %{schema_node: nil} ->
+            directive
+
+          %{schema_node: %{repeatable: true}} ->
+            directive
+
+          directive ->
+            check_duplicates(
+              directive,
+              Enum.filter(
+                node.directives,
+                &compare_directive_schema_node(directive.schema_node, &1.schema_node)
+              )
+            )
+        end
+      end
+
+    %{node | directives: directives}
+  end
+
+  defp compare_directive_schema_node(_, nil), do: false
+
+  defp compare_directive_schema_node(%{identifier: identifier}, %{identifier: identifier}),
+    do: true
+
+  defp compare_directive_schema_node(_, _), do: false
+
+  # Generate the error for the node
+  @spec error_repeated(Blueprint.node_t()) :: Phase.Error.t()
+  defp error_repeated(node) do
+    %Phase.Error{
+      phase: __MODULE__,
+      message: "Directive `#{node.name}' cannot be applied repeatedly.",
+      locations: [node.source_location]
+    }
+  end
+
+  defp check_duplicates(directive, [_single]) do
+    directive
+  end
+
+  defp check_duplicates(directive, _multiple) do
+    directive
+    |> flag_invalid(:duplicate_directive)
+    |> put_error(error_repeated(directive))
+  end
+end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -85,6 +85,7 @@ defmodule Absinthe.Pipeline do
       Phase.Document.Arguments.FlagInvalid,
       # Validate Full Document
       Phase.Document.Validation.KnownDirectives,
+      Phase.Document.Validation.RepeatableDirectives,
       Phase.Document.Validation.ScalarLeafs,
       Phase.Document.Validation.VariablesAreInputTypes,
       Phase.Document.Validation.ArgumentsOfCorrectType,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -912,6 +912,23 @@ defmodule Absinthe.Schema.Notation do
     |> record_expand!(func_ast)
   end
 
+  @placement {:repeatable, [under: [:directive]]}
+  @doc """
+  Set whether the directive can be applied multiple times
+  an entity.
+
+  If omitted, defaults to `false`
+
+  ## Placement
+
+  #{Utils.placement_docs(@placement)}
+  """
+  defmacro repeatable(bool) do
+    __CALLER__
+    |> recordable!(:repeatable, @placement[:repeatable])
+    |> record_repeatable!(bool)
+  end
+
   # INPUT OBJECTS
 
   @placement {:input_object, [toplevel: true]}
@@ -1303,6 +1320,11 @@ defmodule Absinthe.Schema.Notation do
   # Record a directive expand function in the current scope
   def record_expand!(env, func_ast) do
     put_attr(env.module, {:expand, func_ast})
+  end
+
+  @doc false
+  def record_repeatable!(env, bool) do
+    put_attr(env.module, {:repeatable, bool})
   end
 
   @doc false

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -192,6 +192,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       "directive ",
       concat("@", string(directive.name)),
       arguments(directive.arguments, type_definitions),
+      repeatable(directive.repeatable),
       " on ",
       join(locations, " | ")
     ])
@@ -440,6 +441,9 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
 
   defp block_string_line(["", _ | _]), do: nest(line(), :reset)
   defp block_string_line(_), do: line()
+
+  defp repeatable(true), do: " repeatable"
+  defp repeatable(_), do: empty()
 
   def join(docs, joiner) do
     fold_doc(docs, fn doc, acc ->

--- a/lib/absinthe/type/built_ins/directives.ex
+++ b/lib/absinthe/type/built_ins/directives.ex
@@ -13,6 +13,8 @@ defmodule Absinthe.Type.BuiltIns.Directives do
 
     on [:field, :fragment_spread, :inline_fragment]
 
+    repeatable false
+
     expand fn
       %{if: true}, node ->
         Blueprint.put_flag(node, :include, __MODULE__)
@@ -26,6 +28,8 @@ defmodule Absinthe.Type.BuiltIns.Directives do
     description """
     Directs the executor to skip this field or fragment when the `if` argument is true.
     """
+
+    repeatable false
 
     arg :if, non_null(:boolean), description: "Skipped when true."
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -48,17 +48,17 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
   object :__directive do
     description "Represents a directive"
 
-    field :name, :string
+    field :name, non_null(:string)
 
     field :description, :string
 
-    field :is_repeatable, :boolean,
+    field :is_repeatable, non_null(:boolean),
       resolve: fn _, %{source: source} ->
         {:ok, source.repeatable}
       end
 
     field :args,
-      type: list_of(:__inputvalue),
+      type: non_null(list_of(non_null(:__inputvalue))),
       resolve: fn _, %{source: source} ->
         args =
           source.args
@@ -89,7 +89,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
         {:ok, Enum.member?(source.locations, :field)}
       end
 
-    field :locations, list_of(:__directive_location)
+    field :locations, non_null(list_of(non_null(:__directive_location)))
   end
 
   enum :__directive_location,

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -52,6 +52,11 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :description, :string
 
+    field :is_repeatable, :boolean,
+      resolve: fn _, %{source: source} ->
+        {:ok, source.repeatable}
+      end
+
     field :args,
       type: list_of(:__inputvalue),
       resolve: fn _, %{source: source} ->

--- a/lib/absinthe/type/directive.ex
+++ b/lib/absinthe/type/directive.ex
@@ -17,6 +17,7 @@ defmodule Absinthe.Type.Directive do
   * `:description` - A nice description for introspection.
   * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/2`.
   * `:locations` - A list of places the directives can be used.
+  * `:repeatable` - A directive may be defined as repeatable by including the “repeatable” keyword
 
   The `:__reference__` key is for internal use.
   """
@@ -28,6 +29,7 @@ defmodule Absinthe.Type.Directive do
           locations: [location],
           expand: (map, Absinthe.Blueprint.node_t() -> atom),
           definition: module,
+          repeatable: boolean,
           __private__: Keyword.t(),
           __reference__: Type.Reference.t()
         }
@@ -42,6 +44,7 @@ defmodule Absinthe.Type.Directive do
             locations: [],
             expand: nil,
             definition: nil,
+            repeatable: false,
             __private__: [],
             __reference__: nil
 

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -17,7 +17,7 @@ Nonterminals
 
 Terminals
   '{' '}' '(' ')' '[' ']' '!' ':' '@' '$' '=' '|' '...'
-  'query' 'mutation' 'subscription' 'fragment' 'on' 'directive'
+  'query' 'mutation' 'subscription' 'fragment' 'on' 'directive' 'repeatable'
   'type' 'implements' 'interface' 'union' 'scalar' 'enum' 'input' 'extend' 'schema'
   name int_value float_value string_value block_string_value boolean_value null.
 
@@ -193,6 +193,18 @@ DirectiveDefinition -> 'directive' '@' Name 'on' DirectiveDefinitionLocations Di
   build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'directives' => '$6', 'locations' => extract_directive_locations('$5')}, extract_location('$1')).
 DirectiveDefinition -> 'directive' '@' Name ArgumentsDefinition 'on' DirectiveDefinitionLocations Directives :
   build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'arguments' => '$4', 'directives' => '$7', 'locations' => extract_directive_locations('$6')}, extract_location('$1')).
+
+DirectiveDefinition -> 'directive' '@' Name 'repeatable' 'on' DirectiveDefinitionLocations :
+  build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'locations' => extract_directive_locations('$6'), 'repeatable' => true}, extract_location('$1')).
+DirectiveDefinition -> 'directive' '@' Name ArgumentsDefinition 'repeatable' 'on' DirectiveDefinitionLocations :
+  build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'arguments' => '$4', 'locations' => extract_directive_locations('$7'), 'repeatable' => true}, extract_location('$1')).
+
+DirectiveDefinition -> 'directive' '@' Name 'repeatable' 'on' DirectiveDefinitionLocations Directives :
+  build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'directives' => '$7', 'locations' => extract_directive_locations('$6'), 'repeatable' => true}, extract_location('$1')).
+DirectiveDefinition -> 'directive' '@' Name ArgumentsDefinition 'repeatable' 'on' DirectiveDefinitionLocations Directives :
+  build_ast_node('DirectiveDefinition', #{'name' => extract_binary('$3'), 'arguments' => '$4', 'directives' => '$8', 'locations' => extract_directive_locations('$7'), 'repeatable' => true}, extract_location('$1')).
+
+
 
 SchemaDefinition -> 'schema' : build_ast_node('SchemaDeclaration', #{}, extract_location('$1')).
 SchemaDefinition -> 'schema' Directives : build_ast_node('SchemaDeclaration', #{'directives' => '$2'}, extract_location('$1')).

--- a/test/absinthe/integration/execution/introspection/directives_test.exs
+++ b/test/absinthe/integration/execution/introspection/directives_test.exs
@@ -8,6 +8,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.DirectivesTest do
         name
         args { name type { kind ofType { name kind } } }
         locations
+        isRepeatable
         onField
         onFragment
         onOperation
@@ -36,7 +37,8 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.DirectivesTest do
                       "name" => "include",
                       "onField" => true,
                       "onFragment" => true,
-                      "onOperation" => false
+                      "onOperation" => false,
+                      "isRepeatable" => false
                     },
                     %{
                       "args" => [
@@ -52,7 +54,8 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.DirectivesTest do
                       "name" => "skip",
                       "onField" => true,
                       "onFragment" => true,
-                      "onOperation" => false
+                      "onOperation" => false,
+                      "isRepeatable" => false
                     }
                   ]
                 }

--- a/test/absinthe/language/directive_definition_test.exs
+++ b/test/absinthe/language/directive_definition_test.exs
@@ -5,8 +5,19 @@ defmodule Absinthe.Language.DirectiveDefinitionTest do
 
   describe "blueprint conversion" do
     test "works, given a Blueprint Schema 'directive' definition without arguments" do
-      assert %Blueprint.Schema.DirectiveDefinition{name: "thingy", locations: [:field, :object]} =
-               from_input("directive @thingy on FIELD | OBJECT")
+      assert %Blueprint.Schema.DirectiveDefinition{
+               name: "thingy",
+               locations: [:field, :object],
+               repeatable: false
+             } = from_input("directive @thingy on FIELD | OBJECT")
+    end
+
+    test "works, given a Blueprint Schema 'repeatable' 'directive' definition without arguments" do
+      assert %Blueprint.Schema.DirectiveDefinition{
+               name: "thingy",
+               locations: [:field, :object],
+               repeatable: true
+             } = from_input("directive @thingy repeatable on FIELD | OBJECT")
     end
 
     test "works, given a Blueprint Schema 'directive' definition without arguments and with directives" do

--- a/test/absinthe/phase/document/validation/repeatable_directives_test.exs
+++ b/test/absinthe/phase/document/validation/repeatable_directives_test.exs
@@ -1,0 +1,45 @@
+defmodule Absinthe.Phase.Document.Validation.RepeatableDirectivesTest do
+  @phase Absinthe.Phase.Document.Validation.RepeatableDirectives
+
+  use Absinthe.ValidationPhaseCase,
+    phase: @phase,
+    async: true
+
+  alias Absinthe.Blueprint
+
+  defp duplicate(name, line) do
+    bad_value(
+      Blueprint.Directive,
+      "Directive `#{name}' cannot be applied repeatedly.",
+      line,
+      name: name
+    )
+  end
+
+  test "with disallowed repeated directives" do
+    assert_fails_validation(
+      """
+      query Foo {
+        skippedField @skip(if: true) @skip(if: true)
+      }
+      """,
+      [],
+      duplicate("skip", 2)
+    )
+  end
+
+  test "with allowed repeated directives" do
+    assert_passes_validation(
+      """
+      query Foo {
+        skippedField @onField @onField
+      }
+
+      mutation Bar @onMutation {
+        someField
+      }
+      """,
+      []
+    )
+  end
+end

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -21,7 +21,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
     # Embedded SDL
     import_sdl """
-    directive @foo(name: String!) on SCALAR | OBJECT
+    directive @foo(name: String!) repeatable on SCALAR | OBJECT
     directive @bar(name: String!) on SCALAR | OBJECT
 
     type Query {
@@ -254,7 +254,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
   describe "directives" do
     test "can be defined" do
-      assert %{name: "foo", identifier: :foo, locations: [:object, :scalar]} =
+      assert %{name: "foo", identifier: :foo, locations: [:object, :scalar], repeatable: true} =
                lookup_compiled_directive(Definition, :foo)
 
       assert %{name: "bar", identifier: :bar, locations: [:object, :scalar]} =

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -11,7 +11,7 @@ defmodule SdlRenderTest do
       query: Query
     }
 
-    directive @foo(name: String!) on OBJECT | SCALAR
+    directive @foo(name: String!) repeatable on OBJECT | SCALAR
 
     interface Animal {
       legCount: Int!

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -207,6 +207,7 @@ defmodule Absinthe.Fixtures.PetsSchema do
   end
 
   directive :on_field do
+    repeatable true
     on [:field]
   end
 


### PR DESCRIPTION
Adds support for repeatable directives as defined by the spec (https://spec.graphql.org/draft/#sec-Type-System.Directives). See https://github.com/graphql/graphql-spec/pull/472 where the RFC was merged for more information.

This PR does several things:
  * adds support for the `repeatable` keyword for directives  in the parser
  * directives by default have `repeatable` set to false
  * renders directives with `repeatable` in SDL
  * adds `isRepeatable` to the directive type available for introspection
  * adds `repeatable(true|false)` to the schema definition macro's placed under directive
  * adds validation phase in the document pipeline to check whether a non-repeatable phase is applied multiple times
  * changes the directive type to match the spec (other built-in types could also be tightened with `non_null` declarations to closer match the spec, but can be done in a separate PR)

In theory this could be a breaking change, i.e. if the built-in directives were applied multiple times to the same field in a document this will now trigger an error. 