### PR TITLE
Account for `nil` schema_node in ArgumentsOfCorrectType suggestions

### DIFF
--- a/lib/absinthe/phase/document/validation/arguments_of_correct_type.ex
+++ b/lib/absinthe/phase/document/validation/arguments_of_correct_type.ex
@@ -84,6 +84,7 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType do
           case Type.unwrap(node.schema_node) do
             %Type.Scalar{} -> []
             %Type.Enum{} -> []
+            nil -> []
             _ -> suggested_field_names(node.schema_node, child.name)
           end
 

--- a/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
@@ -974,6 +974,36 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectTypeTest do
     end
   end
 
+  describe "Invalid Custom Scalar value" do
+    test "Invalid scalar input on mutation, no suggestion" do
+      assert_fails_validation(
+        """
+        mutation($scalarInput: CustomScalar) {
+          createDog(customScalarInput: $scalarInput)
+        }
+        """,
+        [
+          variables: %{
+            "scalarInput" => [
+              %{
+                "foo" => "BAR"
+              }
+            ]
+          }
+        ],
+        [
+          bad_argument(
+            "customScalarInput",
+            "CustomScalar",
+            ~s($scalarInput),
+            2,
+            [@phase.unknown_field_error_message("foo")]
+          )
+        ]
+      )
+    end
+  end
+
   describe "Directive arguments" do
     test "with directives of valid types" do
       assert_passes_validation(

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -124,17 +124,7 @@ defmodule Absinthe.Fixtures.PetsSchema do
   end
 
   scalar :custom_scalar do
-    parse fn
-      %Absinthe.Blueprint.Input.Object{} = input ->
-        {:ok, input}
-
-      %Absinthe.Blueprint.Input.Null{} ->
-        {:ok, nil}
-
-      _other ->
-        :error
-    end
-
+    parse & &1
     serialize & &1
   end
 

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -123,6 +123,21 @@ defmodule Absinthe.Fixtures.PetsSchema do
     field :string_list_field, list_of(:string)
   end
 
+  scalar :custom_scalar do
+    parse fn
+      %Absinthe.Blueprint.Input.Object{} = input ->
+        {:ok, input}
+
+      %Absinthe.Blueprint.Input.Null{} ->
+        {:ok, nil}
+
+      _other ->
+        :error
+    end
+
+    serialize & &1
+  end
+
   object :complicated_args do
     field :int_arg_field, :string do
       arg :int_arg, :integer
@@ -192,6 +207,12 @@ defmodule Absinthe.Fixtures.PetsSchema do
     field :dog_or_human, :dog_or_human
     field :human_or_alien, :human_or_alien
     field :complicated_args, :complicated_args
+  end
+
+  mutation do
+    field :create_dog, :dog do
+      arg :custom_scalar_input, non_null(:custom_scalar)
+    end
   end
 
   directive :on_query do


### PR DESCRIPTION
When unstructured scalar input is sent in a list to a mutation argument (see example), the `schema_node` in the `ArgumentsOfCorrectType.suggested_field_names/2` function is `nil`. I accounted for the case at the source of the error, but it is totally possible that the blueprint should account for this case and the `schema_node` should be something other than `nil`. I will defer to y'all's knowledge on that though.
 
**Mutation example:**
```
mutation($scalarInput: CustomScalar) {
    createDog(customScalarInput: $scalarInput)
}
variables: { "scalarInput": [ {"foo": "BAR"} ] }
```

**Stacktrace:** 
```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function nil.fields/0 is undefined
        nil.fields()
        (absinthe 1.5.4) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:125: Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.suggested_field_names/2
        (absinthe 1.5.4) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:87: anonymous fn/3 in Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.collect_child_errors/2
        (elixir 1.10.4) lib/enum.ex:3343: Enum.flat_map_list/2
        (absinthe 1.5.4) lib/absinthe/phase/document/validation/arguments_of_correct_type.ex:33: Absinthe.Phase.Document.Validation.ArgumentsOfCorrectType.handle_node/2
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:16: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.4) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.4) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.4) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        (absinthe 1.5.4) lib/absinthe/blueprint/transform.ex:15: Absinthe.Blueprint.Transform.prewalk/2
```