### PR TITLE
Add `isRepeatable` to Introspection query

### DIFF
--- a/priv/graphql/introspection.graphql
+++ b/priv/graphql/introspection.graphql
@@ -10,6 +10,7 @@ query IntrospectionQuery {
       name
       description
       locations
+      isRepeatable
       args {
         ...InputValue
       }


### PR DESCRIPTION
Followup to #999 

This PR adds `isRepeatable` to `directives` in the `IntrospectionQuery` now that it's supported by Absinthe

@maartenvanvliet @benwilson512 