### PR TITLE
Ensure interface nullable types can be implemented by non-nullable types

### DIFF
--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -164,6 +164,15 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
     check_covariant(inner_type1, inner_type2, field_ident, types)
   end
 
+  defp check_covariant(
+         itype,
+         %Absinthe.Blueprint.TypeReference.NonNull{of_type: inner_type},
+         field_ident,
+         types
+       ) do
+    check_covariant(itype, inner_type, field_ident, types)
+  end
+
   defp check_covariant(%{identifier: identifier}, %{identifier: identifier}, _field_ident, _types) do
     :ok
   end

--- a/test/support/fixtures/dynamic/invalid_interface_types.exs
+++ b/test/support/fixtures/dynamic/invalid_interface_types.exs
@@ -20,7 +20,7 @@ defmodule Absinthe.Fixtures.InvalidInterfaceTypes do
   end
 
   interface :named do
-    field :name, :string
+    field :name, non_null(:string)
   end
 
   query do


### PR DESCRIPTION
Fixes https://github.com/absinthe-graphql/absinthe/issues/987

Two cases are added to the schema:
 * a simple nullable interface -> non-nullable implementor.
 * a nullable list -> with implementors `list_of(non_null(type))` and
   `non_null(list_of(non_null(type)))`.

From my reading of the spec these should all validate.

https://spec.graphql.org/draft/#IsValidImplementationFieldType()

I did find that it is not validated whether the object implements
the field's arguments as specified by the interface. Also that the object
does not implement extra non-nullable arguments that are not specified in the interface.

From the spec
```
field must include an argument of the same name for every argument defined in implementedField.

    That named argument on field must accept the same type (invariant) as that named argument on implementedField.

field may include additional arguments not defined in implementedField, but any additional argument must not be required, e.g. must not be of a non‐nullable type.
```

I'll create an issue for this.
