### PR TITLE
Add support for interface implementing other interfaces

### DIFF
--- a/lib/absinthe/blueprint/schema/interface_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/interface_type_definition.ex
@@ -12,6 +12,8 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
     description: nil,
     fields: [],
     directives: [],
+    interfaces: [],
+    interface_blueprints: [],
     source_location: nil,
     # Added by phases
     flags: %{},
@@ -27,6 +29,8 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
           description: nil | String.t(),
           fields: [Blueprint.Schema.FieldDefinition.t()],
           directives: [Blueprint.Directive.t()],
+          interfaces: [String.t()],
+          interface_blueprints: [Blueprint.Draft.t()],
           source_location: nil | Blueprint.SourceLocation.t(),
           # Added by phases
           flags: Blueprint.flags_t(),
@@ -40,12 +44,15 @@ defmodule Absinthe.Blueprint.Schema.InterfaceTypeDefinition do
       fields: Blueprint.Schema.ObjectTypeDefinition.build_fields(type_def, schema),
       identifier: type_def.identifier,
       resolve_type: type_def.resolve_type,
-      definition: type_def.module
+      definition: type_def.module,
+      interfaces: type_def.interfaces
     }
   end
 
+  @interface_types [Schema.ObjectTypeDefinition, Schema.InterfaceTypeDefinition]
+
   def find_implementors(iface, type_defs) do
-    for %Schema.ObjectTypeDefinition{} = obj <- type_defs,
+    for %struct{} = obj when struct in @interface_types <- type_defs,
         iface.identifier in obj.interfaces,
         do: obj.identifier
   end

--- a/lib/absinthe/blueprint/transform.ex
+++ b/lib/absinthe/blueprint/transform.ex
@@ -83,7 +83,7 @@ defmodule Absinthe.Blueprint.Transform do
     Blueprint.Schema.FieldDefinition => [:type, :arguments, :directives],
     Blueprint.Schema.InputObjectTypeDefinition => [:fields, :directives],
     Blueprint.Schema.InputValueDefinition => [:type, :default_value, :directives],
-    Blueprint.Schema.InterfaceTypeDefinition => [:fields, :directives],
+    Blueprint.Schema.InterfaceTypeDefinition => [:interfaces, :fields, :directives],
     Blueprint.Schema.ObjectTypeDefinition => [:interfaces, :fields, :directives],
     Blueprint.Schema.ScalarTypeDefinition => [:directives],
     Blueprint.Schema.SchemaDefinition => [:directive_definitions, :type_definitions, :directives],

--- a/lib/absinthe/language/interface_type_definition.ex
+++ b/lib/absinthe/language/interface_type_definition.ex
@@ -7,6 +7,7 @@ defmodule Absinthe.Language.InterfaceTypeDefinition do
             description: nil,
             fields: [],
             directives: [],
+            interfaces: [],
             loc: %{line: nil}
 
   @type t :: %__MODULE__{
@@ -14,6 +15,7 @@ defmodule Absinthe.Language.InterfaceTypeDefinition do
           description: nil | String.t(),
           fields: [Language.FieldDefinition.t()],
           directives: [Language.Directive.t()],
+          interfaces: [Language.NamedType.t()],
           loc: Language.loc_t()
         }
 
@@ -25,8 +27,16 @@ defmodule Absinthe.Language.InterfaceTypeDefinition do
         identifier: Macro.underscore(node.name) |> String.to_atom(),
         fields: Absinthe.Blueprint.Draft.convert(node.fields, doc),
         directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
+        interfaces: interfaces(node.interfaces, doc),
+        interface_blueprints: Absinthe.Blueprint.Draft.convert(node.interfaces, doc),
         source_location: source_location(node)
       }
+    end
+
+    defp interfaces(interfaces, doc) do
+      interfaces
+      |> Absinthe.Blueprint.Draft.convert(doc)
+      |> Enum.map(&(&1.name |> Macro.underscore() |> String.to_atom()))
     end
 
     defp source_location(%{loc: nil}), do: nil

--- a/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
+++ b/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
@@ -53,7 +53,7 @@ defmodule Absinthe.Phase.Schema.Validation.NoInterfaceCyles do
     implementor
   end
 
-  # Add an edge, modeling the relationship between two fragments
+  # Add an edge, modeling the relationship between two interfaces
   defp edge(implementor, interface, graph) do
     :digraph.add_vertex(graph, interface)
 

--- a/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
+++ b/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
@@ -1,0 +1,83 @@
+defmodule Absinthe.Phase.Schema.Validation.NoInterfaceCyles do
+  @moduledoc false
+
+  use Absinthe.Phase
+  alias Absinthe.Blueprint
+  alias Absinthe.Blueprint.Schema
+
+  def run(blueprint, _opts) do
+    blueprint = check(blueprint)
+
+    {:ok, blueprint}
+  end
+
+  defp check(blueprint) do
+    graph = :digraph.new([:cyclic])
+
+    try do
+      _ = build_interface_graph(blueprint, graph)
+
+      Blueprint.prewalk(blueprint, &validate_schema(&1, graph))
+    after
+      :digraph.delete(graph)
+    end
+  end
+
+  defp validate_schema(%Schema.InterfaceTypeDefinition{interfaces: []} = interface, graph) do
+    interface
+  end
+
+  defp validate_schema(%Schema.InterfaceTypeDefinition{} = interface, graph) do
+    if cycle = :digraph.get_cycle(graph, interface.identifier) do
+      interface |> put_error(error(interface, cycle))
+    else
+      interface
+    end
+  end
+
+  defp validate_schema(node, _graph) do
+    node
+  end
+
+  defp build_interface_graph(blueprint, graph) do
+    _ = Blueprint.prewalk(blueprint, &vertex(&1, graph))
+  end
+
+  defp vertex(%Schema.InterfaceTypeDefinition{} = iface, graph) do
+    :digraph.add_vertex(graph, iface.identifier)
+
+    for interface <- iface.interfaces do
+      edge(iface, interface, graph)
+    end
+
+    iface
+  end
+
+  defp vertex(iface, _graph) do
+    iface
+  end
+
+  # Add an edge, modeling the relationship between two fragments
+
+  defp edge(interface, spread, graph) do
+    :digraph.add_vertex(graph, spread)
+
+    :digraph.add_edge(graph, interface.identifier, spread)
+
+    true
+  end
+
+  defp error(type, deps) do
+    %Absinthe.Phase.Error{
+      message:
+        String.trim("""
+        Interface Cycle Error
+
+        Interface `#{type.identifier}' forms a cycle via: (#{inspect(deps)})
+        """),
+      locations: [type.__reference__.location],
+      phase: __MODULE__,
+      extra: type.identifier
+    }
+  end
+end

--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -25,7 +25,12 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
     obj
   end
 
-  defp validate_objects(%Blueprint.Schema.ObjectTypeDefinition{} = object, ifaces, types) do
+  @interface_types [
+    Blueprint.Schema.ObjectTypeDefinition,
+    Blueprint.Schema.InterfaceTypeDefinition
+  ]
+
+  defp validate_objects(%struct{} = object, ifaces, types) when struct in @interface_types do
     Enum.reduce(object.interfaces, object, fn ident, object ->
       case Map.fetch(ifaces, ident) do
         {:ok, iface} -> validate_object(object, iface, types)

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -150,6 +150,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.Validation.InterfacesMustResolveTypes,
       Phase.Schema.Validation.ObjectInterfacesMustBeValid,
       Phase.Schema.Validation.ObjectMustImplementInterfaces,
+      Phase.Schema.Validation.NoInterfaceCyles,
       Phase.Schema.Validation.QueryTypeMustBeObject,
       Phase.Schema.Validation.NamesMustBeValid,
       Phase.Schema.RegisterTriggers,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -220,7 +220,7 @@ defmodule Absinthe.Schema.Notation do
     )
   end
 
-  @placement {:interfaces, [under: [:object]]}
+  @placement {:interfaces, [under: [:object, :interface]]}
   @doc """
   Declare implemented interfaces for an object.
 
@@ -299,7 +299,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
-  @placement {:interface_attribute, [under: [:object]]}
+  @placement {:interface_attribute, [under: [:object, :interface]]}
   defmacro interface(identifier) do
     __CALLER__
     |> recordable!(:interface_attribute, @placement[:interface_attribute])

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -173,6 +173,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       "interface",
       concat([
         string(interface_type.name),
+        implements(interface_type, type_definitions),
         directives(interface_type.directives, type_definitions)
       ]),
       render_list(interface_type.fields, type_definitions)

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -63,6 +63,7 @@ defmodule Absinthe.Type.Interface do
           description: binary,
           fields: map,
           identifier: atom,
+          interfaces: [Absinthe.Type.Interface.t()],
           __private__: Keyword.t(),
           definition: module,
           __reference__: Type.Reference.t()
@@ -73,6 +74,7 @@ defmodule Absinthe.Type.Interface do
             fields: nil,
             identifier: nil,
             resolve_type: nil,
+            interfaces: [],
             __private__: [],
             definition: nil,
             __reference__: nil

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -261,6 +261,11 @@ InterfaceTypeDefinition -> 'interface' Name '{' FieldDefinitionList '}' :
   build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, extract_location('$1')).
 InterfaceTypeDefinition -> 'interface' Name Directives '{' FieldDefinitionList '}' :
   build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'directives' => '$3', 'fields' => '$5'}, extract_location('$1')).
+InterfaceTypeDefinition -> 'interface' Name ImplementsInterfaces '{' FieldDefinitionList '}' :
+  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'interfaces' => '$3', 'fields' => '$5'}, extract_location('$1')).
+InterfaceTypeDefinition -> 'interface' Name ImplementsInterfaces Directives '{' FieldDefinitionList '}' :
+  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'interfaces' => '$3', 'directives' => '$4', 'fields' => '$6'}, extract_location('$1')).
+
 
 UnionTypeDefinition -> 'union' Name :
   build_ast_node('UnionTypeDefinition', #{'name' => extract_binary('$2')}, extract_location('$1')).

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -204,7 +204,7 @@ defmodule Absinthe.Schema.NotationTest do
           interface :foo
         end
         """,
-        "Invalid schema notation: `interface_attribute` must only be used within `object`"
+        "Invalid schema notation: `interface_attribute` must only be used within `object`, `interface`"
       )
     end
   end
@@ -232,7 +232,7 @@ defmodule Absinthe.Schema.NotationTest do
         end
         interfaces [:bar]
         """,
-        "Invalid schema notation: `interfaces` must only be used within `object`"
+        "Invalid schema notation: `interfaces` must only be used within `object`, `interface`"
       )
     end
   end

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -211,12 +211,25 @@ defmodule Absinthe.Schema.NotationTest do
 
   describe "interfaces" do
     test "can be under object as an attribute" do
-      assert_no_notation_error("InterfacesValid", """
+      assert_no_notation_error("ObjectInterfacesValid", """
       interface :bar do
         field :name, :string
         resolve_type fn _, _ -> :foo end
       end
       object :foo do
+        field :name, :string
+        interfaces [:bar]
+      end
+      """)
+    end
+
+    test "can be under interface as an attribute" do
+      assert_no_notation_error("InterfaceInterfacesValid", """
+      interface :bar do
+        field :name, :string
+        resolve_type fn _, _ -> :foo end
+      end
+      interface :foo do
         field :name, :string
         interfaces [:bar]
       end

--- a/test/absinthe/schema/rule/no_interface_cycles_test.exs
+++ b/test/absinthe/schema/rule/no_interface_cycles_test.exs
@@ -1,0 +1,36 @@
+defmodule Absinthe.Schema.Rule.NoInterfacecyclesTest do
+  use Absinthe.Case, async: true
+
+  describe "rule" do
+    test "is enforced" do
+      assert_schema_error("interface_cycle_schema", [
+        %{
+          extra: :named,
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/interface_cycle_schema.exs",
+              line: 24
+            }
+          ],
+          message:
+            "Interface Cycle Error\n\nInterface `named' forms a cycle via: ([:named, :node, :named])",
+          path: [],
+          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCyles
+        },
+        %{
+          extra: :node,
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/interface_cycle_schema.exs",
+              line: 24
+            }
+          ],
+          message:
+            "Interface Cycle Error\n\nInterface `node' forms a cycle via: ([:node, :named, :node])",
+          path: [],
+          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCyles
+        }
+      ])
+    end
+  end
+end

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -86,6 +86,15 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     end
   end
 
+  test "interfaces are propogated across type imports" do
+    assert %{
+             named: [:cat, :dog, :nameable, :user],
+             favorite_foods: [:cat, :dog, :user],
+             nameable: []
+           } ==
+             Schema.__absinthe_interface_implementors__()
+  end
+
   defmodule InterfaceImplementsInterfaces do
     use Absinthe.Schema
 
@@ -111,13 +120,13 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     end
   end
 
-  test "interfaces are propogated across type imports" do
+  test "interfaces are propagated from sdl" do
     assert %{
-             named: [:cat, :dog, :nameable, :user],
-             favorite_foods: [:cat, :dog, :user],
-             nameable: []
+             image: [],
+             node: [:image, :resource],
+             resource: [:image]
            } ==
-             Schema.__absinthe_interface_implementors__()
+             InterfaceImplementsInterfaces.__absinthe_interface_implementors__()
   end
 
   test "is enforced" do

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -19,7 +19,13 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     use Absinthe.Schema
     import_types Types
 
+    interface :parented do
+      field :parent, :named
+      field :another_parent, :named
+    end
+
     interface :named do
+      interface :parented
       field :name, :string
       field :parent, :named
       field :another_parent, :named
@@ -41,13 +47,6 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
         %{type: :cat}, _ -> :cat
         _, _ -> nil
       end
-    end
-
-    interface :nameable do
-      interface :named
-      field :name, :string
-      field :parent, :named
-      field :another_parent, :named
     end
 
     object :dog do
@@ -88,9 +87,9 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
 
   test "interfaces are propogated across type imports" do
     assert %{
-             named: [:cat, :dog, :nameable, :user],
+             named: [:cat, :dog, :user],
              favorite_foods: [:cat, :dog, :user],
-             nameable: []
+             parented: [:named]
            } ==
              Schema.__absinthe_interface_implementors__()
   end
@@ -120,7 +119,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     end
   end
 
-  test "interfaces are propagated from sdl" do
+  test "interfaces are set from sdl" do
     assert %{
              image: [],
              node: [:image, :resource],

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -43,6 +43,13 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
       end
     end
 
+    interface :nameable do
+      interface :named
+      field :name, :string
+      field :parent, :named
+      field :another_parent, :named
+    end
+
     object :dog do
       field :name, :string
       interface :named
@@ -79,8 +86,37 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     end
   end
 
+  defmodule InterfaceImplementsInterfaces do
+    use Absinthe.Schema
+
+    import_sdl """
+    interface Node {
+      id: ID!
+    }
+
+    interface Resource implements Node {
+      id: ID!
+      url: String
+    }
+
+    interface Image implements Resource & Node {
+      id: ID!
+      url: String
+      thumbnail: String
+    }
+
+    """
+
+    query do
+    end
+  end
+
   test "interfaces are propogated across type imports" do
-    assert %{named: [:cat, :dog, :user], favorite_foods: [:cat, :dog, :user]} ==
+    assert %{
+             named: [:cat, :dog, :nameable, :user],
+             favorite_foods: [:cat, :dog, :user],
+             nameable: []
+           } ==
              Schema.__absinthe_interface_implementors__()
   end
 

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -75,8 +75,9 @@ defmodule Absinthe.Schema.SdlRenderTest do
       CLASSIFIED
     }
 
-    interface Pet {
+    interface Pet implements Animal {
       name: String!
+      legCount: Int!
     }
 
     "One or the other"
@@ -125,7 +126,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
 
     test "for an interface" do
       assert_rendered("""
-      interface Entity {
+      interface Entity implements Node {
         name: String!
       }
       """)

--- a/test/support/fixtures/dynamic/interface_cycle_schema.exs
+++ b/test/support/fixtures/dynamic/interface_cycle_schema.exs
@@ -1,0 +1,62 @@
+defmodule Absinthe.TestSupport.Schema.InterfaceCycleSchema do
+  use Absinthe.Schema
+
+  @sdl """
+  schema {
+    query: Query
+  }
+
+  type Query {
+    node: Node
+  }
+
+  interface Node implements Named & Node {
+    id: ID!
+    name: String
+  }
+
+  interface Named implements Node & Named {
+    id: ID!
+    name: String
+  }
+  """
+
+  import_sdl @sdl
+  # query do
+  #   field :foo, :foo
+  #   field :quux, :quux
+  #   field :span, :spam
+  # end
+
+  # object :foo do
+  #   field :not_name, :string
+  #   interface :named
+  #   interface :aged
+
+  #   is_type_of fn _ ->
+  #     true
+  #   end
+  # end
+
+  # object :quux do
+  #   field :not_name, :string
+  #   interface :foo
+
+  #   is_type_of fn _ ->
+  #     true
+  #   end
+  # end
+
+  # object :spam do
+  #   field :name, :string
+  #   interface :named
+  # end
+
+  # interface :named do
+  #   field :name, :string
+  # end
+
+  # interface :aged do
+  #   field :age, :integer
+  # end
+end


### PR DESCRIPTION
Fixes https://github.com/absinthe-graphql/absinthe/issues/990

Adds support for interfaces implementing other interfaces according to the spec https://spec.graphql.org/draft/#sec-Interfaces.Interfaces-Implementing-Interfaces

 * added support in the parser/sdl schema
 * added support in macro schema
 * check if interfaces don't form a cycle
 * add support for rendering in the sdl
