### PR TITLE
Add phase to reformat descriptions

### DIFF
--- a/lib/absinthe/phase/schema/reformat_descriptions.ex
+++ b/lib/absinthe/phase/schema/reformat_descriptions.ex
@@ -1,0 +1,24 @@
+defmodule Absinthe.Phase.Schema.ReformatDescriptions do
+  @moduledoc false
+
+  # Trim all Descriptions
+
+  use Absinthe.Phase
+  alias Absinthe.Blueprint
+
+  @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(input, _options \\ []) do
+    node = Blueprint.prewalk(input, &handle_node/1)
+    {:ok, node}
+  end
+
+  @spec handle_node(Blueprint.node_t()) :: Blueprint.node_t()
+  defp handle_node(%{description: description} = node)
+       when is_binary(description) do
+    %{node | description: String.trim(description)}
+  end
+
+  defp handle_node(node) do
+    node
+  end
+end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -155,6 +155,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.Validation.NamesMustBeValid,
       Phase.Schema.RegisterTriggers,
       Phase.Schema.MarkReferenced,
+      Phase.Schema.ReformatDescriptions,
       # This phase is run again now after additional validations
       {Phase.Schema.Validation.Result, pass: :final},
       Phase.Schema.Build,

--- a/test/absinthe/phase/schema/reformat_description_test.exs
+++ b/test/absinthe/phase/schema/reformat_description_test.exs
@@ -1,0 +1,102 @@
+defmodule Absinthe.Phase.Schema.ReformatDescriptionTest do
+  use Absinthe.Case, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    query do
+      # Must exist
+    end
+
+    object :via_macro do
+      description "  Description via macro  "
+
+      field :foo, :string do
+        description "  Description via macro  "
+      end
+    end
+
+    object :via_attribute, description: "  Description via attribute  " do
+      field :foo, :string, description: "  Description via attribute  "
+    end
+
+    @desc "  Description via module attribute  "
+    object :via_module_attribute do
+      @desc "  Description via module attribute  "
+      field :foo, :string
+    end
+
+    def desc(), do: "  Description via function  "
+
+    object :via_function, description: desc() do
+      field :foo, :string, description: desc()
+    end
+
+    import_sdl """
+    "  Description via SDL  "
+    type ViaSdl {
+      "  Description via SDL  "
+      foo: String
+    }
+
+    "  Description on Enum  "
+    enum OnEnum {
+      "  Description on Enum  "
+      FOO
+    }
+
+    "  Description on Scalar  "
+    scalar OnScalar
+    """
+  end
+
+  describe "Description trimming" do
+    test "via macro" do
+      type = Schema.__absinthe_type__(:via_macro)
+
+      assert %{description: "Description via macro"} = type
+      assert %{description: "Description via macro"} = type.fields.foo
+    end
+
+    test "via attribute" do
+      type = Schema.__absinthe_type__(:via_attribute)
+
+      assert %{description: "Description via attribute"} = type
+      assert %{description: "Description via attribute"} = type.fields.foo
+    end
+
+    test "via module attribute" do
+      type = Schema.__absinthe_type__(:via_module_attribute)
+
+      assert %{description: "Description via module attribute"} = type
+      assert %{description: "Description via module attribute"} = type.fields.foo
+    end
+
+    test "via function" do
+      type = Schema.__absinthe_type__(:via_function)
+
+      assert %{description: "Description via function"} = type
+      assert %{description: "Description via function"} = type.fields.foo
+    end
+
+    test "via SDL" do
+      type = Schema.__absinthe_type__(:via_sdl)
+
+      assert %{description: "Description via SDL"} = type
+      assert %{description: "Description via SDL"} = type.fields.foo
+    end
+
+    test "on Enum" do
+      type = Schema.__absinthe_type__(:on_enum)
+
+      assert %{description: "Description on Enum"} = type
+      assert %{description: "Description on Enum"} = type.values.foo
+    end
+
+    test "on Scalar" do
+      type = Schema.__absinthe_type__(:on_scalar)
+
+      assert %{description: "Description on Scalar"} = type
+    end
+  end
+end


### PR DESCRIPTION
This PR brings back the logic to trim descriptions, but this time as a simple schema phase rather than part of the schema compilation mechanism. This behavior was lost in #1005.
