### PR TITLE
Fix introspection bug with import_fields and input

### DIFF
--- a/lib/absinthe/phase/schema/field_imports.ex
+++ b/lib/absinthe/phase/schema/field_imports.ex
@@ -33,7 +33,7 @@ defmodule Absinthe.Phase.Schema.FieldImports do
     Enum.reduce(type.imports, type, fn {source, opts}, type ->
       source_type = Map.fetch!(types, source)
 
-      rejections = Keyword.get(opts, :except, [])
+      rejections = Keyword.get(opts, :except, []) ++ exclusions(type)
 
       fields = source_type.fields |> Enum.reject(&(&1.identifier in rejections))
 
@@ -51,4 +51,7 @@ defmodule Absinthe.Phase.Schema.FieldImports do
   end
 
   def import_fields(type, _), do: type
+
+  defp exclusions(%Schema.InputObjectTypeDefinition{}), do: [:__typename]
+  defp exclusions(_), do: []
 end

--- a/lib/absinthe/phase/schema/field_imports.ex
+++ b/lib/absinthe/phase/schema/field_imports.ex
@@ -29,11 +29,14 @@ defmodule Absinthe.Phase.Schema.FieldImports do
     Schema.InputObjectTypeDefinition,
     Schema.InterfaceTypeDefinition
   ]
+  @exclude_fields [
+    :__typename
+  ]
   def import_fields(%def_type{} = type, types) when def_type in @can_import do
     Enum.reduce(type.imports, type, fn {source, opts}, type ->
       source_type = Map.fetch!(types, source)
 
-      rejections = Keyword.get(opts, :except, []) ++ exclusions(type)
+      rejections = Keyword.get(opts, :except, []) ++ @exclude_fields
 
       fields = source_type.fields |> Enum.reject(&(&1.identifier in rejections))
 
@@ -51,7 +54,4 @@ defmodule Absinthe.Phase.Schema.FieldImports do
   end
 
   def import_fields(type, _), do: type
-
-  defp exclusions(%Schema.InputObjectTypeDefinition{}), do: [:__typename]
-  defp exclusions(_), do: []
 end


### PR DESCRIPTION
This PR fixes a bug that would include `__typename` in an `input` if it called `import_fields` on an object.

Fixes #989 