### PR TITLE
Conform built in types to spec

### DIFF
--- a/lib/absinthe/introspection/kind.ex
+++ b/lib/absinthe/introspection/kind.ex
@@ -8,19 +8,20 @@ defmodule Absinthe.Introspection.Kind do
         __MODULE__
         |> Module.split()
         |> List.last()
-        |> Absinthe.Introspection.Kind.upcase()
+        |> Absinthe.Introspection.Kind.downcase()
+        |> String.to_existing_atom()
       end
 
       defoverridable kind: 0
     end
   end
 
-  def upcase(name) do
+  def downcase(name) do
     Regex.scan(~r{[A-Z]+[a-z]+}, name)
     |> List.flatten()
-    |> Enum.map(&String.upcase/1)
+    |> Enum.map(&String.downcase/1)
     |> Enum.join("_")
   end
 
-  @callback kind :: binary
+  @callback kind :: atom
 end

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -92,6 +92,19 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :locations, non_null(list_of(non_null(:__directive_location)))
   end
 
+  enum :__type_kind,
+    values: [
+      :schema,
+      :scalar,
+      :object,
+      :interface,
+      :union,
+      :enum,
+      :non_null,
+      :input_object,
+      :list
+    ]
+
   enum :__directive_location,
     values: [
       :query,
@@ -118,7 +131,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     description "Represents scalars, interfaces, object types, unions, enums in the system"
 
     field :kind,
-      type: :string,
+      type: non_null(:__type_kind),
       resolve: fn _, %{source: %{__struct__: type}} ->
         {:ok, type.kind}
       end
@@ -157,7 +170,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     end
 
     field :interfaces,
-      type: list_of(:__type),
+      type: list_of(non_null(:__type)),
       resolve: fn
         _, %{schema: schema, source: %{interfaces: interfaces}} ->
           interfaces =
@@ -172,7 +185,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :possible_types,
-      type: list_of(:__type),
+      type: list_of(non_null(:__type)),
       resolve: fn
         _, %{schema: schema, source: %{types: types}} ->
           possible_types =
@@ -190,7 +203,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :enum_values,
-      type: list_of(:__enumvalue),
+      type: list_of(non_null(:__enumvalue)),
       args: [
         include_deprecated: [
           type: :boolean,
@@ -217,7 +230,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :input_fields,
-      type: list_of(:__inputvalue),
+      type: list_of(non_null(:__inputvalue)),
       resolve: fn
         _, %{source: %Absinthe.Type.InputObject{fields: fields}} ->
           input_fields =
@@ -244,7 +257,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
   object :__field do
     field :name,
-      type: :string,
+      type: non_null(:string),
       resolve: fn _, %{adapter: adapter, source: source} ->
         {:ok, adapter.to_external_name(source.name, :field)}
       end
@@ -252,7 +265,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :description, :string
 
     field :args,
-      type: list_of(:__inputvalue),
+      type: non_null(list_of(non_null(:__inputvalue))),
       resolve: fn _, %{source: %{args: args}} ->
         args =
           args
@@ -263,7 +276,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :type,
-      type: :__type,
+      type: non_null(:__type),
       resolve: fn _, %{schema: schema, source: source} ->
         result =
           case source.type do
@@ -278,7 +291,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :is_deprecated,
-      type: :boolean,
+      type: non_null(:boolean),
       resolve: fn
         _, %{source: %{deprecation: nil}} ->
           {:ok, false}
@@ -300,7 +313,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
   object :__inputvalue, name: "__InputValue" do
     field :name,
-      type: :string,
+      type: non_null(:string),
       resolve: fn _, %{adapter: adapter, source: source} ->
         {:ok, adapter.to_external_name(source.name, :field)}
       end
@@ -308,7 +321,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :description, :string
 
     field :type,
-      type: :__type,
+      type: non_null(:__type),
       resolve: fn _, %{schema: schema, source: %{type: ident}} ->
         type = Absinthe.Schema.lookup_type(schema, ident, unwrap: false)
         {:ok, type}
@@ -329,12 +342,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
   end
 
   object :__enumvalue, name: "__EnumValue" do
-    field :name, :string
+    field :name, non_null(:string)
 
     field :description, :string
 
     field :is_deprecated,
-      type: :boolean,
+      type: non_null(:boolean),
       resolve: fn
         _, %{source: %{deprecation: nil}} ->
           {:ok, false}

--- a/test/absinthe/integration/execution/introspection/schema_types_test.exs
+++ b/test/absinthe/integration/execution/introspection/schema_types_test.exs
@@ -13,6 +13,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.SchemaTypesTest do
     "__InputValue",
     "__Schema",
     "__Type",
+    "__TypeKind",
     "Boolean",
     "Business",
     "Contact",


### PR DESCRIPTION
Changes the built in types to conform to the spec, see https://spec.graphql.org/draft/#sec-Schema-Introspection
Most notably adds the `__TypeKind` enum. 

`Absinthe.Introspection.Kind.kind` now returns an atom for the `__TypeKind` enum resolver. 
