### PR TITLE
Add variable_definition to __DirectiveLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bug Fix: Fix [field listing for Inputs](https://github.com/absinthe-graphql/absinthe/pull/1015) that import fields
 - Bug Fix: Properly [trim all descriptions](https://github.com/absinthe-graphql/absinthe/pull/1014) no matter the mechanism used to specify them
 - Bug Fix: Fix incorrect specification of [`__TypeKind`](https://github.com/absinthe-graphql/absinthe/pull/1019)
+- Bug Fix: Add missing value to [`__DirectiveLocation`](https://github.com/absinthe-graphql/absinthe/pull/1020)
 
 ## 1.5.5
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -113,16 +113,17 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       :fragment_definition,
       :fragment_spread,
       :inline_fragment,
+      :variable_definition,
       :schema,
       :scalar,
       :object,
       :field_definition,
+      :argument_definition,
       :interface,
       :union,
       :enum,
       :enum_value,
       :input_object,
-      :argument_definition,
       :input_field_definition
     ]
 


### PR DESCRIPTION
Adds missing `variable_definition` to `__DirectiveLocation` in Introspection

Also, tweaks their order just to match

https://github.com/graphql/graphql-spec/pull/761