### PR TITLE
Don't duplicate full introspection query

### DIFF
--- a/test/absinthe/integration/execution/introspection/full_test.exs
+++ b/test/absinthe/integration/execution/introspection/full_test.exs
@@ -1,101 +1,15 @@
 defmodule Elixir.Absinthe.Integration.Execution.Introspection.FullTest do
   use Absinthe.Case, async: true
 
-  @query """
-  query IntrospectionQuery {
-    __schema {
-      queryType { name }
-      mutationType { name }
-      subscriptionType { name }
-      types {
-        ...FullType
-      }
-      directives {
-        name
-        description
-        locations
-        args {
-          ...InputValue
-        }
-      }
-    }
-  }
-  fragment FullType on __Type {
-    kind
-    name
-    description
-    fields(includeDeprecated: true) {
-      name
-      description
-      args {
-        ...InputValue
-      }
-      type {
-        ...TypeRef
-      }
-      isDeprecated
-      deprecationReason
-    }
-    inputFields {
-      ...InputValue
-    }
-    interfaces {
-      ...TypeRef
-    }
-    enumValues(includeDeprecated: true) {
-      name
-      description
-      isDeprecated
-      deprecationReason
-    }
-    possibleTypes {
-      ...TypeRef
-    }
-  }
-  fragment InputValue on __InputValue {
-    name
-    description
-    type { ...TypeRef }
-    defaultValue
-  }
-  fragment TypeRef on __Type {
-    kind
-    name
-    ofType {
-      kind
-      name
-      ofType {
-        kind
-        name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  """
-
   test "scenario #1" do
-    result = Absinthe.run(@query, Absinthe.Fixtures.ContactSchema, [])
+    result = Absinthe.Schema.introspect(Absinthe.Fixtures.ContactSchema)
     {:ok, %{data: %{"__schema" => schema}}} = result
-    assert !is_nil(schema)
+
+    assert schema["queryType"]
+    assert schema["mutationType"]
+    assert schema["subscriptionType"]
+    assert schema["types"]
+    assert schema["directives"]
   end
 
   defmodule MiddlewareSchema do
@@ -110,6 +24,6 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.FullTest do
   end
 
   test "middleware callback does not apply to introspection fields" do
-    assert Absinthe.run(@query, MiddlewareSchema, [])
+    assert Absinthe.Schema.introspect(MiddlewareSchema)
   end
 end

--- a/test/absinthe/phase/document/complexity_test.exs
+++ b/test/absinthe/phase/document/complexity_test.exs
@@ -350,27 +350,10 @@ defmodule Absinthe.Phase.Document.ComplexityTest do
     end
 
     test "handles GraphQL introspection" do
-      doc = """
-      query IntrospectionQuery {
-        __schema {
-          types {
-            ...FullType
-          }
-        }
-      }
-
-      fragment FullType on __Type {
-        fields {
-          args {
-            ...InputValue
-          }
-        }
-      }
-
-      fragment InputValue on __InputValue {
-        type { name }
-      }
-      """
+      doc =
+        [:code.priv_dir(:absinthe), "graphql", "introspection.graphql"]
+        |> Path.join()
+        |> File.read!()
 
       assert {:ok, _, _} =
                run_phase(


### PR DESCRIPTION
Minor housekeeping - don't copy/pasta the introspection query when we can just reference the stored query file