### PR TITLE
Fix import_types/2 for A.{B, C}

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1680,11 +1680,7 @@ defmodule Absinthe.Schema.Notation do
     for {_, _, leaf} <- modules_ast_list do
       type_module = Module.concat([root_module_with_alias | leaf])
 
-      if Code.ensure_loaded?(type_module) do
-        do_import_types(type_module, env, opts)
-      else
-        raise ArgumentError, "module #{type_module} is not available"
-      end
+      do_import_types(type_module, env, opts)
     end
   end
 

--- a/test/absinthe/schema/notation/import_test.exs
+++ b/test/absinthe/schema/notation/import_test.exs
@@ -251,6 +251,17 @@ defmodule Absinthe.Schema.Notation.ImportTest do
     end
   end
 
+  describe "unknown imported modules" do
+    test "returns error" do
+      assert_schema_error("unknown_import_schema", [
+        %Absinthe.Phase.Error{
+          message: "Could not load module `Elixir.Test.Unknown`. It returned reason: `nofile`.",
+          phase: Absinthe.Phase.Schema.TypeImports
+        }
+      ])
+    end
+  end
+
   defp validate(schema) do
     pipeline =
       schema

--- a/test/support/fixtures/dynamic/unknown_import_schema.exs
+++ b/test/support/fixtures/dynamic/unknown_import_schema.exs
@@ -1,0 +1,8 @@
+defmodule Absinthe.TestSupport.Schema.UnknownImportSchema do
+  use Absinthe.Schema
+
+  import_types Test.Unknown
+
+  query do
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/absinthe-graphql/absinthe/issues/937

I can reproduce issue #937 with a repo with absinthe as a dependency but not from within a test in absinthe. Has to do with the modules not being compiled (yet)

Changing https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/schema/notation.ex#L1683 to `if Code.ensure_compiled(type_module) do` fixed it. (See https://github.com/absinthe-graphql/absinthe/pull/534 for dealing with this in an earlier version).

Or, removing the if-clause entirely and relying on the TypeImports phase to handle this. This is what happens for ordinary imports like `import_types(MyApp.Schema.Types.UnknownModule)`. I've done this in this PR and let failed imports add a phase error to the schema. 

This could also be extended that whenever non absinthe modules are imported another error is added e.g.

```elixir
defmodule Test do
end
defmodule Schema do
   use Absinthe.Schema
   import_types Test
end
```
The TypeImports phase could check  `function_exported(Test, :__absinthe_blueprint__, 0)` and add an error if it's not present.
