### PR TITLE
Copy logger metadata for async and batch

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
 config :logger, level: :info
+
+config :logger, :console, metadata: [:request_id]

--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -50,8 +50,17 @@ defmodule Absinthe.Middleware.Async do
   # This function inserts additional middleware into the remaining middleware
   # stack for this field. On the next resolution pass, we need to `Task.await` the
   # task so we have actual data. Thus, we prepend this module to the middleware stack.
-  def call(%{state: :unresolved} = res, {fun, opts}) when is_function(fun),
-    do: call(res, {Task.async(fun), opts})
+  def call(%{state: :unresolved} = res, {fun, opts}) when is_function(fun) do
+    metadata = Logger.metadata()
+
+    task =
+      Task.async(fn ->
+        Logger.metadata(metadata)
+        fun.()
+      end)
+
+    call(res, {task, opts})
+  end
 
   def call(%{state: :unresolved} = res, {task, opts}) do
     task_data = {task, opts}

--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -130,6 +130,8 @@ defmodule Absinthe.Middleware.Batch do
   end
 
   defp do_batching(input) do
+    logger_metadata = Logger.metadata()
+
     input
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
     |> Enum.map(fn {{batch_fun, batch_opts}, batch_data} ->
@@ -138,6 +140,7 @@ defmodule Absinthe.Middleware.Batch do
 
       task =
         Task.async(fn ->
+          Logger.metadata(logger_metadata)
           {batch_fun, call_batch_fun(batch_fun, batch_data)}
         end)
 


### PR DESCRIPTION
Hi folks! Thanks for creating and maintaining an awesome library. I debated opening an issue for this first, but decided it's a simple enough change that I would just create a PR. I'm happy to rework it or scrap it if that's what's decided.

Currently whenever the async or batch middleware is used, any logger metadata is lost when the new async tasks are created. This means that the Phoenix request ID doesn't show in log lines if using Phoenix, and it means that a user ID or other metadata needs to be added in every resolver to be present for logs.

This copies the logger metadata from the parent process whenever a new async task is created so that any logs further down the stack will have access to it.

Thanks for reviewing! I look forward to any feedback 😄