### PR TITLE
Allow directives on variable variable_definition_test

### DIFF
--- a/lib/absinthe/blueprint/document/variable_definition.ex
+++ b/lib/absinthe/blueprint/document/variable_definition.ex
@@ -7,6 +7,7 @@ defmodule Absinthe.Blueprint.Document.VariableDefinition do
   defstruct [
     :name,
     :type,
+    directives: [],
     default_value: nil,
     source_location: nil,
     # Added by phases
@@ -19,6 +20,7 @@ defmodule Absinthe.Blueprint.Document.VariableDefinition do
   @type t :: %__MODULE__{
           name: String.t(),
           type: Blueprint.TypeReference.t(),
+          directives: [Blueprint.Directive.t()],
           default_value: Blueprint.Input.t(),
           source_location: nil | Blueprint.SourceLocation.t(),
           provided_value: nil | Blueprint.Input.t(),

--- a/lib/absinthe/blueprint/transform.ex
+++ b/lib/absinthe/blueprint/transform.ex
@@ -70,7 +70,7 @@ defmodule Absinthe.Blueprint.Transform do
     Blueprint.Document.Fragment.Inline => [:selections, :directives],
     Blueprint.Document.Fragment.Named => [:selections, :directives],
     Blueprint.Document.Fragment.Spread => [:directives],
-    Blueprint.Document.VariableDefinition => [:type, :default_value],
+    Blueprint.Document.VariableDefinition => [:type, :default_value, :directives],
     Blueprint.Input.Argument => [:input_value],
     Blueprint.Input.Field => [:input_value],
     Blueprint.Input.Object => [:fields],

--- a/lib/absinthe/language/variable_definition.ex
+++ b/lib/absinthe/language/variable_definition.ex
@@ -5,6 +5,7 @@ defmodule Absinthe.Language.VariableDefinition do
 
   defstruct variable: nil,
             type: nil,
+            directives: [],
             default_value: nil,
             loc: %{line: nil}
 
@@ -20,6 +21,7 @@ defmodule Absinthe.Language.VariableDefinition do
       %Blueprint.Document.VariableDefinition{
         name: node.variable.name,
         type: Blueprint.Draft.convert(node.type, doc),
+        directives: Absinthe.Blueprint.Draft.convert(node.directives, doc),
         default_value: Blueprint.Draft.convert(node.default_value, doc),
         source_location: source_location(node)
       }

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -55,6 +55,7 @@ VariableDefinitionList -> VariableDefinition : ['$1'].
 VariableDefinitionList -> VariableDefinition VariableDefinitionList : ['$1'|'$2'].
 VariableDefinition -> Variable ':' Type : build_ast_node('VariableDefinition', #{'variable' => '$1', 'type' => '$3'}, extract_child_location('$1')).
 VariableDefinition -> Variable ':' Type DefaultValue : build_ast_node('VariableDefinition', #{'variable' => '$1', 'type' => '$3', 'default_value' => '$4'}, extract_child_location('$1')).
+VariableDefinition -> Variable ':' Type DefaultValue Directives : build_ast_node('VariableDefinition', #{'variable' => '$1', 'type' => '$3', 'default_value' => '$4', 'directives' => '$5'}, extract_child_location('$1')).
 Variable -> '$' NameWithoutOn : build_ast_node('Variable', #{'name' => extract_binary('$2')}, extract_location('$1')).
 Variable -> '$' 'on' : build_ast_node('Variable', #{'name' => extract_binary('$2')}, extract_location('$1')).
 

--- a/test/absinthe/language/variable_definition_test.exs
+++ b/test/absinthe/language/variable_definition_test.exs
@@ -4,7 +4,7 @@ defmodule Absinthe.Language.VariableDefinitionTest do
   alias Absinthe.{Blueprint, Language}
 
   @query """
-  query Foo($showFoo: Boolean = true) {
+  query Foo($showFoo: Boolean = true @bar(a: 1)) {
     foo @include(if: $showFoo)
   }
   """
@@ -13,6 +13,7 @@ defmodule Absinthe.Language.VariableDefinitionTest do
     test "builds a VariableDefinition.t" do
       assert %Blueprint.Document.VariableDefinition{
                name: "showFoo",
+               directives: [%Blueprint.Directive{name: "bar"}],
                type: %Blueprint.TypeReference.Name{name: "Boolean"},
                default_value: %Blueprint.Input.Boolean{value: true},
                source_location: %Blueprint.SourceLocation{line: 1}


### PR DESCRIPTION
See https://github.com/graphql/graphql-spec/pull/510

Adds support for directives on variable definitions in the parser as is defined by the spec.
