### PR TITLE
Update builtin types according to spec

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -42,7 +42,8 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
         %{
           query: Enum.find(type_definitions, &(&1.identifier == :query)),
           mutation: Enum.find(type_definitions, &(&1.identifier == :mutation)),
-          subscription: Enum.find(type_definitions, &(&1.identifier == :subscription))
+          subscription: Enum.find(type_definitions, &(&1.identifier == :subscription)),
+          description: Enum.find(type_definitions, &(&1.identifier == :__schema)).description
         }
 
     directive_definitions =
@@ -72,13 +73,15 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       ]),
       render_list(schema.field_definitions, type_definitions)
     )
+    |> description(schema.description)
   end
 
   defp render(
          %{
            query: query_type,
            mutation: mutation_type,
-           subscription: subscription_type
+           subscription: subscription_type,
+           description: description
          },
          _type_definitions
        ) do
@@ -95,6 +98,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       "schema",
       schema_type_docs
     )
+    |> description(description)
   end
 
   @adapter Absinthe.Adapter.LanguageConventions

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -6,6 +6,12 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
   object :__schema do
     description "Represents a schema"
 
+    field :description, :string do
+      resolve(fn _, %{schema: schema} ->
+        {:ok, Absinthe.Schema.lookup_type(schema, :__schema).description}
+      end)
+    end
+
     field :types, list_of(:__type) do
       resolve fn _, %{schema: schema} ->
         types =

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -12,7 +12,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end)
     end
 
-    field :types, list_of(:__type) do
+    field :types, non_null(list_of(non_null(:__type))) do
       resolve fn _, %{schema: schema} ->
         types =
           Absinthe.Schema.types(schema)
@@ -41,7 +41,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       end
 
     field :directives,
-      type: list_of(:__directive),
+      type: non_null(list_of(non_null(:__directive))),
       resolve: fn _, %{schema: schema} ->
         directives =
           Absinthe.Schema.directives(schema)
@@ -146,7 +146,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
 
     field :description, :string
 
-    field :fields, list_of(:__field) do
+    field :fields, list_of(non_null(:__field)) do
       arg :include_deprecated, :boolean, default_value: false
 
       resolve fn

--- a/priv/graphql/introspection.graphql
+++ b/priv/graphql/introspection.graphql
@@ -1,8 +1,15 @@
 query IntrospectionQuery {
   __schema {
-    queryType { name }
-    mutationType { name }
-    subscriptionType { name }
+    description
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
     types {
       ...FullType
     }
@@ -52,7 +59,9 @@ fragment FullType on __Type {
 fragment InputValue on __InputValue {
   name
   description
-  type { ...TypeRef }
+  type {
+    ...TypeRef
+  }
   defaultValue
 }
 fragment TypeRef on __Type {

--- a/test/absinthe/integration/execution/introspection/full_test.exs
+++ b/test/absinthe/integration/execution/introspection/full_test.exs
@@ -5,6 +5,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.FullTest do
     result = Absinthe.Schema.introspect(Absinthe.Fixtures.ContactSchema)
     {:ok, %{data: %{"__schema" => schema}}} = result
 
+    assert schema["description"] == "Represents a schema"
     assert schema["queryType"]
     assert schema["mutationType"]
     assert schema["subscriptionType"]

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -7,6 +7,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
     alias Absinthe.Blueprint.Schema
 
     @sdl """
+    "Schema description"
     schema {
       query: Query
     }
@@ -229,6 +230,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
   test "Render SDL from blueprint defined with macros" do
     assert Absinthe.Schema.to_sdl(MacroTestSchema) ==
              """
+             "Represents a schema"
              schema {
                query: RootQueryType
              }

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -300,7 +300,7 @@ defmodule Absinthe.SchemaTest do
   describe "to_sdl/1" do
     test "return schema sdl" do
       assert Schema.to_sdl(SourceSchema) == """
-             schema {\n  query: RootQueryType\n}\n\ntype Foo {\n  name: String\n}\n\n\"can describe query\"\ntype RootQueryType {\n  foo: Foo\n}
+             \"Represents a schema\"\nschema {\n  query: RootQueryType\n}\n\ntype Foo {\n  name: String\n}\n\n\"can describe query\"\ntype RootQueryType {\n  foo: Foo\n}
              """
     end
   end


### PR DESCRIPTION
Found some mismatches between the builtin types and the spec (https://spec.graphql.org/draft/#sec-Schema-Introspection), this PR fixes those.

Also adds the schema description to SDL rendering and introspection, see graphql/graphql-spec#466