### PR TITLE
Make tests async where possible

### DIFF
--- a/test/absinthe/schema/experimental_test.exs
+++ b/test/absinthe/schema/experimental_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.ExperimentalTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
 
   @moduletag :experimental
 

--- a/test/absinthe/schema/notation/experimental/argument_test.exs
+++ b/test/absinthe/schema/notation/experimental/argument_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ArgumentTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/notation/experimental/field_test.exs
+++ b/test/absinthe/schema/notation/experimental/field_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.FieldTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/notation/experimental/import_fields_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_fields_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ImportFieldsTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/notation/experimental/import_types_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_types_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ImportTypesTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
 
   @moduletag :experimental
 

--- a/test/absinthe/schema/notation/experimental/object_test.exs
+++ b/test/absinthe/schema/notation/experimental/object_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ObjectTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/notation/experimental/resolve_test.exs
+++ b/test/absinthe/schema/notation/experimental/resolve_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.Notation.Experimental.ResolveTest do
-  use Absinthe.Case
+  use Absinthe.Case, async: true
   import ExperimentalNotationHelpers
 
   @moduletag :experimental

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.SdlRenderTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   defmodule SdlTestSchema do
     use Absinthe.Schema

--- a/test/absinthe/schema/type_system_directive_test.exs
+++ b/test/absinthe/schema/type_system_directive_test.exs
@@ -1,5 +1,5 @@
 defmodule Absinthe.Schema.TypeSystemDirectiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   defmodule WithTypeSystemDirective do
     use Absinthe.Schema.Prototype


### PR DESCRIPTION
Some tests could be marked as async to speed up the test suite a little :)

In Elixir master it reports the async and sync test durations.
```
Finished in 11.5 seconds (8.6s async, 2.9s sync)
```