### PR TITLE
Render null default values in SDL

### DIFF
--- a/lib/absinthe/language/input_value_definition.ex
+++ b/lib/absinthe/language/input_value_definition.ex
@@ -48,6 +48,9 @@ defmodule Absinthe.Language.InputValueDefinition do
     defp to_term(%Language.ListValue{values: values}),
       do: Enum.map(values, &to_term/1)
 
+    defp to_term(%Language.NullValue{}),
+      do: nil
+
     defp to_term(%Language.ObjectValue{fields: fields}),
       do: Enum.into(fields, %{}, &{String.to_atom(&1.name), to_term(&1.value)})
 

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -408,6 +408,9 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   defp render_value(%Blueprint.Input.Value{raw: raw}),
     do: render_value(raw)
 
+  defp render_value(%Blueprint.Input.Null{}),
+    do: "null"
+
   defp render_value(%Blueprint.Input.Object{fields: fields}) do
     default_fields = Enum.map(fields, &render_value/1)
     concat(["{", join(default_fields, ", "), "}"])

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -53,6 +53,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
       defaultInputArg(input: ComplexInput = {foo: "bar"}): String
       defaultListArg(things: [String] = ["ThisThing"]): [String]
       defaultEnumArg(category: Category = NEWS): Category
+      defaultNullStringArg(name: String = null): String
       animal: Animal
     }
 


### PR DESCRIPTION
Literal null default values in arguments in the SDL notation triggered errors.

 * A pattern match was missing for the `Language.NullValue` when converting to `Blueprint.Schema.InputValueDefinition`
 * In the SDL rendered the `Blueprint.Input.Null` was not matched when in render_value
