### PR TITLE
Improved serialization failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1
+
+- Feature: [Improved serialization failure messages](https://github.com/absinthe-graphql/absinthe/pull/1033)
+
 ## 1.6.0
 
 - Feature: [Interfaces can now implement Interfaces](https://github.com/absinthe-graphql/absinthe/pull/1012), matching the latest spec

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -56,9 +56,9 @@ defmodule Absinthe.Phase.Document.Result do
           rescue
             Absinthe.SerializationError ->
               raise(Absinthe.SerializationError, """
-              Could not serialize: #{inspect(value)} as a #{schema_node.name}
+              Could not serialize term #{inspect(value)} as type #{schema_node.name}
 
-              When resolving field:
+              When serializing the field:
               #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{
                 emitter.schema_node.__reference__.location.file
               }:#{emitter.schema_node.__reference__.location.line})

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -51,7 +51,19 @@ defmodule Absinthe.Phase.Document.Result do
     value =
       case Type.unwrap(emitter.schema_node.type) do
         %Type.Scalar{} = schema_node ->
-          Type.Scalar.serialize(schema_node, value)
+          try do
+            Type.Scalar.serialize(schema_node, value)
+          rescue
+            Absinthe.SerializationError ->
+              raise(Absinthe.SerializationError, """
+              Could not serialize: #{inspect(value)} as a #{schema_node.name}
+
+              When resolving field:
+              #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{
+                emitter.schema_node.__reference__.location.file
+              }:#{emitter.schema_node.__reference__.location.line})
+              """)
+          end
 
         %Type.Enum{} = schema_node ->
           Type.Enum.serialize(schema_node, value)


### PR DESCRIPTION
This changes the relatively unhelpful message we have today:

```
** (Absinthe.SerializationError) Value 1.0 is not a valid integer
```

into something that actually tells you what field to go look for to fix the issue:

```
** (Absinthe.SerializationError) Could not serialize term 1.0 as type Int
When serializing the field:
RootQueryType.bad_integer (/path/to/schema/module.ex:8)
```