### PR TITLE
Hibernate Absinthe.Schema.Manager

### DIFF
--- a/lib/absinthe/schema/manager.ex
+++ b/lib/absinthe/schema/manager.ex
@@ -23,6 +23,6 @@ defmodule Absinthe.Schema.Manager do
         raise Absinthe.Schema.Error, phase_errors: List.wrap(errors)
     end
 
-    {:ok, schema_module}
+    {:ok, schema_module, :hibernate}
   end
 end


### PR DESCRIPTION
I noticed that the `Absinthe.Schema.Manager` process was using a lot of memory in our app, but it shouldn't since it doesn't do anything. I dug around and realized that it never gets GC'd since the process `init`s and then never does anything again, and therefore it never gets checked for memory usage.

This PR fixes that by having it `:hibernate` immediately which triggers a GC.