### PR TITLE
Add failing test for macro deprecated field in SDL render

### DIFF
--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -214,7 +214,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
       field :id, :id
       field :name, :string
       field :status, :order_status
-      field :other_status, :status
+      field :other_status, :status, deprecate: "See status field"
       import_fields :imported_fields
     end
 
@@ -275,7 +275,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
                id: ID
                name: String
                status: OrderStatus
-               otherStatus: Status
+               otherStatus: Status @deprecated(reason: "See status field")
              }
              """
   end


### PR DESCRIPTION
A field that is deprecated in the macro defined schema's is not rendered as deprecated in SDL. See this failing test case. This is a regression from Absinthe 1.5.5

In 1352d8fd6e520dabae3cd642c69ec663065d829c the deprecation directive was no longer special-cased, which works for SDL defined schema's, but not in macro defined schema's. The difference being that the macro schema's don't add a `deprecated` directive  to`Absinthe.Blueprint.Schema.FieldDefinition.directives`, so it only relies on the `FieldDefinition.deprecation` field. 

SDL schema's directives do add the `deprecated` directive to the `directives` field, so they are rendered correctly in SDL. They rely on [this directive expansion](https://github.com/absinthe-graphql/absinthe/blob/v1.6.3/lib/absinthe/schema/prototype/notation.ex#L47) to set the deprecation field. 

We could either special case the `deprecated` directive again in the SDL renderer, or use the macro schema to add a `deprecated` directive when deprecating a field (perhaps through a schema phase) 