### PR TITLE
Skip duplicates Github actions run

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,16 +2,32 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
 
 jobs:
+  check_duplicate_runs:
+    name: Check for duplicate runs
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: always
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/CHANGELOG.md", "**/CODE_OF_CONDUCT.md", "**/CONTRIBUTING.md", "**/LICENSE.md"]'
+          do_not_skip: '["pull_request"]'
+
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
     runs-on: ubuntu-latest
+    needs: check_duplicate_runs
+    if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 
     strategy:
       matrix:
@@ -34,44 +50,47 @@ jobs:
     - name: Restore deps cache
       uses: actions/cache@v2
       with:
-        path: deps
-        key: deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
         restore-keys: |
-          deps-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
 
-    - name: Restore _build cache
-      uses: actions/cache@v2
-      with:
-        path: _build
-        key: _build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          _build-${{ matrix.otp }}-${{ matrix.elixir }}
+    - name: Create dializer plts path
+      run: mkdir -p priv/plts || true
 
     - name: Restore plts cache
       uses: actions/cache@v2
       with:
         path: priv/plts
-        key: plts-${{ matrix.otp }}-${{ matrix.elixir }}
+        key: ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}
 
-    - name: Install deps
+    - name: Install package dependencies
       run: mix deps.get
+
+    - name: Remove compiled application files
+      run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
+      env:
+        MIX_ENV: test
 
     - name: Check Formatting
       run: mix format --check-formatted
 
     - name: Run unit tests
-      run: |
-        mix clean
-        mix test
+      run: mix test
 
     - name: Run unit tests with persistent_term backend
-      run: |
-        mix clean
-        mix test
+      run: mix test
       env:
         SCHEMA_PROVIDER: persistent_term
 
     - name: Run dialyzer
-      run: |
-        mkdir -p priv/plts
-        MIX_ENV=test mix dialyzer
+      run: mix dialyzer

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,9 @@ defmodule Absinthe.Mixfile do
       start_permanent: Mix.env() == :prod,
       package: package(),
       source_url: @source_url,
+      preferred_cli_env: [
+        dialyzer: :test
+      ],
       docs: [
         source_ref: "v#{@version}",
         main: "overview",


### PR DESCRIPTION
Hello.

It looks like commiting to branches excluding `master` does not run Github Actions. So users which are working on feature/bugfix branches cannot see that their changes are leading to failed tests until they'll create a pull request to master branch.
So I've removed restriction against branch name for `push` events.

But there is an annoying fact about Github Actions - sometimes it runs actions twice. For example:
1. You just pushed a commit to a branch - testing workflow will run only once
2. Someone forked your repo and creates a pull request - same thing
3. You've created a new branch (feature, bugfix or release branch), pushed a commit here and also created a pull request to the main branch - two copies of workflow will be run

Running a workflow twice does not make any sense, it just takes twice the time without any useful side effect.

So in this PR I've also added a separated job of checking if another copy of workflow already started: https://github.com/fkirc/skip-duplicate-actions

This job allows to:
1. Skip the second copy of workflow in the case 3 (branch in original repo + PR to main branch). Cases 1 and 2 will work just the same as now
2. Skip workflow if someone changed only files which are not connected to package code, like README or CHANGELOG
3. Cancel already started workflow in the same PR or branch if someone pushed new commits to it.

Also I've found another quite annoying bug - step `actions/cache` does not update cache item if it was restored using a primary key.
For example, some dependencies like dialyzer or other ones store their files in `deps` or `_build` folders (which are cached in the workflow). But when these dependencies perform some updates of these folders, it does not lead to the updating of `mix.lock` file. File hasn't been changed -> hash is the same -> cache primary key is the same -> caching action will not update the existing cache.
This will cause the increase of workflow run time because the stored cache will not be used by some steps. Until `mix.lock` will be updated which will lead to updating the cache item.
Here I've appended a commit SHA to the cache primary key, so it will always be updated. But it will not affect cache reading.

What do you think about that?