### PR TITLE
Optimize actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -7,27 +7,9 @@ on:
       - master
 
 jobs:
-  check_duplicate_runs:
-    name: Check for duplicate runs
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          concurrent_skipping: always
-          cancel_others: true
-          skip_after_successful_duplicate: true
-          paths_ignore: '["**/README.md", "**/CHANGELOG.md", "**/CODE_OF_CONDUCT.md", "**/CONTRIBUTING.md", "**/LICENSE.md"]'
-          do_not_skip: '["pull_request"]'
-
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
     runs-on: ubuntu-latest
-    needs: check_duplicate_runs
-    if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 
     strategy:
       matrix:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -55,11 +55,6 @@ jobs:
     - name: Install package dependencies
       run: mix deps.get
 
-    - name: Compile application
-      run: mix compile
-      env:
-        MIX_ENV: test
-
     - name: Check Formatting
       run: mix format --check-formatted
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,22 +35,22 @@ jobs:
         path: |
           deps
           _build
-        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
+          deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
 
     - name: Create dializer plts path
-      run: mkdir -p priv/plts || true
+      run: mkdir -p priv/plts
 
     - name: Restore plts cache
       uses: actions/cache@v2
       with:
         path: priv/plts
-        key: ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        key: plts-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}
+          plts-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          plts-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
 
     - name: Install package dependencies
       run: mix deps.get
@@ -58,7 +58,7 @@ jobs:
     - name: Remove compiled application files
       run: mix clean
 
-    - name: Compile dependencies
+    - name: Compile application
       run: mix compile
       env:
         MIX_ENV: test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,16 +2,32 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
 
 jobs:
+  check_duplicate_runs:
+    name: Check for duplicate runs
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: always
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/CHANGELOG.md", "**/CODE_OF_CONDUCT.md", "**/CONTRIBUTING.md", "**/LICENSE.md"]'
+          do_not_skip: '["pull_request"]'
+
   test:
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
     runs-on: ubuntu-latest
+    needs: check_duplicate_runs
+    if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
 
     strategy:
       matrix:
@@ -34,44 +50,47 @@ jobs:
     - name: Restore deps cache
       uses: actions/cache@v2
       with:
-        path: deps
-        key: deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
         restore-keys: |
-          deps-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
 
-    - name: Restore _build cache
-      uses: actions/cache@v2
-      with:
-        path: _build
-        key: _build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          _build-${{ matrix.otp }}-${{ matrix.elixir }}
+    - name: Create dializer plts path
+      run: mkdir -p priv/plts || true
 
     - name: Restore plts cache
       uses: actions/cache@v2
       with:
         path: priv/plts
-        key: plts-${{ matrix.otp }}-${{ matrix.elixir }}
+        key: ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-plts-${{ matrix.otp }}-${{ matrix.elixir }}
 
-    - name: Install deps
+    - name: Install package dependencies
       run: mix deps.get
+
+    - name: Remove compiled application files
+      run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
+      env:
+        MIX_ENV: test
 
     - name: Check Formatting
       run: mix format --check-formatted
 
     - name: Run unit tests
-      run: |
-        mix clean
-        mix test
+      run: mix test
 
     - name: Run unit tests with persistent_term backend
-      run: |
-        mix clean
-        mix test
+      run: mix test
       env:
         SCHEMA_PROVIDER: persistent_term
 
     - name: Run dialyzer
-      run: |
-        mkdir -p priv/plts
-        MIX_ENV=test mix dialyzer
+      run: mix dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -55,9 +55,6 @@ jobs:
     - name: Install package dependencies
       run: mix deps.get
 
-    - name: Remove compiled application files
-      run: mix clean
-
     - name: Compile application
       run: mix compile
       env:
@@ -67,10 +64,14 @@ jobs:
       run: mix format --check-formatted
 
     - name: Run unit tests
-      run: mix test
+      run: |
+        mix clean
+        mix test
 
     - name: Run unit tests with persistent_term backend
-      run: mix test
+      run: |
+        mix clean
+        mix test
       env:
         SCHEMA_PROVIDER: persistent_term
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,9 @@ defmodule Absinthe.Mixfile do
       start_permanent: Mix.env() == :prod,
       package: package(),
       source_url: @source_url,
+      preferred_cli_env: [
+        dialyzer: :test
+      ],
       docs: [
         source_ref: "v#{@version}",
         main: "overview",


### PR DESCRIPTION
Optimize our use of Github actions. Continued from #1050.

Biggest change is to build on all branch pushes which will be helpful for other users forks, not so much for the main repo. Also tweaks the cache keys to function better. Excludes the section to skip duplicates for now. 