### PR TITLE
Support only 2 latest versions of Elixir

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,11 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - elixir: '1.11'
-            otp: '23'
-          - elixir: '1.10'
-            otp: '22'
+        elixir:
+          - '1.10'
+          - '1.11'
+        otp:
+          - '22'
+          - '23'
 
     steps:
     - name: Checkout

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Absinthe.Mixfile do
     [
       app: :absinthe,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
According to https://github.com/absinthe-graphql/dataloader/pull/121/files/c91311bb0e05fbc3911067d5e1756ce780b28b60#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88:
```
Absinthe tends to only support the last 2 Elixir versions, so we can remove 1.7-1.9. This does need to be updated in our mix.exs probably.
```

Let's update it.