### PR TITLE
Compress registry tables by default

### DIFF
--- a/lib/absinthe/subscription/supervisor.ex
+++ b/lib/absinthe/subscription/supervisor.ex
@@ -26,7 +26,8 @@ defmodule Absinthe.Subscription.Supervisor do
          keys: :duplicate,
          name: registry_name,
          partitions: System.schedulers_online(),
-         meta: meta
+         meta: meta,
+         compressed: true
        ]},
       {Absinthe.Subscription.ProxySupervisor, [pubsub, registry_name, pool_size]}
     ]


### PR DESCRIPTION
@benwilson512 sent a PR to Elixir to support compressed
tables. This enables it by default on the Registry.

This is just a proposal, perhaps you want to make it opt-in
instead.