### PR TITLE
Fix serialization string serialization bug

### DIFF
--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -54,8 +54,16 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
     represent free-form human-readable text.
     """
 
-    serialize &String.Chars.to_string/1
+    serialize &__MODULE__.serialize_string/1
     parse parse_with([Absinthe.Blueprint.Input.String], &parse_string/1)
+  end
+
+  def serialize_string(n) when not is_map(n), do: String.Chars.to_string(n)
+
+  def serialize_string(n) do
+    raise Absinthe.SerializationError, """
+    Value #{inspect(n)} is not a valid string
+    """
   end
 
   scalar :id, name: "ID" do

--- a/test/absinthe/integration/execution/serialization_test.exs
+++ b/test/absinthe/integration/execution/serialization_test.exs
@@ -16,6 +16,10 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
       field :bad_boolean, :boolean do
         resolve fn _, _, _ -> {:ok, "true"} end
       end
+
+      field :bad_string, :string do
+        resolve fn _, _, _ -> {:ok, %{}} end
+      end
     end
   end
 
@@ -41,6 +45,15 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
   query { badBoolean }
   """
   test "returning not a boolean for a boolean raises" do
+    assert_raise(Absinthe.SerializationError, fn ->
+      Absinthe.run(@query, Schema)
+    end)
+  end
+
+  @query """
+  query { badString }
+  """
+  test "returning not a string for a string raises" do
     assert_raise(Absinthe.SerializationError, fn ->
       Absinthe.run(@query, Schema)
     end)


### PR DESCRIPTION
During serialization of the result, `String.Chars.to_string` raises the following error when given a map: 
```
** (Protocol.UndefinedError) protocol String.Chars not implemented for %{} of type Map. This protocol is implemented for the following type(s): Decimal, Float, DateTime, Time, List, Version.Requirement, Atom, Integer, Version, Date, BitString, NaiveDateTime, URI
```
This trickles up to the end user when instead it should handle the serialization error more gracefully like the other scalars.