### PR TITLE
Fix string serialization error raising

### DIFF
--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -54,15 +54,18 @@ defmodule Absinthe.Phase.Document.Result do
           try do
             Type.Scalar.serialize(schema_node, value)
           rescue
-            Absinthe.SerializationError ->
-              raise(Absinthe.SerializationError, """
-              Could not serialize term #{inspect(value)} as type #{schema_node.name}
+            _e in [Absinthe.SerializationError, Protocol.UndefinedError] ->
+              raise(
+                Absinthe.SerializationError,
+                """
+                Could not serialize term #{inspect(value)} as type #{schema_node.name}
 
-              When serializing the field:
-              #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{
-                emitter.schema_node.__reference__.location.file
-              }:#{emitter.schema_node.__reference__.location.line})
-              """)
+                When serializing the field:
+                #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{
+                  emitter.schema_node.__reference__.location.file
+                }:#{emitter.schema_node.__reference__.location.line})
+                """
+              )
           end
 
         %Type.Enum{} = schema_node ->

--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -54,8 +54,16 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
     represent free-form human-readable text.
     """
 
-    serialize &String.Chars.to_string/1
+    serialize &__MODULE__.serialize_string/1
     parse parse_with([Absinthe.Blueprint.Input.String], &parse_string/1)
+  end
+
+  def serialize_string(n) when not is_map(n), do: String.Chars.to_string(n)
+
+  def serialize_string(n) do
+    raise Absinthe.SerializationError, """
+    Value #{inspect(n)} is not a valid string
+    """
   end
 
   scalar :id, name: "ID" do

--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -54,16 +54,8 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
     represent free-form human-readable text.
     """
 
-    serialize &__MODULE__.serialize_string/1
+    serialize &String.Chars.to_string/1
     parse parse_with([Absinthe.Blueprint.Input.String], &parse_string/1)
-  end
-
-  def serialize_string(n) when not is_map(n), do: String.Chars.to_string(n)
-
-  def serialize_string(n) do
-    raise Absinthe.SerializationError, """
-    Value #{inspect(n)} is not a valid string
-    """
   end
 
   scalar :id, name: "ID" do

--- a/test/absinthe/integration/execution/serialization_test.exs
+++ b/test/absinthe/integration/execution/serialization_test.exs
@@ -16,6 +16,10 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
       field :bad_boolean, :boolean do
         resolve fn _, _, _ -> {:ok, "true"} end
       end
+
+      field :bad_string, :string do
+        resolve fn _, _, _ -> {:ok, %{}} end
+      end
     end
   end
 
@@ -41,6 +45,15 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
   query { badBoolean }
   """
   test "returning not a boolean for a boolean raises" do
+    assert_raise(Absinthe.SerializationError, fn ->
+      Absinthe.run(@query, Schema)
+    end)
+  end
+
+  @query """
+  query { badString }
+  """
+  test "returning not a string for a string raises" do
     assert_raise(Absinthe.SerializationError, fn ->
       Absinthe.run(@query, Schema)
     end)

--- a/test/absinthe/integration/execution/serialization_test.exs
+++ b/test/absinthe/integration/execution/serialization_test.exs
@@ -53,7 +53,7 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
   @query """
   query { badString }
   """
-  test "returning not a string for a string raises" do
+  test "returning a type that can't `to_string` for a string raises" do
     assert_raise(Absinthe.SerializationError, fn ->
       Absinthe.run(@query, Schema)
     end)


### PR DESCRIPTION
During serialization of the result, String.Chars.to_string raises the following error when given a map:
```
** (Protocol.UndefinedError) protocol String.Chars not implemented for %{} of type Map. This protocol is implemented for the following type(s): Decimal, Float, DateTime, Time, List, Version.Requirement, Atom, Integer, Version, Date, BitString, NaiveDateTime, URI
```
This trickles up to the end user when instead it should handle the serialization error more gracefully like the other scalars.

