### PR TITLE
Returns an error when `{:error, nil}` is given to resolve/3 (#1063)

### DIFF
--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -269,6 +269,10 @@ defmodule Absinthe.Resolution do
     %{res | state: :resolved, errors: [error_keyword]}
   end
 
+  def put_result(res, {:error, nil}) do
+    put_result(res, {:error, ""})
+  end
+
   def put_result(res, {:error, errors}) do
     %{res | state: :resolved, errors: List.wrap(errors)}
   end

--- a/test/absinthe/resolution/middleware_test.exs
+++ b/test/absinthe/resolution/middleware_test.exs
@@ -61,6 +61,12 @@ defmodule Absinthe.MiddlewareTest do
         end
       end
 
+      field :returns_nil_error, :secret_object do
+        resolve fn _, _, _ ->
+          {:error, nil}
+        end
+      end
+
       field :from_context, :string do
         middleware fn res, _ ->
           %{res | context: %{value: "yooooo"}}
@@ -135,6 +141,22 @@ defmodule Absinthe.MiddlewareTest do
                locations: [%{column: 16, line: 1}],
                message: "unauthorized",
                path: ["public", "email"]
+             }
+           ] == errors
+  end
+
+  test "query returns an error with a nil error message" do
+    doc = """
+    { returns_nil_error { key } }
+    """
+
+    assert {:ok, %{errors: errors}} = Absinthe.run(doc, __MODULE__.Schema)
+
+    assert [
+             %{
+               locations: [%{column: 3, line: 1}],
+               message: "",
+               path: ["returns_nil_error"]
              }
            ] == errors
   end


### PR DESCRIPTION
Works in the same way that `{:error, ""}` would

I realize that maybe there isn't a conclusion on #1063 but I though I would at least hunt down the place where it's happening and make a test.  It should be easy enough to change the test if different behavior is desired