### PR TITLE
Support open ended scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Dev
 
 - Feature: Always inline functions when using persistent_term backend.
+- Feature: [Support optional open ended scalars](https://github.com/absinthe-graphql/absinthe/pull/1069)
 
 ## 1.6.4
 
@@ -72,11 +73,12 @@
 ## v1.5.0 (Rc)
 
 - Breaking Bug Fix: Variable types must align exactly with the argument type. Previously
-Absinthe allowed variables of different types to be used by accident as long as the data parsed.
+  Absinthe allowed variables of different types to be used by accident as long as the data parsed.
 - Feature (Experimental): `:persistent_term` based schema backend
 - Breaking Change: `telemetry` event keys [changed](https://github.com/absinthe-graphql/absinthe/pull/901) since the beta release.
 
 ## v1.5.0 (Beta)
+
 - Feature: SDL directives, other improvements
 - Feature: Output rendered SDL for a schema
 - Feature: Substantially lower subscription memory usage.

--- a/lib/absinthe/blueprint/schema/scalar_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/scalar_type_definition.ex
@@ -13,6 +13,7 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
     serialize: nil,
     directives: [],
     source_location: nil,
+    open_ended: false,
     # Added by phases
     flags: %{},
     errors: [],
@@ -37,7 +38,8 @@ defmodule Absinthe.Blueprint.Schema.ScalarTypeDefinition do
       description: type_def.description,
       definition: type_def.module,
       serialize: type_def.serialize,
-      parse: type_def.parse
+      parse: type_def.parse,
+      open_ended: type_def.open_ended
     }
   end
 

--- a/lib/absinthe/phase/document/arguments/data.ex
+++ b/lib/absinthe/phase/document/arguments/data.ex
@@ -53,7 +53,12 @@ defmodule Absinthe.Phase.Document.Arguments.Data do
   def handle_node(%Input.Value{normalized: %Input.Object{fields: fields}} = node) do
     data =
       for field <- fields, include_field?(field), into: %{} do
-        {field.schema_node.identifier, field.input_value.data}
+        # Scalar child nodes will not have a schema_node
+        if field.schema_node != nil do
+          {field.schema_node.identifier, field.input_value.data}
+        else
+          {field.name, field.input_value.data}
+        end
       end
 
     %{node | data: data}

--- a/lib/absinthe/phase/document/arguments/flag_invalid.ex
+++ b/lib/absinthe/phase/document/arguments/flag_invalid.ex
@@ -5,7 +5,7 @@ defmodule Absinthe.Phase.Document.Arguments.FlagInvalid do
   #
   # This is later used by the ArgumentsOfCorrectType phase.
 
-  alias Absinthe.{Blueprint, Phase}
+  alias Absinthe.{Blueprint, Phase, Type}
 
   use Absinthe.Phase
 
@@ -32,6 +32,10 @@ defmodule Absinthe.Phase.Document.Arguments.FlagInvalid do
 
   defp handle_node(%Blueprint.Input.List{} = node) do
     check_children(node, node.items |> Enum.map(& &1.normalized), :bad_list)
+  end
+
+  defp handle_node(%Blueprint.Input.Object{schema_node: %Type.Scalar{open_ended: true}} = node) do
+    node
   end
 
   defp handle_node(%Blueprint.Input.Object{} = node) do

--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -12,10 +12,6 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     {:ok, result}
   end
 
-  defp handle_node(%{schema_node: nil} = node, _context) do
-    {:halt, node}
-  end
-
   defp handle_node(%{normalized: nil} = node, _context) do
     node
   end
@@ -50,8 +46,26 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     end
   end
 
+  defp build_value(
+         %Input.Object{} = normalized,
+         %Type.Scalar{open_ended: true} = schema_node,
+         context
+       ) do
+    case Type.Scalar.parse(schema_node, normalized, context) do
+      :error ->
+        {:error, :bad_parse}
+
+      {:ok, val} ->
+        {:ok, val}
+    end
+  end
+
   defp build_value(_normalized, %Type.Scalar{}, _context) do
     {:error, :bad_parse}
+  end
+
+  defp build_value(%{value: value} = _normalized, nil = _schema_node, _context) do
+    {:ok, value}
   end
 
   defp build_value(%Input.Null{}, %Type.Enum{}, _) do

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -78,7 +78,8 @@ defmodule Absinthe.Type.Scalar do
             definition: nil,
             __reference__: nil,
             parse: nil,
-            serialize: nil
+            serialize: nil,
+            open_ended: false
 
   @typedoc "The internal, canonical representation of a scalar value"
   @type value_t :: any

--- a/test/absinthe/execution/arguments_test.exs
+++ b/test/absinthe/execution/arguments_test.exs
@@ -24,6 +24,58 @@ defmodule Absinthe.Execution.ArgumentsTest do
     )
   end
 
+  describe "open ended scalar" do
+    @graphql """
+    query {
+      entities(representations: [{__typename: "Product", id: "123"}])
+    }
+    """
+    test "supports passing an object directly" do
+      assert_data(
+        %{"entities" => [%{"__typename" => "Product", "id" => "123"}]},
+        run(@graphql, @schema)
+      )
+    end
+
+    @graphql """
+    query($representations: [Any!]!) {
+      entities(representations: $representations)
+    }
+    """
+    test "supports passing an object through variables" do
+      assert_data(
+        %{"entities" => [%{"__typename" => "Product", "id" => "123"}]},
+        run(@graphql, @schema,
+          variables: %{"representations" => [%{"__typename" => "Product", "id" => "123"}]}
+        )
+      )
+    end
+
+    @graphql """
+    query {
+      entities(representations: [{__typename: "Product", id: null}])
+    }
+    """
+    test "supports passing an object with a nested value of null" do
+      assert_data(
+        %{"entities" => [%{"__typename" => "Product", "id" => nil}]},
+        run(@graphql, @schema)
+      )
+    end
+
+    @graphql """
+    query {
+      entities(representations: [{__typename: "Product", contact_type: PHONE}])
+    }
+    """
+    test "supports passing an object with a nested value of ENUM" do
+      assert_data(
+        %{"entities" => [%{"__typename" => "Product", "contact_type" => "PHONE"}]},
+        run(@graphql, @schema)
+      )
+    end
+  end
+
   describe "errors" do
     @graphql """
     query FindUser {

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -7,6 +7,11 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
     false: "NO"
   }
 
+  scalar :any, open_ended: true do
+    parse fn value -> {:ok, value} end
+    serialize fn value -> value end
+  end
+
   scalar :input_name do
     parse fn %{value: value} -> {:ok, %{first_name: value}} end
     serialize fn %{first_name: name} -> name end
@@ -62,6 +67,14 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
   end
 
   query do
+    field :entities, list_of(:any) do
+      arg :representations, non_null(list_of(non_null(:any)))
+
+      resolve fn %{representations: representations}, _ ->
+        {:ok, representations}
+      end
+    end
+
     field :stuff, :integer do
       arg :stuff, non_null(:input_stuff)
 


### PR DESCRIPTION
This adds support for defining `open_ended` scalars that can recieve arbitrary GQL data.  We opted to put this behavior behind a flag so that it is an opt-in feature.  This was a necessary feature to support the Federation spec's `_Any` scalar