### PR TITLE
Fix union render with no UnionMemberTypes

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -150,25 +150,33 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   end
 
   defp render(%Blueprint.Schema.UnionTypeDefinition{} = union_type, type_definitions) do
-    types =
-      Enum.map(union_type.types, fn
-        identifier when is_atom(identifier) ->
-          render(%Blueprint.TypeReference.Identifier{id: identifier}, type_definitions)
+    Enum.map(union_type.types, fn
+      identifier when is_atom(identifier) ->
+        render(%Blueprint.TypeReference.Identifier{id: identifier}, type_definitions)
 
-        %Blueprint.TypeReference.Name{} = ref ->
-          render(ref, type_definitions)
+      %Blueprint.TypeReference.Name{} = ref ->
+        render(ref, type_definitions)
 
-        %Blueprint.TypeReference.Identifier{} = ref ->
-          render(ref, type_definitions)
-      end)
+      %Blueprint.TypeReference.Identifier{} = ref ->
+        render(ref, type_definitions)
+    end)
+    |> case do
+      [] ->
+        concat([
+          "union ",
+          string(union_type.name),
+          directives(union_type.directives, type_definitions)
+        ])
 
-    concat([
-      "union ",
-      string(union_type.name),
-      directives(union_type.directives, type_definitions),
-      " = ",
-      join(types, " | ")
-    ])
+      types ->
+        concat([
+          "union ",
+          string(union_type.name),
+          directives(union_type.directives, type_definitions),
+          " = ",
+          join(types, " | ")
+        ])
+    end
     |> description(union_type.description)
   end
 

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -144,9 +144,15 @@ defmodule Absinthe.Schema.SdlRenderTest do
       """)
     end
 
-    test "for a union" do
+    test "for a union with types" do
       assert_rendered("""
       union Foo = Bar | Baz
+      """)
+    end
+
+    test "for a union without types" do
+      assert_rendered("""
+      union Foo
       """)
     end
 


### PR DESCRIPTION
Adds a unit test for a case that wasnt being tested for union with no types and fixes the issue.  Spec says that the UnionMemberTypes are optional https://spec.graphql.org/draft/#UnionTypeDefinition

Resolves #1084 
