### PR TITLE
Account for prototype schema when generating SDL

### DIFF
--- a/lib/mix/tasks/absinthe.schema.sdl.ex
+++ b/lib/mix/tasks/absinthe.schema.sdl.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Sdl do
   def generate_schema(%Options{schema: schema}) do
     pipeline =
       schema
-      |> Absinthe.Pipeline.for_schema()
+      |> Absinthe.Pipeline.for_schema(prototype_schema: schema.__absinthe_prototype_schema__())
       |> Absinthe.Pipeline.upto({Absinthe.Phase.Schema.Validation.Result, pass: :final})
       |> Absinthe.Schema.apply_modifiers(schema)
 


### PR DESCRIPTION
The `Absinthe.Schema.to_sdl` function was taking this into account but the mix task was missing it see
https://github.com/absinthe-graphql/absinthe/blob/1948513d2103ac68182b64c62c0bf9fc35b96180/lib/absinthe/schema.ex#L616
