### PR TITLE
Is interface validation wrong with import_sdl?

### DIFF
--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -42,6 +42,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       scalarEcho(input: CoolScalar): CoolScalar
       namedThings: [Named]
       titledThings: [Titled]
+      playerField: PlayerInterface
     }
 
     scalar CoolScalar
@@ -95,6 +96,22 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     type Movie implements Titled {
       title: String!
       duration: Int!
+    }
+
+    interface PlayerInterface {
+      metadata: PlayerMetadataInterface
+    }
+
+    interface PlayerMetadataInterface {
+      displayName: String
+    }
+
+    type HumanPlayer implements PlayerInterface {
+      metadata: HumanMetadata
+    }
+
+    type HumanMetadata implements PlayerMetadataInterface {
+      displayName: String
     }
 
     scalar B
@@ -173,6 +190,18 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       [{:resolve_type, &__MODULE__.titled_resolve_type/2}]
     end
 
+    def hydrate(%{identifier: :player_field}, _) do
+      []
+    end
+
+    def hydrate(%{identifier: :player_interface}, _) do
+      [{:resolve_type, &__MODULE__.generic_interface_resolve_type/2}]
+    end
+
+    def hydrate(%{identifier: :player_metadata_interface}, _) do
+      [{:resolve_type, &__MODULE__.generic_interface_resolve_type/2}]
+    end
+
     def hydrate(%{identifier: :content}, _) do
       [{:resolve_type, &__MODULE__.content_resolve_type/2}]
     end
@@ -224,6 +253,10 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
     def titled_resolve_type(%{duration: _}, _), do: :movie
     def titled_resolve_type(%{pages: _}, _), do: :book
+
+    def generic_interface_resolve_type(_, _), do: nil
+    def interface_a_resolve_type(_, _), do: nil
+    def interface_b_resolve_type(_, _), do: nil
 
     def content_resolve_type(_, _), do: :comment
 

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -446,4 +446,75 @@ defmodule Absinthe.SchemaTest do
       assert Type.meta(result, :is_union) == true
     end
   end
+
+  defmodule InterfaceWebSchema do
+    use Absinthe.Schema
+
+    import_types SourceSchema
+
+    query do
+      field :player_field, type: :player_interface
+    end
+
+    interface :player_interface do
+      field :metadata, :player_metadata_interface
+
+      resolve_type fn _, _ -> nil end
+    end
+
+    interface :player_metadata_interface do
+      field :display_name, :string
+
+      resolve_type fn _, _ -> nil end
+    end
+
+    object :human_player do
+      interfaces [:player_interface]
+
+      field :metadata, :human_metadata
+    end
+
+    object :human_metadata do
+      interfaces [:player_metadata_interface]
+
+      field :display_name, :string
+    end
+  end
+
+  describe "Interface Web" do
+    test "is valid maybe?" do
+      human_player_type = Schema.lookup_type(InterfaceWebSchema, :human_player)
+
+      assert human_player_type.fields.metadata.name == "metadata"
+      assert human_player_type.fields.metadata.type == :human_metadata
+
+      # Schema.to_sdl(InterfaceWebSchema)
+      # |> IO.puts()
+      #
+      # "Represents a schema"
+      # schema {
+      #   query: RootQueryType
+      # }
+
+      # interface PlayerMetadataInterface {
+      #   displayName: String
+      # }
+
+      # type HumanMetadata implements PlayerMetadataInterface {
+      #   displayName: String
+      # }
+
+      # type RootQueryType {
+      #   playerField: PlayerInterface
+      # }
+
+      # interface PlayerInterface {
+      #   metadata: PlayerMetadataInterface
+      # }
+
+      # type HumanPlayer implements PlayerInterface {
+      #   metadata: HumanMetadata
+      # }
+    end
+  end
 end


### PR DESCRIPTION
This is a question/maybe-bug but I'm submitting as a PR to include my testing code. Let me know if you'd like me to move this over to an issue.

We recently received a schema addition with a usage of interfaces that's atypical for us. It looks something like this:

```graphql
    interface PlayerInterface {
      metadata: PlayerMetadataInterface
    }

    interface PlayerMetadataInterface {
      displayName: String
    }

    type HumanPlayer implements PlayerInterface {
      metadata: HumanMetadata
    }

    type HumanMetadata implements PlayerMetadataInterface {
      displayName: String
    }
```

I think the thing that caught my eye is that `HumanPlayer` implements `PlayerInterface` but uses the type `HumanMetadata` for the metadata field. Since `HumanMetadata` implements `PlayerMetadataInterface` I think... it... should work? Honestly I'm not sure.

What I'm curious about is a possible discrepancy between defining a schema with import_sdl vs. the DSL.

If I import an SDL with this schema I get an error I'm familiar with:
```
== Compilation error in file test/absinthe/schema/notation/experimental/import_sdl_test.exs ==
** (Absinthe.Schema.Error) Compilation failed:
---------------------------------------
## Locations
/Users/mbaker/code/absinthe/test/absinthe/schema/notation/experimental/import_sdl_test.exs:23

Type "human_player" does not fully implement interface type "player_interface" for fields [:metadata]

An object type must be a super-set of all interfaces it implements.

* The object type must include a field of the same name for every field
  defined in an interface.
  * The object field must be of a type which is equal to or a sub-type of
    the interface field (covariant).
  * An object field type is a valid sub-type if it is equal to (the same
    type as) the interface field type.
  * An object field type is a valid sub-type if it is an Object type and the
    interface field type is either an Interface type or a Union type and the
    object field type is a possible type of the interface field type.
  * An object field type is a valid sub-type if it is a List type and the
    interface field type is also a List type and the list-item type of the
    object field type is a valid sub-type of the list-item type of the
    interface field type.
  * An object field type is a valid sub-type if it is a Non-Null variant of a
    valid sub-type of the interface field type.
* The object field must include an argument of the same name for every
  argument defined in the interface field.
  * The object field argument must accept the same type (invariant) as the
    interface field argument.
* The object field may include additional arguments not defined in the
  interface field, but any additional argument must not be required.
  ```

If I do it via the DSL Absinthe _seems_ to be ok with it (the sample test passes at least). This is backed up by the fact that the actual schema this example is derived from is in an Absinthe service (expressed using the DSL) and compiles just fine. My apologies if this is unclear, it's sort of hard to describe!

I think my first question is, am I right that we're seeing a discrepancy here? And if there is a discrepancy, is the schema truly valid or truly invalid?

As an aside, I realize the resolve_type functions are just returning `nil` but I don't think it should matter here, right? 