### PR TITLE
Allow interface fields to reference other interfaces (#1089)

### DIFF
--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -191,6 +191,18 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
     :ok
   end
 
+  defp check_covariant(
+         %Blueprint.TypeReference.Name{name: iface_name},
+         %Blueprint.TypeReference.Name{name: type_name},
+         field_ident,
+         types
+       ) do
+    {_, itype} = Enum.find(types, fn {_, %{name: name}} -> name == iface_name end)
+    {_, type} = Enum.find(types, fn {_, %{name: name}} -> name == type_name end)
+
+    check_covariant(itype, type, field_ident, types)
+  end
+
   defp check_covariant(nil, _, field_ident, _), do: {:error, field_ident}
   defp check_covariant(_, nil, field_ident, _), do: {:error, field_ident}
 

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -42,6 +42,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       scalarEcho(input: CoolScalar): CoolScalar
       namedThings: [Named]
       titledThings: [Titled]
+      playerField: PlayerInterface
     }
 
     scalar CoolScalar
@@ -95,6 +96,22 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     type Movie implements Titled {
       title: String!
       duration: Int!
+    }
+
+    interface PlayerInterface {
+      metadata: PlayerMetadataInterface
+    }
+
+    interface PlayerMetadataInterface {
+      displayName: String
+    }
+
+    type HumanPlayer implements PlayerInterface {
+      metadata: HumanMetadata
+    }
+
+    type HumanMetadata implements PlayerMetadataInterface {
+      displayName: String
     }
 
     scalar B
@@ -173,6 +190,14 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
       [{:resolve_type, &__MODULE__.titled_resolve_type/2}]
     end
 
+    def hydrate(%{identifier: :player_interface}, _) do
+      [{:resolve_type, &__MODULE__.player_interface/2}]
+    end
+
+    def hydrate(%{identifier: :player_metadata_interface}, _) do
+      [{:resolve_type, &__MODULE__.player_metadata_interface/2}]
+    end
+
     def hydrate(%{identifier: :content}, _) do
       [{:resolve_type, &__MODULE__.content_resolve_type/2}]
     end
@@ -231,6 +256,9 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
 
     def parse_cool_scalar(value), do: {:ok, value}
     def serialize_cool_scalar(%{value: value}), do: value
+
+    def player_interface(_, _), do: :human_player
+    def player_metadata_interface(_, _), do: :human_metadata
   end
 
   describe "custom prototype schema" do

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -176,10 +176,10 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
 
   test "interface fields can reference other interfaces" do
     assert %{
-             pet: [:dog, :cat],
-             pet_food: [:dog_food, :cat_food]
+             pet: [:cat, :dog],
+             pet_food: [:cat_food, :dog_food]
            } ==
-             InterfaceImplementsInterfaces.__absinthe_interface_implementors__()
+             InterfaceFieldsReferenceInterfaces.__absinthe_interface_implementors__()
   end
 
   test "is enforced" do

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -128,6 +128,60 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
              InterfaceImplementsInterfaces.__absinthe_interface_implementors__()
   end
 
+  defmodule InterfaceFieldsReferenceInterfaces do
+    use Absinthe.Schema
+
+    import_sdl """
+    interface Pet {
+      food: PetFood!
+    }
+
+    interface PetFood {
+      brand: String!
+    }
+
+    type Dog implements Pet {
+      food: DogFood!
+    }
+
+    type DogFood implements PetFood {
+      brand: String!
+    }
+
+    type Cat implements Pet {
+      food: CatFood!
+    }
+
+    type CatFood implements PetFood {
+      brand: String!
+    }
+    """
+
+    query do
+    end
+
+    def hydrate(%{identifier: :pet}, _) do
+      [{:resolve_type, &__MODULE__.pet/2}]
+    end
+
+    def hydrate(%{identifier: :pet_food}, _) do
+      [{:resolve_type, &__MODULE__.pet_food/2}]
+    end
+
+    def hydrate(_, _), do: []
+
+    def pet(_, _), do: nil
+    def pet_food(_, _), do: nil
+  end
+
+  test "interface fields can reference other interfaces" do
+    assert %{
+             pet: [:dog, :cat],
+             pet_food: [:dog_food, :cat_food]
+           } ==
+             InterfaceImplementsInterfaces.__absinthe_interface_implementors__()
+  end
+
   test "is enforced" do
     assert_schema_error("invalid_interface_types", [
       %{


### PR DESCRIPTION
Closes #1089

It appears the DSL and the `import_sdl` differ in how interface types, with fields that themselves interfaces types, are compiled. When creating schemas via the DSL, compilation works as intended. I can create an interface that contains a field that is another interface type. When I do the same via `import_sdl`, compilation fails because it Absinthe thinks that the interface is not fully adhered to. This attempts to patch that behavior to ensure interface types can have fields that are themselves interfaces.

To ensure this use case is valid according to the GraphQL [spec](https://spec.graphql.org/June2018/#sec-Interface), I created a [minimal reproduction](https://github.com/jerelmiller/graphql-interface-reproduction) of this schema using GraphQL.js to validate whether the SDL or the DSL had the correct behavior. It does indeed appear that interface types are allowed as fields to other interface types.