### PR TITLE
Fix exception when field name contains all invalid characters

### DIFF
--- a/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
+++ b/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
@@ -5,7 +5,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Schema
 
-  @valid_name_regex ~r/[_A-Za-z][_0-9A-Za-z]*/
+  @valid_name_regex ~r/^[_A-Za-z][_0-9A-Za-z]*$/
 
   def run(bp, _) do
     bp = Blueprint.prewalk(bp, &validate_names/1)
@@ -31,8 +31,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
   end
 
   defp valid_name?(name) do
-    [match] = Regex.run(@valid_name_regex, name)
-    match == name
+    Regex.match?(@valid_name_regex, name)
   end
 
   defp error(object, data) do
@@ -50,6 +49,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
   defp struct_to_kind(Schema.ScalarTypeDefinition), do: "scalar"
   defp struct_to_kind(Schema.ObjectTypeDefinition), do: "object"
   defp struct_to_kind(Schema.InputObjectTypeDefinition), do: "input object"
+  defp struct_to_kind(Schema.EnumValueDefinition), do: "enum value"
   defp struct_to_kind(_), do: "type"
 
   @description """

--- a/test/absinthe/schema/rule/names_must_be_valid_test.exs
+++ b/test/absinthe/schema/rule/names_must_be_valid_test.exs
@@ -17,7 +17,8 @@ defmodule Absinthe.Schema.Rule.NamesMustBeValidTest do
         %{
           phase: NamesMustBeValid,
           extra: %{artifact: "input object name", value: "bad input name"}
-        }
+        },
+        %{phase: NamesMustBeValid, extra: %{artifact: "enum value name", value: "1"}}
       ])
     end
   end

--- a/test/support/fixtures/dynamic/bad_names_schema.exs
+++ b/test/support/fixtures/dynamic/bad_names_schema.exs
@@ -25,4 +25,8 @@ defmodule Absinthe.TestSupport.Schema.BadNamesSchema do
       arg :foo, :string, name: "bad arg name"
     end
   end
+
+  enum :rating do
+    value :"1", as: 1
+  end
 end


### PR DESCRIPTION
This exception is raised when the entire artifact name is invalid (like "1").

    == Compilation error in file lib/my_app/schema.ex ==
    ** (MatchError) no match of right hand side value: nil
        lib/absinthe/phase/schema/validation/names_must_be_valid.ex:34: Absinthe.Phase.Schema.Validation.NamesMustBeValid.valid_name?/1
        lib/absinthe/phase/schema/validation/names_must_be_valid.ex:20: Absinthe.Phase.Schema.Validation.NamesMustBeValid.validate_names/1
        lib/absinthe/blueprint/transform.ex:16: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
        lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        (elixir 1.10.2) lib/enum.ex:1520: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:145: anonymous fn/4 in Absinthe.Blueprint.Transform.walk_children/5
        (elixir 1.10.2) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
        lib/absinthe/blueprint/transform.ex:114: Absinthe.Blueprint.Transform.walk/4
        lib/absinthe/blueprint/transform.ex:15: Absinthe.Blueprint.Transform.prewalk/2
        lib/absinthe/phase/schema/validation/names_must_be_valid.ex:11: Absinthe.Phase.Schema.Validation.NamesMustBeValid.run/2
        lib/absinthe/pipeline.ex:369: Absinthe.Pipeline.run_phase/3

This fixes that exception by simplifying the code by using `Regex.match?/2` together with beginning and end of line anchors.

It also adds a new kind: `"enum value"`.
