### PR TITLE
Update telemetry dependency to stable ~> 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule Absinthe.Mixfile do
   defp deps do
     [
       {:nimble_parsec, "~> 0.5 or ~> 1.0"},
-      {:telemetry, "~> 0.4.0"},
+      {:telemetry, "~> 1.0 or ~> 0.4"},
       {:dataloader, "~> 1.0.0", optional: true},
       {:decimal, "~> 1.0 or ~> 2.0", optional: true},
       {:ex_doc, "~> 0.22", only: :dev},


### PR DESCRIPTION
There [were no changes in the Telemetry 1.0.0 release](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100) - but it does represent the first "stable" version of the API.

Matches [dataloader requirements update](https://github.com/absinthe-graphql/dataloader/pull/132).