### PR TITLE
Add missing information in 1.5 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Feature: Substantially lower subscription memory usage.
 - Documentation: Testing guide, numerous fixes and updates
 - Breaking Change: Scalar outputs are now type checked and will raise exceptions if the result tries to send the wrong data type in the result.
+- Breaking Change: Scalar variables are now type checked and will raise exceptions when clients try to send a query with invalid variable definitions.
 - Breaking Change: `telemetry` event names [changed](https://github.com/absinthe-graphql/absinthe/pull/782) from the `alpha` to match an emerging naming convention for tracing.
 - Breaking Change: Added phase to check validity of field names according to GraphQL spec. Might break existing schema's. Remove the `Absinthe.Phase.Schema.Validation.NamesMustBeValid` from the schema pipeline if you want to ignore this.
 - Breaking Change: To match the GraphQL spec, we [no longer](https://github.com/absinthe-graphql/absinthe/pull/816) add a non-null error when a resolver on a non-null field explicitly returns its own error.

--- a/guides/upgrading/v1.5.md
+++ b/guides/upgrading/v1.5.md
@@ -16,9 +16,11 @@ Existing macro-based schemas will work as-is, but make sure to note that the sch
 
 Default values are evaluated at compile time. For example `default_value: DateTime.utc_now()` will have its time set at compile time. You probably don't want this :)
 
-### Scalar output validation
+### Scalar validation
 
 Scalar outputs are now type checked and will raise exceptions if the result tries to send the wrong data type in the result.
+
+Scalar variables are now type checked too and will raise exceptions when clients try to send a query with invalid variable definitions.
 
 ### Field name validation
 


### PR DESCRIPTION
Bumping from 1.4 to 1.6, I feel like this information was missing in changelogs.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
