### PR TITLE
Rename root type names

### DIFF
--- a/lib/absinthe/phase/schema/introspection.ex
+++ b/lib/absinthe/phase/schema/introspection.ex
@@ -37,7 +37,7 @@ defmodule Absinthe.Phase.Schema.Introspection do
   def update_type_defs(type_defs) do
     for type_def = %struct_type{} <- type_defs do
       cond do
-        type_def.name in ["RootQueryType", "Query"] ->
+        type_def.name in ["Query", "Query"] ->
           type_field = field_def(:type)
           schema_field = field_def(:schema)
           typename_field = field_def(:typename)

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -150,7 +150,7 @@ defmodule Absinthe.Schema do
 
   @object_type Absinthe.Blueprint.Schema.ObjectTypeDefinition
 
-  @default_query_name "RootQueryType"
+  @default_query_name "Query"
   @doc """
   Defines a root Query object
   """
@@ -166,7 +166,7 @@ defmodule Absinthe.Schema do
     Absinthe.Schema.Notation.record!(env, @object_type, :query, attrs, block)
   end
 
-  @default_mutation_name "RootMutationType"
+  @default_mutation_name "Mutation"
   @doc """
   Defines a root Mutation object
 
@@ -193,7 +193,7 @@ defmodule Absinthe.Schema do
     Absinthe.Schema.Notation.record!(env, @object_type, :mutation, attrs, block)
   end
 
-  @default_subscription_name "RootSubscriptionType"
+  @default_subscription_name "Subscription"
   @doc """
   Defines a root Subscription object
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -275,7 +275,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
                  %{
                    locations: [%{column: 30, line: 2}],
                    message:
-                     "Unknown argument \"extra\" on field \"thing\" of type \"RootSubscriptionType\"."
+                     "Unknown argument \"extra\" on field \"thing\" of type \"Subscription\"."
                  }
                ]
              }

--- a/test/absinthe/fragment_merge_test.exs
+++ b/test/absinthe/fragment_merge_test.exs
@@ -109,7 +109,7 @@ defmodule Absinthe.FragmentMergeTest do
       }
     }
 
-    fragment fragmentWithOtherField on RootQueryType {
+    fragment fragmentWithOtherField on Query {
       viewer {
         todos {
           completedCount

--- a/test/absinthe/integration/execution/fragments/basic_root_type_test.exs
+++ b/test/absinthe/integration/execution/fragments/basic_root_type_test.exs
@@ -6,7 +6,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Fragments.BasicRootTypeTest do
     ... Fields
   }
 
-  fragment Fields on RootQueryType {
+  fragment Fields on Query {
     thing(id: "foo") {
       name
     }

--- a/test/absinthe/integration/execution/introspection/mutation_type_test.exs
+++ b/test/absinthe/integration/execution/introspection/mutation_type_test.exs
@@ -10,7 +10,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.MutationTypeTest d
             %{
               data: %{
                 "__schema" => %{
-                  "mutationType" => %{"kind" => "OBJECT", "name" => "RootMutationType"}
+                  "mutationType" => %{"kind" => "OBJECT", "name" => "Mutation"}
                 }
               }
             }} == Absinthe.run(@query, Absinthe.Fixtures.ContactSchema, [])

--- a/test/absinthe/integration/execution/introspection/query_type_test.exs
+++ b/test/absinthe/integration/execution/introspection/query_type_test.exs
@@ -9,7 +9,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.QueryTypeTest do
     assert {:ok,
             %{
               data: %{
-                "__schema" => %{"queryType" => %{"kind" => "OBJECT", "name" => "RootQueryType"}}
+                "__schema" => %{"queryType" => %{"kind" => "OBJECT", "name" => "Query"}}
               }
             }} == Absinthe.run(@query, Absinthe.Fixtures.ContactSchema, [])
   end

--- a/test/absinthe/integration/execution/introspection/schema_types_test.exs
+++ b/test/absinthe/integration/execution/introspection/schema_types_test.exs
@@ -18,14 +18,14 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.SchemaTypesTest do
     "Business",
     "Contact",
     "Int",
-    "RootMutationType",
+    "Mutation",
     "NamedEntity",
     "Person",
     "ProfileInput",
-    "RootQueryType",
+    "Query",
     "SearchResult",
     "String",
-    "RootSubscriptionType"
+    "Subscription"
   ]
 
   test "scenario #1" do

--- a/test/absinthe/integration/execution/introspection/subscription_type_test.exs
+++ b/test/absinthe/integration/execution/introspection/subscription_type_test.exs
@@ -10,7 +10,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.SubscriptionTypeTe
             %{
               data: %{
                 "__schema" => %{
-                  "subscriptionType" => %{"kind" => "OBJECT", "name" => "RootSubscriptionType"}
+                  "subscriptionType" => %{"kind" => "OBJECT", "name" => "Subscription"}
                 }
               }
             }} == Absinthe.run(@query, Absinthe.Fixtures.ContactSchema, [])

--- a/test/absinthe/integration/validation/cycles_test.exs
+++ b/test/absinthe/integration/validation/cycles_test.exs
@@ -35,7 +35,7 @@ defmodule Elixir.Absinthe.Integration.Validation.CyclesTest do
   query Foo {
     ...Bar
   }
-  fragment Bar on RootQueryType {
+  fragment Bar on Query {
     version
     ...Foo
   }

--- a/test/absinthe/integration/validation/extra_arguments_test.exs
+++ b/test/absinthe/integration/validation/extra_arguments_test.exs
@@ -14,8 +14,7 @@ defmodule Elixir.Absinthe.Integration.Validation.ExtraArgumentsTest do
             %{
               errors: [
                 %{
-                  message:
-                    "Unknown argument \"extra\" on field \"thing\" of type \"RootQueryType\".",
+                  message: "Unknown argument \"extra\" on field \"thing\" of type \"Query\".",
                   locations: [%{column: 20, line: 2}]
                 }
               ]

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -583,7 +583,7 @@ defmodule Absinthe.IntrospectionTest do
          errors: [
            %{
              locations: [%{column: 3, line: 2}],
-             message: "Cannot query field \"__foobar\" on type \"RootQueryType\"."
+             message: "Cannot query field \"__foobar\" on type \"Query\"."
            }
          ]
        }},

--- a/test/absinthe/language/inline_fragment_test.exs
+++ b/test/absinthe/language/inline_fragment_test.exs
@@ -5,7 +5,7 @@ defmodule Absinthe.Language.InlineFragmentTest do
 
   @query """
   {
-    ... on RootQueryType {
+    ... on Query {
       foo
       bar
     }
@@ -15,7 +15,7 @@ defmodule Absinthe.Language.InlineFragmentTest do
   describe "converting to Blueprint" do
     test "builds a Document.Fragment.Inline.t" do
       assert %Blueprint.Document.Fragment.Inline{
-               type_condition: %Blueprint.TypeReference.Name{name: "RootQueryType"},
+               type_condition: %Blueprint.TypeReference.Name{name: "Query"},
                selections: [
                  %Blueprint.Document.Field{name: "foo"},
                  %Blueprint.Document.Field{name: "bar"}

--- a/test/absinthe/resolution/middleware_test.exs
+++ b/test/absinthe/resolution/middleware_test.exs
@@ -194,7 +194,7 @@ defmodule Absinthe.MiddlewareTest do
     assert {:ok, %{data: data}} =
              Absinthe.run(doc, __MODULE__.Schema, context: %{current_user: %{}})
 
-    assert %{"foo" => %{"bar" => %{"result" => ["result", "bar", "foo", "RootQueryType"]}}} ==
+    assert %{"foo" => %{"bar" => %{"result" => ["result", "bar", "foo", "Query"]}}} ==
              data
   end
 end

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -242,13 +242,13 @@ defmodule Absinthe.Schema.SdlRenderTest do
              """
              "Represents a schema"
              schema {
-               query: RootQueryType
+               query: Query
              }
 
              directive @foo(baz: String) on FIELD
 
              "Escaped\\t\\\"descrição\\/description\\\""
-             type RootQueryType {
+             type Query {
                echo(
                  "The number of times"
                  times: Int

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -201,7 +201,7 @@ defmodule Absinthe.SchemaTest do
       field :name, :string
     end
 
-    subscription name: "RootSubscriptionTypeThing" do
+    subscription name: "SubscriptionThing" do
       field :name, :string
     end
   end
@@ -267,7 +267,7 @@ defmodule Absinthe.SchemaTest do
 
   describe "root fields" do
     test "can have a default name" do
-      assert "RootQueryType" == Schema.lookup_type(RootsSchema, :query).name
+      assert "Query" == Schema.lookup_type(RootsSchema, :query).name
     end
 
     test "can have a custom name" do
@@ -275,7 +275,7 @@ defmodule Absinthe.SchemaTest do
     end
 
     test "supports subscriptions" do
-      assert "RootSubscriptionTypeThing" == Schema.lookup_type(RootsSchema, :subscription).name
+      assert "SubscriptionThing" == Schema.lookup_type(RootsSchema, :subscription).name
     end
   end
 
@@ -300,7 +300,7 @@ defmodule Absinthe.SchemaTest do
   describe "to_sdl/1" do
     test "return schema sdl" do
       assert Schema.to_sdl(SourceSchema) == """
-             \"Represents a schema\"\nschema {\n  query: RootQueryType\n}\n\ntype Foo {\n  name: String\n}\n\n\"can describe query\"\ntype RootQueryType {\n  foo: Foo\n}
+             \"Represents a schema\"\nschema {\n  query: Query\n}\n\ntype Foo {\n  name: String\n}\n\n\"can describe query\"\ntype Query {\n  foo: Foo\n}
              """
     end
   end

--- a/test/absinthe/strict_schema_test.exs
+++ b/test/absinthe/strict_schema_test.exs
@@ -158,7 +158,7 @@ defmodule Absinthe.StrictSchemaTest do
       variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
 
       assert_error_message(
-        "Cannot query field \"foo_bar_query\" on type \"RootQueryType\". Did you mean to use an inline fragment on \"RootQueryType\"?",
+        "Cannot query field \"foo_bar_query\" on type \"Query\". Did you mean to use an inline fragment on \"Query\"?",
         run(document, Absinthe.Fixtures.StrictSchema,
           adapter: Absinthe.Adapter.StrictLanguageConventions,
           variables: variables
@@ -178,7 +178,7 @@ defmodule Absinthe.StrictSchemaTest do
       variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
 
       assert_error_message(
-        "Unknown argument \"baz_qux\" on field \"fooBarQuery\" of type \"RootQueryType\".",
+        "Unknown argument \"baz_qux\" on field \"fooBarQuery\" of type \"Query\".",
         run(document, Absinthe.Fixtures.StrictSchema,
           adapter: Absinthe.Adapter.StrictLanguageConventions,
           variables: variables
@@ -282,7 +282,7 @@ defmodule Absinthe.StrictSchemaTest do
       variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
 
       assert_error_message(
-        "Cannot query field \"foo_bar_mutation\" on type \"RootMutationType\". Did you mean to use an inline fragment on \"RootMutationType\"?",
+        "Cannot query field \"foo_bar_mutation\" on type \"Mutation\". Did you mean to use an inline fragment on \"Mutation\"?",
         run(document, Absinthe.Fixtures.StrictSchema,
           adapter: Absinthe.Adapter.StrictLanguageConventions,
           variables: variables
@@ -302,7 +302,7 @@ defmodule Absinthe.StrictSchemaTest do
       variables = %{"input" => %{"naiveDatetime" => "2017-01-27T20:31:55"}}
 
       assert_error_message(
-        "Unknown argument \"baz_qux\" on field \"fooBarMutation\" of type \"RootMutationType\".",
+        "Unknown argument \"baz_qux\" on field \"fooBarMutation\" of type \"Mutation\".",
         run(document, Absinthe.Fixtures.StrictSchema,
           adapter: Absinthe.Adapter.StrictLanguageConventions,
           variables: variables

--- a/test/absinthe/type/mutation_test.exs
+++ b/test/absinthe/type/mutation_test.exs
@@ -62,7 +62,7 @@ defmodule Absinthe.Type.MutationTest do
                       expected_value: expected_value
                     } ->
       test "for #{test_label} (evaluates description to '#{expected_value}')" do
-        type = TestSchema.__absinthe_type__("RootMutationType")
+        type = TestSchema.__absinthe_type__("Mutation")
 
         assert type.fields[unquote(test_label)].args.arg_example.description ==
                  unquote(expected_value)

--- a/test/absinthe/type/query_test.exs
+++ b/test/absinthe/type/query_test.exs
@@ -10,7 +10,7 @@ defmodule Absinthe.Type.QueryTest do
                       expected_value: expected_value
                     } ->
       test "for #{test_label} (evaluates description to '#{expected_value}')" do
-        type = Query.TestSchemaFieldArgDescription.__absinthe_type__("RootQueryType")
+        type = Query.TestSchemaFieldArgDescription.__absinthe_type__("Query")
 
         assert type.fields[unquote(test_label)].args.arg_example.description ==
                  unquote(expected_value)
@@ -25,7 +25,7 @@ defmodule Absinthe.Type.QueryTest do
                       expected_value: expected_value
                     } ->
       test "for #{test_label} (evaluates default_value to '#{expected_value}')" do
-        type = Query.TestSchemaFieldArgDefaultValue.__absinthe_type__("RootQueryType")
+        type = Query.TestSchemaFieldArgDefaultValue.__absinthe_type__("Query")
         field = type.fields[unquote(test_label)]
 
         assert field.args.arg_example.default_value == unquote(expected_value)
@@ -40,8 +40,7 @@ defmodule Absinthe.Type.QueryTest do
                       expected_value: expected_value
                     } ->
       test "for #{test_label} (evaluates default_value to '#{expected_value}')" do
-        type =
-          Query.TestSchemaFieldArgDefaultValueWithImportFields.__absinthe_type__("RootQueryType")
+        type = Query.TestSchemaFieldArgDefaultValueWithImportFields.__absinthe_type__("Query")
 
         field = type.fields[unquote(test_label)]
 

--- a/test/absinthe/type_test.exs
+++ b/test/absinthe/type_test.exs
@@ -57,11 +57,11 @@ defmodule Absinthe.TypeTest do
   end
 
   test "root query type definition" do
-    assert Absinthe.Fixtures.ContactSchema.__absinthe_type__(:query).name == "RootQueryType"
+    assert Absinthe.Fixtures.ContactSchema.__absinthe_type__(:query).name == "Query"
   end
 
   test "root mutation type definition" do
-    assert Absinthe.Fixtures.ContactSchema.__absinthe_type__(:mutation).name == "RootMutationType"
+    assert Absinthe.Fixtures.ContactSchema.__absinthe_type__(:mutation).name == "Mutation"
   end
 
   defmodule MetadataSchema do

--- a/test/support/fixtures/things/sdl_schema.ex
+++ b/test/support/fixtures/things/sdl_schema.ex
@@ -21,13 +21,13 @@ defmodule Absinthe.Fixtures.Things.SDLSchema do
     MULTIPLE_WITHOUT_MESSAGE
   }
 
-  type RootMutationType {
+  type Mutation {
     updateThing(id: String!, thing: InputThing!): Thing
 
     failingThing(type: FailureType): Thing
   }
 
-  type RootQueryType {
+  type Query {
     version: String
 
     badResolution: Thing
@@ -94,8 +94,8 @@ defmodule Absinthe.Fixtures.Things.SDLSchema do
   }
 
   schema {
-    mutation: RootMutationType
-    query: RootQueryType
+    mutation: Mutation
+    query: Query
   }
 
   """


### PR DESCRIPTION
I realize this is a breaking change for some but seems to be going in the right direction, I am okay with waiting for this until we are ready to make breaking changes.  I ran into this difference while working on https://github.com/apollographql/apollo-federation-subgraph-compatibility/pull/35 thankfully you can override the name so I was able to.

https://spec.graphql.org/draft/#sec-Root-Operation-Types.Default-Root-Operation-Type-Names

## Default Root Operation Type Names

While any type can be the root operation type for a GraphQL operation, the type system definition language can omit the schema definition when the query, mutation, and subscription root types are named "Query", "Mutation", and "Subscription" respectively.

Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if it only uses the default root operation type names.

This example describes a valid complete GraphQL schema, despite not explicitly including a schema definition. The "Query" type is presumed to be the query root operation type of the schema.

```graphql
type Query {
  someField: String
}
```