### PR TITLE
Default values not rendered in the sdl

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -143,6 +143,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       directives(input_value.directives, type_definitions)
     ])
     |> description(input_value.description)
+    |> deprecation(input_value.deprecation)
   end
 
   defp render(%Blueprint.Schema.FieldDefinition{} = field, type_definitions) do
@@ -154,6 +155,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       directives(field.directives, type_definitions)
     ])
     |> description(field.description)
+    |> deprecation(field.deprecation)
   end
 
   defp render(%Blueprint.Schema.ObjectTypeDefinition{} = object_type, type_definitions) do
@@ -243,6 +245,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       directives(enum_value.directives, type_definitions)
     ])
     |> description(enum_value.description)
+    |> deprecation(enum_value.deprecation)
   end
 
   defp render(%Blueprint.Schema.ScalarTypeDefinition{} = scalar_type, type_definitions) do
@@ -392,6 +395,14 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       line(),
       docs
     ])
+  end
+
+  defp deprecation(docs, nil) do
+    docs
+  end
+
+  defp deprecation(docs, %Absinthe.Type.Deprecation{reason: reason}) do
+    concat([docs, " @deprecated(reason: \"#{reason}\")"])
   end
 
   defp implements(%{interface_blueprints: [], interfaces: []}, _) do

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -196,7 +196,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
 
       field :echo, :string do
         arg :times, :integer, default_value: 10, description: "The number of times"
-        arg :time_interval, :integer
+        arg :time_interval, :integer, deprecate: "Old interval"
         arg :time_string, :string, default_value: "2021"
         arg :order_status, non_null(:order_status), default_value: :processing
       end
@@ -221,6 +221,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
     object :order do
       field :id, :id
       field :name, :string
+      field :braun, :string, deprecate: "Deprecated"
       field :status, :order_status
       field :other_status, :status
       import_fields :imported_fields
@@ -255,7 +256,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
                  "The number of times"
                  times: Int = 10
 
-                 timeInterval: Int
+                 timeInterval: Int @deprecated(reason: \"Old interval\")
 
                  timeString: String = "2021"
 
@@ -286,6 +287,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
                imported: Boolean!
                id: ID
                name: String
+               braun: String @deprecated(reason: \"Deprecated\")
                status: OrderStatus
                otherStatus: Status
              }

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -197,6 +197,8 @@ defmodule Absinthe.Schema.SdlRenderTest do
       field :echo, :string do
         arg :times, :integer, default_value: 10, description: "The number of times"
         arg :time_interval, :integer
+        arg :time_string, :string, default_value: "2021"
+        arg :order_status, non_null(:order_status), default_value: :processing
       end
 
       field :search, :search_result
@@ -251,9 +253,13 @@ defmodule Absinthe.Schema.SdlRenderTest do
              type RootQueryType {
                echo(
                  "The number of times"
-                 times: Int
+                 times: Int = 10
 
                  timeInterval: Int
+
+                 timeString: String = "2021"
+
+                 orderStatus: OrderStatus! = PROCESSING
                ): String
                search: SearchResult
              }


### PR DESCRIPTION
When specifying default values in input arguments they aren't rendered in the sdl, using `Absinthe.Schema.to_sdl`