### PR TITLE
Update typespec for resolver_t

### DIFF
--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -19,7 +19,13 @@ defmodule Absinthe.Type.Field do
 
   See the `Absinthe.Type.Field.t` explanation of `:resolve` for more information.
   """
-  @type resolver_t :: (%{atom => any}, Absinthe.Resolution.t() -> result)
+  @type resolver_t ::
+          (Absinthe.Resolution.arguments(), Absinthe.Resolution.t() -> result)
+          | (Absinthe.Resolution.source(),
+             Absinthe.Resolution.arguments(),
+             Absinthe.Resolution.t() ->
+               result)
+          | {module(), atom()}
 
   @typedoc """
   The result of a resolver.


### PR DESCRIPTION
As per code [of `Absinthe.Resolution.call/2`](https://github.com/absinthe-graphql/absinthe/blob/master/lib/absinthe/resolution.ex#L204-L212) three different forms of resolution function are supported, type spec `resolver_t` is updated accordingly to this.

