### PR TITLE
Changes misnamed `:__absinthe_type_import__` to `:__absinthe_type_imports__` in Schema.Notation

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -40,7 +40,6 @@ defmodule Absinthe.Schema.Notation do
           batch: 4
         ]
 
-      Module.register_attribute(__MODULE__, :__absinthe_type_imports__, accumulate: true)
       @desc nil
       import unquote(__MODULE__), unquote(import_opts)
       @before_compile unquote(__MODULE__)
@@ -1676,7 +1675,10 @@ defmodule Absinthe.Schema.Notation do
   end
 
   defp do_import_types(module, env, opts) do
-    Module.put_attribute(env.module, :__absinthe_type_imports__, {module, opts})
+    Module.put_attribute(env.module, :__absinthe_type_imports__, [
+       {module, opts} | Module.get_attribute(env.module, :__absinthe_type_imports__) || []
+     ])
+     
     []
   end
 

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1676,10 +1676,7 @@ defmodule Absinthe.Schema.Notation do
   end
 
   defp do_import_types(module, env, opts) do
-    Module.put_attribute(env.module, :__absinthe_type_imports__, [
-      {module, opts} | Module.get_attribute(env.module, :__absinthe_type_imports__) || []
-    ])
-
+    Module.put_attribute(env.module, :__absinthe_type_imports__, {module, opts})
     []
   end
 

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -40,7 +40,7 @@ defmodule Absinthe.Schema.Notation do
           batch: 4
         ]
 
-      Module.register_attribute(__MODULE__, :__absinthe_type_import__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__absinthe_type_imports__, accumulate: true)
       @desc nil
       import unquote(__MODULE__), unquote(import_opts)
       @before_compile unquote(__MODULE__)

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1676,9 +1676,9 @@ defmodule Absinthe.Schema.Notation do
 
   defp do_import_types(module, env, opts) do
     Module.put_attribute(env.module, :__absinthe_type_imports__, [
-       {module, opts} | Module.get_attribute(env.module, :__absinthe_type_imports__) || []
-     ])
-     
+      {module, opts} | Module.get_attribute(env.module, :__absinthe_type_imports__) || []
+    ])
+
     []
   end
 


### PR DESCRIPTION
This PR changes a (probably) misnamed module attribute registered during the compilation of `use Schema.Notation`.

Closes #1119

Signed-off-by: Jason Goldberger <jasongoldberger@gmail.com>

