### PR TITLE
Use inspect/1 to safely encode bad binary samples

### DIFF
--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -104,7 +104,7 @@ defmodule Absinthe.Phase.Parse do
   @spec format_raw_parse_error({:lexer, String.t(), {line :: pos_integer, column :: pos_integer}}) ::
           Phase.Error.t()
   defp format_raw_parse_error({:lexer, rest, {line, column}}) do
-    sample = String.slice(rest, 0, 10)
+    sample = String.slice(rest, 0, 10) |> inspect()
 
     message = "Parsing failed at `#{sample}`"
     %Phase.Error{message: message, locations: [%{line: line, column: column}], phase: __MODULE__}

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -104,7 +104,8 @@ defmodule Absinthe.Phase.Parse do
   @spec format_raw_parse_error({:lexer, String.t(), {line :: pos_integer, column :: pos_integer}}) ::
           Phase.Error.t()
   defp format_raw_parse_error({:lexer, rest, {line, column}}) do
-    sample = String.slice(rest, 0, 10) |> inspect()
+    sample_slice = String.slice(rest, 0, 10)
+    sample = if String.valid?(sample_slice), do: sample_slice, else: inspect(sample_slice)
 
     message = "Parsing failed at `#{sample}`"
     %Phase.Error{message: message, locations: [%{line: line, column: column}], phase: __MODULE__}

--- a/test/absinthe/phase/parse_test.exs
+++ b/test/absinthe/phase/parse_test.exs
@@ -47,14 +47,15 @@ defmodule Absinthe.Phase.ParseTest do
   test "coerces non-string binaries to strings" do
     assert {:error, bp} = Absinthe.Phase.Parse.run(@graphql)
 
-    assert [
-             %Absinthe.Phase.Error{
-               extra: %{},
-               locations: [%{column: 16, line: 1}],
-               message: "Parsing failed at `<<223, 101, 114, 114, 111, 114>>`",
-               phase: Absinthe.Phase.Parse
-             }
-           ] == bp.execution.validation_errors
+    [parse_error] = bp.execution.validation_errors
+    assert String.valid?(parse_error.message)
+
+    assert %Absinthe.Phase.Error{
+             extra: %{},
+             locations: [%{column: 16, line: 1}],
+             message: "Parsing failed at `<<223, 101, 114, 114, 111, 114>>`",
+             phase: Absinthe.Phase.Parse
+           } == parse_error
   end
 
   @graphql ";"

--- a/test/absinthe/phase/parse_test.exs
+++ b/test/absinthe/phase/parse_test.exs
@@ -43,6 +43,20 @@ defmodule Absinthe.Phase.ParseTest do
            ] == bp.execution.validation_errors
   end
 
+  @graphql "test bad string" <> <<223>> <> "error"
+  test "coerces non-string binaries to strings" do
+    assert {:error, bp} = Absinthe.Phase.Parse.run(@graphql)
+
+    assert [
+             %Absinthe.Phase.Error{
+               extra: %{},
+               locations: [%{column: 16, line: 1}],
+               message: "Parsing failed at `<<223, 101, 114, 114, 111, 114>>`",
+               phase: Absinthe.Phase.Parse
+             }
+           ] == bp.execution.validation_errors
+  end
+
   @graphql ";"
   test "should provide sample of parsing failure on very short query strings" do
     assert {:error, bp} = Absinthe.Phase.Parse.run(@graphql, jump_phases: false)


### PR DESCRIPTION
My team finds ourselves in an odd situation.

- We use Absinthe and Absinthe Plug
- A user is (surprisingly) sending us a GET request with their query
- We _think_ that user is sending that in the body of a GET (weird)
- That query appears to have a bad byte in it (`0xDF`)

The parser correctly fails when it encounters the bad byte, but it also generates an error message with a sample of the input that could not be parsed as a string.

In this case the string it generates is not a valid string because it includes the bad byte. This can cause problems later, for example when `absinthe_plug` attempts to JSON encode the phase error and send it to the client. In that case the end result is an exception and a 500.

Given the typespec of `Absinthe.Phase.Error.message` is `String.t()` I think it's safe to say Absinthe itself should ensure that's the case. The simplest option to me seems to simply run the "sample" we take through `inspect/1`.

We still preserve useful debugging information by sending back the list of bytes which I consider a good thing personally.

I don't have a strong opinion on the style of the code below, happy to modify it however we see fit. I did opt to only apply this if the string isn't valid so we don't change the way existing errors are formatted.