### PR TITLE
Remove unused transform walk functions

### DIFF
--- a/lib/absinthe/blueprint/transform.ex
+++ b/lib/absinthe/blueprint/transform.ex
@@ -118,12 +118,6 @@ defmodule Absinthe.Blueprint.Transform do
   end
 
   for {node_name, children} <- nodes_with_children do
-    if :selections in children do
-      def maybe_walk_children(%unquote(node_name){flags: %{flat: _}} = node, acc, pre, post) do
-        node_with_children(node, unquote(children -- [:selections]), acc, pre, post)
-      end
-    end
-
     def maybe_walk_children(%unquote(node_name){} = node, acc, pre, post) do
       node_with_children(node, unquote(children), acc, pre, post)
     end


### PR DESCRIPTION
This was introduced in commit 7529731 but with the removal of
the flatten.ex in 0f33807 it's no longer needed.

