### PR TITLE
Use concrete implementors to resolve interface type when leveraging `is_type_of`

### DIFF
--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -86,13 +86,6 @@ defmodule Absinthe.Type.Interface do
   def resolve_type(type, obj, env, opts \\ [lookup: true])
 
   def resolve_type(interface, obj, %{schema: schema} = env, opts) do
-    concrete_implementors =
-      Schema.implementors(schema, interface.identifier)
-      |> Enum.filter(fn
-        %Absinthe.Type.Object{} -> true
-        _ -> false
-      end)
-
     if resolver = Type.function(interface, :resolve_type) do
       case resolver.(obj, env) do
         nil ->
@@ -106,6 +99,13 @@ defmodule Absinthe.Type.Interface do
           end
       end
     else
+      concrete_implementors =
+        Schema.implementors(schema, interface.identifier)
+        |> Enum.filter(fn
+          %Absinthe.Type.Object{} -> true
+          _ -> false
+        end)
+
       type_name =
         Enum.find(concrete_implementors, fn type ->
           Absinthe.Type.function(type, :is_type_of).(obj)

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -86,7 +86,12 @@ defmodule Absinthe.Type.Interface do
   def resolve_type(type, obj, env, opts \\ [lookup: true])
 
   def resolve_type(interface, obj, %{schema: schema} = env, opts) do
-    implementors = Schema.implementors(schema, interface.identifier)
+    concrete_implementors =
+      Schema.implementors(schema, interface.identifier)
+      |> Enum.filter(fn
+        %Absinthe.Type.Object{} -> true
+        _ -> false
+      end)
 
     if resolver = Type.function(interface, :resolve_type) do
       case resolver.(obj, env) do
@@ -102,7 +107,7 @@ defmodule Absinthe.Type.Interface do
       end
     else
       type_name =
-        Enum.find(implementors, fn type ->
+        Enum.find(concrete_implementors, fn type ->
           Absinthe.Type.function(type, :is_type_of).(obj)
         end)
 


### PR DESCRIPTION
Given interfaces can now implements interfaces, when we need to resolve the type of a given object by calling `is_type_of` on all implementors, we need to make sure we only enumerate on the concrete ones.

close #1123