### PR TITLE
Invert the instructions for installing subscriptions with phoenix.

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -28,18 +28,7 @@ In your application supervisor add a line _after_ your existing endpoint supervi
 line:
 
 ```elixir
-[
-  # other children ...
-  supervisor(MyAppWeb.Endpoint, []), # this line should already exist
-  supervisor(Absinthe.Subscription, MyAppWeb.Endpoint), # add this line
-  # other children ...
-]
-```
-
-In Phoenix v1.4, the supervisor children are mounted like so:
-
-```elixir
-# List all child processes to be supervised
+    # List all child processes to be supervised
     children = [
       # Start the Ecto repository
       MyAppWeb.Repo,
@@ -52,7 +41,19 @@ In Phoenix v1.4, the supervisor children are mounted like so:
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]
     Supervisor.start_link(children, opts)
+```
 
+In older versions of phoenix (pre 1.4) you might see a slightly different syntax,
+in which case add Absinthe like this:
+
+```
+[
+  # other children ...
+  MyAppWeb.Repo,
+  supervisor(MyAppWeb.Endpoint, []), # this line should already exist
+  supervisor(Absinthe.Subscription, MyAppWeb.Endpoint), # add this line
+  # other children ...
+]
 ```
 
 Where `MyAppWeb.Endpoint` is the name of your application's phoenix endpoint.

--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -46,7 +46,7 @@ line:
 In older versions of phoenix (pre 1.4) you might see a slightly different syntax,
 in which case add Absinthe like this:
 
-```
+```elixir
 [
   # other children ...
   MyAppWeb.Repo,


### PR DESCRIPTION
Add the instructions for installing subscriptions into current versions of Phoenix as the default, and then explain how to use in older versions rather than the other way around. This is less confusing to newcomers, and people working with older Elixir are more likely to know they need to look for special instructions.