### PR TITLE
Validate object/interfaces implement all transitive interfaces

### DIFF
--- a/lib/absinthe/phase/schema/validation/object_interfaces_must_be_valid.ex
+++ b/lib/absinthe/phase/schema/validation/object_interfaces_must_be_valid.ex
@@ -13,8 +13,7 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectInterfacesMustBeValid do
     ifaces =
       schema.type_definitions
       |> Enum.filter(&match?(%Blueprint.Schema.InterfaceTypeDefinition{}, &1))
-      |> Enum.map(& &1.identifier)
-      |> MapSet.new()
+      |> Map.new(&{&1.identifier, &1})
 
     schema = Blueprint.prewalk(schema, &validate_objects(&1, ifaces))
     {:halt, schema}
@@ -24,23 +23,57 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectInterfacesMustBeValid do
     obj
   end
 
-  defp validate_objects(%Blueprint.Schema.ObjectTypeDefinition{} = object, ifaces) do
-    Enum.reduce(object.interfaces, object, fn iface, object ->
-      if iface in ifaces do
-        object
-      else
-        detail = %{
-          object: object.identifier,
-          interface: iface
-        }
-
-        object |> put_error(error(object, detail))
-      end
-    end)
+  defp validate_objects(%struct{} = object, all_interfaces)
+       when struct in [
+              Blueprint.Schema.ObjectTypeDefinition,
+              Blueprint.Schema.InterfaceTypeDefinition
+            ] do
+    check_transitive_interfaces(object, object.interfaces, all_interfaces, nil, [])
   end
 
   defp validate_objects(type, _) do
     type
+  end
+
+  # check that the object declares it implements all interfaces up the
+  # hierarchy chain as per spec https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%203%20--%20Type%20System.md#L1158-L1161
+  defp check_transitive_interfaces(
+         object,
+         [object_interface | tail],
+         all_interfaces,
+         implemented_by,
+         visited
+       ) do
+    current_interface = all_interfaces[object_interface]
+
+    if current_interface && current_interface.identifier in object.interfaces do
+      case current_interface do
+        %{interfaces: interfaces} = interface ->
+          # to prevent walking in cycles we need to filter out visited interfaces
+          interfaces = Enum.filter(interfaces, &(&1 not in visited))
+
+          check_transitive_interfaces(object, tail ++ interfaces, all_interfaces, interface, [
+            object_interface | visited
+          ])
+
+        _ ->
+          check_transitive_interfaces(object, tail, all_interfaces, implemented_by, [
+            object_interface | visited
+          ])
+      end
+    else
+      detail = %{
+        object: object.identifier,
+        interface: object_interface,
+        implemented_by: implemented_by
+      }
+
+      object |> put_error(error(object, detail))
+    end
+  end
+
+  defp check_transitive_interfaces(object, [], _, _, _) do
+    object
   end
 
   defp error(object, data) do
@@ -58,9 +91,17 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectInterfacesMustBeValid do
   Reference: https://github.com/facebook/graphql/blob/master/spec/Section%203%20--%20Type%20System.md#interfaces
   """
 
-  def explanation(%{object: obj, interface: interface}) do
+  def explanation(%{object: obj, interface: interface, implemented_by: nil}) do
     """
-    Type "#{obj}" cannot implement non-interface type "#{interface}"
+    Type "#{obj}" must implement interface type "#{interface}"
+
+    #{@description}
+    """
+  end
+
+  def explanation(%{object: obj, interface: interface, implemented_by: implemented}) do
+    """
+    Type "#{obj}" must implement interface type "#{interface}" because it is implemented by "#{implemented.identifier}".
 
     #{@description}
     """

--- a/lib/absinthe/phase/schema/validation/object_interfaces_must_be_valid.ex
+++ b/lib/absinthe/phase/schema/validation/object_interfaces_must_be_valid.ex
@@ -101,7 +101,9 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectInterfacesMustBeValid do
 
   def explanation(%{object: obj, interface: interface, implemented_by: implemented}) do
     """
-    Type "#{obj}" must implement interface type "#{interface}" because it is implemented by "#{implemented.identifier}".
+    Type "#{obj}" must implement interface type "#{interface}" because it is implemented by "#{
+      implemented.identifier
+    }".
 
     #{@description}
     """

--- a/lib/absinthe/phase/schema/validation/type_references_exist.ex
+++ b/lib/absinthe/phase/schema/validation/type_references_exist.ex
@@ -33,6 +33,10 @@ defmodule Absinthe.Phase.Schema.Validation.TypeReferencesExist do
     |> check_types(:imports, fn {type, _}, obj -> check_or_error(obj, type, types) end)
   end
 
+  def validate_types(%Blueprint.Schema.InterfaceTypeDefinition{} = interface, types) do
+    check_types(interface, :interfaces, &check_or_error(&2, &1, types))
+  end
+
   def validate_types(%Blueprint.Schema.InputObjectTypeDefinition{} = object, types) do
     check_types(object, :imports, fn {type, _}, obj -> check_or_error(obj, type, types) end)
   end

--- a/test/absinthe/schema/rule/object_interfaces_must_be_valid_test.exs
+++ b/test/absinthe/schema/rule/object_interfaces_must_be_valid_test.exs
@@ -1,0 +1,75 @@
+defmodule Absinthe.Schema.Rule.ObjectInterfacesMustBeValidTest do
+  use Absinthe.Case, async: true
+
+  @interface_transitive_interfaces ~S(
+  defmodule InterfaceWithTransitiveInterfaces do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    import_sdl """
+    interface Node {
+      id: ID!
+    }
+
+    interface Resource implements Node {
+      id: ID!
+      url: String
+    }
+
+    # should also implement Node
+    interface Image implements Resource  {
+      id: ID!
+      url: String
+      thumbnail: String
+    }
+    """
+  end
+  )
+
+  test "errors on interface not implementing all transitive interfaces" do
+    error =
+      ~r/Type \"image\" must implement interface type \"node\" because it is implemented by \"resource\"./
+
+    assert_raise(Absinthe.Schema.Error, error, fn ->
+      Code.eval_string(@interface_transitive_interfaces)
+    end)
+  end
+
+  @object_transitive_interfaces ~S(
+  defmodule ObjectWithTransitiveInterfaces do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    import_sdl """
+    interface Node {
+      id: ID!
+    }
+
+    interface Resource implements Node {
+      id: ID!
+      url: String
+    }
+
+    # should also implement Node
+    type Image implements Resource  {
+      id: ID!
+      url: String
+      thumbnail: String
+    }
+    """
+  end
+  )
+
+  test "errors on object not implementing all transitive interfaces" do
+    error =
+      ~r/Type \"image\" must implement interface type \"node\" because it is implemented by \"resource\"./
+
+    assert_raise(Absinthe.Schema.Error, error, fn ->
+      Code.eval_string(@object_transitive_interfaces)
+    end)
+  end
+end

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -25,6 +25,9 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
       field :another_parent, :named
 
       resolve_type fn
+        %{type: :dog}, _ -> :dog
+        %{type: :user}, _ -> :user
+        %{type: :cat}, _ -> :cat
         _, _ -> nil
       end
     end

--- a/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
+++ b/test/absinthe/schema/rule/object_must_implement_interfaces_test.exs
@@ -7,6 +7,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     object :user do
       interface :named
       interface :favorite_foods
+      interface :parented
       field :name, :string
       field :id, :id
       field :parent, :named
@@ -22,6 +23,10 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     interface :parented do
       field :parent, :named
       field :another_parent, :named
+
+      resolve_type fn
+        _, _ -> nil
+      end
     end
 
     interface :named do
@@ -52,6 +57,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     object :dog do
       field :name, :string
       interface :named
+      interface :parented
       interface :favorite_foods
       field :parent, :named
       field :another_parent, :user
@@ -63,6 +69,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     object :cat do
       interface :named
       interface :favorite_foods
+      interface :parented
       field :name, non_null(:string)
       field :parent, :named
       field :another_parent, :user
@@ -89,7 +96,7 @@ defmodule Absinthe.Schema.Rule.ObjectMustImplementInterfacesTest do
     assert %{
              named: [:cat, :dog, :user],
              favorite_foods: [:cat, :dog, :user],
-             parented: [:named]
+             parented: [:cat, :dog, :named, :user]
            } ==
              Schema.__absinthe_interface_implementors__()
   end

--- a/test/absinthe/type/interface_test.exs
+++ b/test/absinthe/type/interface_test.exs
@@ -142,7 +142,7 @@ defmodule Absinthe.Type.InterfaceTest do
         },
         %{
           phase: Validation.ObjectInterfacesMustBeValid,
-          extra: %{object: :quux, interface: :foo}
+          extra: %{object: :quux, interface: :foo, implemented_by: nil}
         },
         %{phase: Validation.InterfacesMustResolveTypes, extra: :named}
       ])


### PR DESCRIPTION
See https://github.com/absinthe-graphql/absinthe/issues/1080 for a full description

 * adds a type reference check to see whether interfaces on interfaces exist
 * adds a check to ensure that an object/interface implements all interfaces, also interfaces it transitively has

@tlvenn can you take a look

fixes https://github.com/absinthe-graphql/absinthe/issues/1080