### PR TITLE
Fix wrapped unknown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Bug Fix: [Validate field names are unique to an object/interface/input object](https://github.com/absinthe-graphql/absinthe/pull/1135)
+- Bug Fix: [Fix check unknown types to also cover wrapped types](https://github.com/absinthe-graphql/absinthe/pull/1138)
+- Bug Fix: [Validate field names are unique to an object, interface or an input object](https://github.com/absinthe-graphql/absinthe/pull/1135)
 
 ## 1.6.6
 

--- a/lib/absinthe/phase/validation/known_type_names.ex
+++ b/lib/absinthe/phase/validation/known_type_names.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Phase.Validation.KnownTypeNames do
   # ```
 
   alias Absinthe.{Blueprint, Phase}
+  alias Absinthe.Phase.Document.Validation.Utils
 
   use Absinthe.Phase
   use Absinthe.Phase.Validation
@@ -40,9 +41,11 @@ defmodule Absinthe.Phase.Validation.KnownTypeNames do
     if inner_schema_type do
       node
     else
+      suggestions = suggested_type_names(schema, name)
+
       node
       |> flag_invalid(:bad_type_name)
-      |> put_error(error(node, name))
+      |> put_error(error(node, name, suggestions))
     end
   end
 
@@ -50,12 +53,27 @@ defmodule Absinthe.Phase.Validation.KnownTypeNames do
     node
   end
 
+  defp suggested_type_names(schema, name) do
+    schema
+    |> Absinthe.Schema.referenced_types()
+    |> Enum.map(& &1.name)
+    |> Absinthe.Utils.Suggestion.sort_list(name)
+  end
+
   @spec error(Blueprint.node_t(), String.t()) :: Phase.Error.t()
-  defp error(node, name) do
+  defp error(node, name, suggestions \\ []) do
     %Phase.Error{
       phase: __MODULE__,
-      message: ~s(Unknown type "#{name}".),
+      message: message(name, suggestions),
       locations: [node.source_location]
     }
+  end
+
+  defp message(name, []) do
+    ~s(Unknown type "#{name}".)
+  end
+
+  defp message(name, suggestions) do
+    ~s(Unknown type "#{name}".) <> Utils.MessageSuggestions.suggest_message(suggestions)
   end
 end

--- a/lib/absinthe/phase/validation/known_type_names.ex
+++ b/lib/absinthe/phase/validation/known_type_names.ex
@@ -33,7 +33,7 @@ defmodule Absinthe.Phase.Validation.KnownTypeNames do
     |> put_error(error(node, name))
   end
 
-  defp handle_node(%Blueprint.Document.VariableDefinition{schema_node: nil} = node, schema) do
+  defp handle_node(%Blueprint.Document.VariableDefinition{} = node, schema) do
     name = Blueprint.TypeReference.unwrap(node.type).name
     inner_schema_type = schema.__absinthe_lookup__(name)
 

--- a/test/absinthe/phase/validation/known_type_names_test.exs
+++ b/test/absinthe/phase/validation/known_type_names_test.exs
@@ -61,7 +61,7 @@ defmodule Absinthe.Phase.Validation.KnownTypeNamesTest do
     test "unknown type names are invalid" do
       assert_fails_validation(
         """
-        query Foo($var: JumbledUpLetters) {
+        query Foo($var: JumbledUpLetters, $foo: Foo!, $bar: [Bar!]) {
           user(id: 4) {
             name
             pets { ... on Badger { name }, ...PetFields }
@@ -74,6 +74,8 @@ defmodule Absinthe.Phase.Validation.KnownTypeNamesTest do
         [],
         [
           unknown_type(:variable_definition, "JumbledUpLetters", 1),
+          unknown_type(:variable_definition, "Foo", 1),
+          unknown_type(:variable_definition, "Bar", 1),
           unknown_type(:inline_type_condition, "Badger", 4),
           unknown_type(:named_type_condition, "Peettt", 7)
         ]

--- a/test/absinthe/phase/validation/known_type_names_test.exs
+++ b/test/absinthe/phase/validation/known_type_names_test.exs
@@ -7,24 +7,26 @@ defmodule Absinthe.Phase.Validation.KnownTypeNamesTest do
 
   alias Absinthe.Blueprint
 
-  def unknown_type(:variable_definition, name, line) do
+  def unknown_type(type, name, line, custom_error_message \\ nil)
+
+  def unknown_type(:variable_definition, name, line, custom_error_message) do
     bad_value(
       Blueprint.Document.VariableDefinition,
-      error_message(name),
+      custom_error_message || error_message(name),
       line,
       &(Blueprint.TypeReference.unwrap(&1.type).name == name)
     )
   end
 
-  def unknown_type(:named_type_condition, name, line) do
+  def unknown_type(:named_type_condition, name, line, _) do
     unknown_type_condition(Blueprint.Document.Fragment.Named, name, line)
   end
 
-  def unknown_type(:spread_type_condition, name, line) do
+  def unknown_type(:spread_type_condition, name, line, _) do
     unknown_type_condition(Blueprint.Document.Fragment.Spread, name, line)
   end
 
-  def unknown_type(:inline_type_condition, name, line) do
+  def unknown_type(:inline_type_condition, name, line, _) do
     unknown_type_condition(Blueprint.Document.Fragment.Inline, name, line)
   end
 
@@ -61,7 +63,7 @@ defmodule Absinthe.Phase.Validation.KnownTypeNamesTest do
     test "unknown type names are invalid" do
       assert_fails_validation(
         """
-        query Foo($var: JumbledUpLetters, $foo: Foo!, $bar: [Bar!]) {
+        query Foo($var: JumbledUpLetters, $foo: Boolen!, $bar: [Bar!]) {
           user(id: 4) {
             name
             pets { ... on Badger { name }, ...PetFields }
@@ -74,7 +76,12 @@ defmodule Absinthe.Phase.Validation.KnownTypeNamesTest do
         [],
         [
           unknown_type(:variable_definition, "JumbledUpLetters", 1),
-          unknown_type(:variable_definition, "Foo", 1),
+          unknown_type(
+            :variable_definition,
+            "Boolen",
+            1,
+            ~s(Unknown type "Boolen". Did you mean "Alien" or "Boolean"?)
+          ),
           unknown_type(:variable_definition, "Bar", 1),
           unknown_type(:inline_type_condition, "Badger", 4),
           unknown_type(:named_type_condition, "Peettt", 7)


### PR DESCRIPTION
I noticed that wrapped unknown types were not marked as errors by the `Absinthe.Phase.Validation.KnownTypeNames` phase. 

E.g. 
```
query Foo($var: UnknownType) { user { id } }
```
would trigger an error but
```
query Foo($var: UnknownType!) { user { id } }
```
wouldn't.
Downstream in other phases this error would still be picked up because e.g. the variable type would not match up to the argument, but the error message was vague.

I added a fix for this and also changed the error message to include "Did you mean?" suggestions.