### PR TITLE
Improve type checks on variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bug Fix: [Validate field names are unique to an object/interface/input object](https://github.com/absinthe-graphql/absinthe/pull/1135)
+- Bug Fix: [Validate variable usage in according to spec](https://github.com/absinthe-graphql/absinthe/pull/1141)
 
 ## 1.6.6
 

--- a/lib/absinthe/blueprint/type_reference.ex
+++ b/lib/absinthe/blueprint/type_reference.ex
@@ -29,6 +29,22 @@ defmodule Absinthe.Blueprint.TypeReference do
     unwrap(inner)
   end
 
+  @doc """
+  Get the GraphQL name for a (possibly wrapped) type reference.
+
+  """
+  def name(%__MODULE__.NonNull{of_type: type}) do
+    name(type) <> "!"
+  end
+
+  def name(%__MODULE__.List{of_type: type}) do
+    "[" <> name(type) <> "]"
+  end
+
+  def name(%__MODULE__.Name{name: name}) do
+    name
+  end
+
   def to_type(%__MODULE__.NonNull{of_type: type}, schema) do
     %Absinthe.Type.NonNull{of_type: to_type(type, schema)}
   end

--- a/lib/absinthe/phase/document/arguments/variable_types_match.ex
+++ b/lib/absinthe/phase/document/arguments/variable_types_match.ex
@@ -1,5 +1,5 @@
 defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
-  # Partially implements: 5.8.5. All Variable Usages are Allowed
+  # Implements: 5.8.5. All Variable Usages are Allowed
   # Specifically, it implements "Variable usages must be compatible with the arguments they are passed to."
   # See relevant counter-example: https://spec.graphql.org/draft/#example-2028e
 
@@ -7,6 +7,7 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
 
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Document.{Operation, Fragment}
+  alias Absinthe.Type
 
   def run(blueprint, _) do
     blueprint =
@@ -44,44 +45,47 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
 
   def check_variable_types(%Operation{} = op) do
     variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
-    Blueprint.prewalk(op, &check_var_type(&1, op.name, variable_defs))
+    Blueprint.prewalk(op, &check_variable_type(&1, op.name, variable_defs))
   end
 
   def check_variable_types(%Operation{} = op, %Fragment.Named{} = fragment) do
     variable_defs = Map.new(op.variable_definitions, &{&1.name, &1})
-    Blueprint.prewalk(fragment, &check_var_type(&1, op.name, variable_defs))
+    Blueprint.prewalk(fragment, &check_variable_type(&1, op.name, variable_defs))
   end
 
-  defp check_var_type(%{schema_node: nil} = node, _, _) do
+  defp check_variable_type(%{schema_node: nil} = node, _, _) do
     {:halt, node}
   end
 
-  defp check_var_type(
-         %Blueprint.Input.Value{
-           raw: %{content: %Blueprint.Input.Variable{} = var},
-           schema_node: schema_node
+  defp check_variable_type(
+         %Absinthe.Blueprint.Input.Argument{
+           input_value: %Blueprint.Input.Value{
+             raw: %{content: %Blueprint.Input.Variable{} = variable}
+           }
          } = node,
-         op_name,
+         operation_name,
          variable_defs
        ) do
-    case Map.fetch(variable_defs, var.name) do
-      {:ok, %{schema_node: var_schema_type}} ->
-        # null vs not null is handled elsewhere
-        var_schema_type = Absinthe.Type.unwrap(var_schema_type)
-        arg_schema_type = Absinthe.Type.unwrap(schema_node)
+    location_type = node.input_value.schema_node
+    location_definition = node.schema_node
 
-        if var_schema_type && arg_schema_type && var_schema_type.name != arg_schema_type.name do
-          # error
-          var_with_error =
-            put_error(var, %Absinthe.Phase.Error{
-              phase: __MODULE__,
-              message: error_message(op_name, var, var_schema_type.name, arg_schema_type.name),
-              locations: [var.source_location]
-            })
-
-          {:halt, put_in(node.raw.content, var_with_error)}
-        else
+    case Map.get(variable_defs, variable.name) do
+      %{schema_node: variable_type} = variable_definition ->
+        if types_compatible?(
+             variable_type,
+             location_type,
+             variable_definition,
+             location_definition
+           ) do
           node
+        else
+          variable =
+            put_error(
+              variable,
+              error(operation_name, variable, variable_definition, location_type)
+            )
+
+          {:halt, put_in(node.input_value.raw.content, variable)}
         end
 
       _ ->
@@ -89,19 +93,96 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
     end
   end
 
-  defp check_var_type(node, _, _) do
+  defp check_variable_type(node, _, _) do
     node
   end
 
-  def error_message(op, variable, var_type, arg_type) do
+  def types_compatible?(type, type, _, _) do
+    true
+  end
+
+  def types_compatible?(
+        %Type.NonNull{of_type: nullable_variable_type},
+        location_type,
+        variable_definition,
+        location_definition
+      ) do
+    types_compatible?(
+      nullable_variable_type,
+      location_type,
+      variable_definition,
+      location_definition
+    )
+  end
+
+  def types_compatible?(
+        %Type.List{of_type: item_variable_type},
+        %Type.List{
+          of_type: item_location_type
+        },
+        variable_definition,
+        location_definition
+      ) do
+    types_compatible?(
+      item_variable_type,
+      item_location_type,
+      variable_definition,
+      location_definition
+    )
+  end
+
+  # https://github.com/graphql/graphql-spec/blame/October2021/spec/Section%205%20--%20Validation.md#L1885-L1893
+  # if argument has default value the variable can be nullable
+  def types_compatible?(nullable_type, %Type.NonNull{of_type: nullable_type}, _, %{
+        default_value: default_value
+      })
+      when not is_nil(default_value) do
+    true
+  end
+
+  # https://github.com/graphql/graphql-spec/blame/main/spec/Section%205%20--%20Validation.md#L2000-L2005
+  # This behavior is explicitly supported for compatibility with earlier editions of this specification.
+  def types_compatible?(
+        nullable_type,
+        %Type.NonNull{of_type: nullable_type},
+        %{
+          default_value: value
+        },
+        _
+      )
+      when is_struct(value) do
+    true
+  end
+
+  def types_compatible?(_, _, _, _) do
+    false
+  end
+
+  defp error(operation_name, variable, variable_definition, location_type) do
+    # need to rely on the type reference here, since the schema node may not be available
+    # as the type could not exist in the schema
+    variable_name = Absinthe.Blueprint.TypeReference.name(variable_definition.type)
+
+    %Absinthe.Phase.Error{
+      phase: __MODULE__,
+      message:
+        error_message(
+          operation_name,
+          variable,
+          variable_name,
+          Absinthe.Type.name(location_type)
+        ),
+      locations: [variable.source_location]
+    }
+  end
+
+  def error_message(op, variable, variable_name, location_type) do
     start =
       case op || "" do
         "" -> "Variable"
-        op -> "In operation `#{op}, variable"
+        op -> "In operation `#{op}`, variable"
       end
 
-    "#{start} `#{Blueprint.Input.inspect(variable)}` of type `#{var_type}` found as input to argument of type `#{
-      arg_type
-    }`."
+    "#{start} `#{Blueprint.Input.inspect(variable)}` of type `#{variable_name}` found as input to argument of type `#{location_type}`."
   end
 end

--- a/lib/absinthe/phase/document/arguments/variable_types_match.ex
+++ b/lib/absinthe/phase/document/arguments/variable_types_match.ex
@@ -183,6 +183,8 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
         op -> "In operation `#{op}`, variable"
       end
 
-    "#{start} `#{Blueprint.Input.inspect(variable)}` of type `#{variable_name}` found as input to argument of type `#{location_type}`."
+    "#{start} `#{Blueprint.Input.inspect(variable)}` of type `#{variable_name}` found as input to argument of type `#{
+      location_type
+    }`."
   end
 end

--- a/test/absinthe/blueprint/type_reference_test.exs
+++ b/test/absinthe/blueprint/type_reference_test.exs
@@ -2,6 +2,7 @@ defmodule Absinthe.Blueprint.TypeReferenceTest do
   use Absinthe.Case, async: true
 
   alias Absinthe.Blueprint
+  @moduletag :f
 
   describe ".unwrap of Name" do
     test "is left intact" do
@@ -37,6 +38,43 @@ defmodule Absinthe.Blueprint.TypeReferenceTest do
       non_null = %Blueprint.TypeReference.NonNull{of_type: name}
       list = %Blueprint.TypeReference.List{of_type: non_null}
       assert Blueprint.TypeReference.unwrap(list) == name
+    end
+  end
+
+  describe "name/1 of Name" do
+    test "returns type name" do
+      name = %Blueprint.TypeReference.Name{name: "Foo"}
+      assert Blueprint.TypeReference.name(name) == "Foo"
+    end
+  end
+
+  describe "name/1 of List" do
+    test "returns type name in list" do
+      name = %Blueprint.TypeReference.Name{name: "Foo"}
+      list = %Blueprint.TypeReference.List{of_type: name}
+      assert Blueprint.TypeReference.name(list) == "[Foo]"
+    end
+
+    test "returns type name, in multiple lists" do
+      name = %Blueprint.TypeReference.Name{name: "Foo"}
+      list_1 = %Blueprint.TypeReference.List{of_type: name}
+      list_2 = %Blueprint.TypeReference.List{of_type: list_1}
+      assert Blueprint.TypeReference.name(list_2) == "[[Foo]]"
+    end
+  end
+
+  describe "name/1 of NonNull" do
+    test "returns non null type name" do
+      name = %Blueprint.TypeReference.Name{name: "Foo"}
+      list = %Blueprint.TypeReference.NonNull{of_type: name}
+      assert Blueprint.TypeReference.name(list) == "Foo!"
+    end
+
+    test "returns nested non null type name" do
+      name = %Blueprint.TypeReference.Name{name: "Foo"}
+      non_null = %Blueprint.TypeReference.NonNull{of_type: name}
+      list = %Blueprint.TypeReference.List{of_type: non_null}
+      assert Blueprint.TypeReference.name(list) == "[Foo!]"
     end
   end
 end

--- a/test/absinthe/execution/arguments/list_test.exs
+++ b/test/absinthe/execution/arguments/list_test.exs
@@ -35,7 +35,7 @@ defmodule Absinthe.Execution.Arguments.ListTest do
   end
 
   @graphql """
-  query ($contacts: [ContactInput]) {
+  query ($contacts: [ContactInput]!) {
     contacts(contacts: $contacts)
   }
   """

--- a/test/absinthe/integration/execution/input_object_test.exs
+++ b/test/absinthe/integration/execution/input_object_test.exs
@@ -35,7 +35,7 @@ defmodule Elixir.Absinthe.Integration.Execution.InputObjectTest do
                 %{
                   locations: [%{column: 33, line: 2}],
                   message:
-                    "Variable `$input` of type `Boolean` found as input to argument of type `InputThing`."
+                    "Variable `$input` of type `Boolean` found as input to argument of type `InputThing!`."
                 }
               ]
             }} ==

--- a/test/absinthe/integration/validation/introspection_fields_ignored_in_input_objects_test.exs
+++ b/test/absinthe/integration/validation/introspection_fields_ignored_in_input_objects_test.exs
@@ -2,7 +2,7 @@ defmodule Elixir.Absinthe.Integration.Validation.IntrospectionFieldsIgnoredInInp
   use Absinthe.Case, async: true
 
   @query """
-  mutation ($input: InputThing) {
+  mutation ($input: InputThing!) {
     thing: updateThing(id: "foo", thing: $input) {
       name
       value

--- a/test/absinthe/type/directive_test.exs
+++ b/test/absinthe/type/directive_test.exs
@@ -28,7 +28,7 @@ defmodule Absinthe.Type.DirectiveTest do
 
   describe "the `@skip` directive" do
     @query_field """
-    query Test($skipPerson: Boolean) {
+    query Test($skipPerson: Boolean!) {
       person @skip(if: $skipPerson) {
         name
       }
@@ -61,7 +61,7 @@ defmodule Absinthe.Type.DirectiveTest do
     end
 
     @query_fragment """
-    query Test($skipAge: Boolean) {
+    query Test($skipAge: Boolean!) {
       person {
         name
         ...Aging @skip(if: $skipAge)
@@ -92,7 +92,7 @@ defmodule Absinthe.Type.DirectiveTest do
 
   describe "the `@include` directive" do
     @query_field """
-    query Test($includePerson: Boolean) {
+    query Test($includePerson: Boolean!) {
       person @include(if: $includePerson) {
         name
       }
@@ -128,7 +128,7 @@ defmodule Absinthe.Type.DirectiveTest do
     end
 
     @query_fragment """
-    query Test($includeAge: Boolean) {
+    query Test($includeAge: Boolean!) {
       person {
         name
         ...Aging @include(if: $includeAge)

--- a/test/absinthe/type/directive_test.exs
+++ b/test/absinthe/type/directive_test.exs
@@ -52,12 +52,6 @@ defmodule Absinthe.Type.DirectiveTest do
                  Absinthe.Fixtures.ContactSchema,
                  variables: %{"skipPerson" => true}
                )
-
-      assert_result(
-        {:ok,
-         %{errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}},
-        run(@query_field, Absinthe.Fixtures.ContactSchema)
-      )
     end
 
     @query_fragment """
@@ -80,12 +74,6 @@ defmodule Absinthe.Type.DirectiveTest do
       assert_result(
         {:ok, %{data: %{"person" => %{"name" => "Bruce"}}}},
         run(@query_fragment, Absinthe.Fixtures.ContactSchema, variables: %{"skipAge" => true})
-      )
-
-      assert_result(
-        {:ok,
-         %{errors: [%{message: ~s(In argument "if": Expected type "Boolean!", found null.)}]}},
-        run(@query_fragment, Absinthe.Fixtures.ContactSchema)
       )
     end
   end
@@ -111,19 +99,6 @@ defmodule Absinthe.Type.DirectiveTest do
       assert_result(
         {:ok, %{data: %{}}},
         run(@query_field, Absinthe.Fixtures.ContactSchema, variables: %{"includePerson" => false})
-      )
-
-      assert_result(
-        {:ok,
-         %{
-           errors: [
-             %{
-               locations: [%{column: 19, line: 2}],
-               message: ~s(In argument "if": Expected type "Boolean!", found null.)
-             }
-           ]
-         }},
-        run(@query_field, Absinthe.Fixtures.ContactSchema)
       )
     end
 

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -182,6 +182,14 @@ defmodule Absinthe.Fixtures.PetsSchema do
       arg :opt1, :integer, default_value: 0
       arg :opt2, :integer, default_value: 0
     end
+
+    field :optional_non_null_boolean_arg_field, :boolean do
+      arg :optional_boolean_arg, non_null(:boolean), default_value: true
+    end
+
+    field :non_null_boolean_arg_field, :boolean do
+      arg :non_null_boolean_arg, non_null(:boolean)
+    end
   end
 
   query do


### PR DESCRIPTION
Currently the check was whether the unwrapped type of the variable and e.g. the argument were the same. The spec is stricter than this. In particular this section: https://spec.graphql.org/October2021/#sec-All-Variable-Usages-are-Allowed

This PR adds checks to see if the wrapped types are the same or the variable is stricter than the argument. Also, when default values are given some of these checks can be relaxed.

This is a bugfix in respect to the spec but will have the effect that some previously valid documents are now marked as invalid.

This fixes https://github.com/absinthe-graphql/absinthe/issues/1134