### PR TITLE
Ensure input/output types are correctly placed for SDL schemas

### DIFF
--- a/test/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
+++ b/test/absinthe/schema/rule/input_output_types_correctly_placed_test.exs
@@ -1,7 +1,7 @@
 defmodule Absinthe.Schema.Rule.InputOutputTypesCorrectlyPlacedTest do
   use Absinthe.Case, async: true
 
-  describe "rule" do
+  describe "macro schema" do
     test "is enforced with output types on arguments" do
       assert_schema_error("invalid_output_types", [
         %{
@@ -49,6 +49,76 @@ defmodule Absinthe.Schema.Rule.InputOutputTypesCorrectlyPlacedTest do
             %{
               file: "test/support/fixtures/dynamic/invalid_input_types.exs",
               line: 8
+            }
+          ],
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
+        }
+      ])
+    end
+  end
+
+  describe "sdl schema" do
+    test "is enforced with output types on arguments" do
+      assert_schema_error("invalid_output_types_sdl", [
+        %{
+          extra: %{
+            field: :blah,
+            parent: Absinthe.Blueprint.Schema.ObjectTypeDefinition,
+            struct: Absinthe.Blueprint.Schema.InputObjectTypeDefinition,
+            type: :input
+          },
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/invalid_output_types_sdl.exs",
+              line: 4
+            }
+          ],
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
+        },
+        %{
+          extra: %{
+            argument: :invalid_arg,
+            struct: Absinthe.Blueprint.Schema.ObjectTypeDefinition,
+            type: :user
+          },
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/invalid_output_types_sdl.exs",
+              line: 4
+            }
+          ],
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
+        }
+      ])
+    end
+
+    test "is enforced with input types on arguments" do
+      assert_schema_error("invalid_input_types_sdl", [
+        %{
+          extra: %{
+            argument: :blah,
+            struct: Absinthe.Blueprint.Schema.ObjectTypeDefinition,
+            type: :user
+          },
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/invalid_input_types_sdl.exs",
+              line: 4
+            }
+          ],
+          phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced
+        },
+        %{
+          extra: %{
+            field: :blah,
+            parent: Absinthe.Blueprint.Schema.InputObjectTypeDefinition,
+            struct: Absinthe.Blueprint.Schema.ObjectTypeDefinition,
+            type: :user
+          },
+          locations: [
+            %{
+              file: "test/support/fixtures/dynamic/invalid_input_types_sdl.exs",
+              line: 4
             }
           ],
           phase: Absinthe.Phase.Schema.Validation.InputOutputTypesCorrectlyPlaced

--- a/test/support/fixtures/dynamic/invalid_input_types_sdl.exs
+++ b/test/support/fixtures/dynamic/invalid_input_types_sdl.exs
@@ -1,0 +1,15 @@
+defmodule Absinthe.Fixtures.InvalidOutputTypesSdlSchema do
+  use Absinthe.Schema
+
+  import_sdl """
+    type User
+
+    input Foo {
+      blah: User
+    }
+
+    type Query {
+      foo(arg: Foo): User
+    }
+  """
+end

--- a/test/support/fixtures/dynamic/invalid_output_types_sdl.exs
+++ b/test/support/fixtures/dynamic/invalid_output_types_sdl.exs
@@ -1,0 +1,17 @@
+defmodule Absinthe.Fixtures.InvalidInputTypesSdlSchema do
+  use Absinthe.Schema
+
+  import_sdl """
+    type User
+
+    input Input
+
+    type BadObject {
+      blah: Input
+    }
+
+    type Query {
+      foo(invalidArg: User): User
+    }
+  """
+end


### PR DESCRIPTION
The InputOutputTypesCorrectlyPlaced phase did not work for
SDL schema's since it would unwrap a TypeReference, which
yields the TypeReference and not the atom type identifier.

The subsequent lookup in the schema types would therefore fail, as
it expects atoms not typereferences, and it would not add errors.

It now correctly fetches the atom type identifier, though in a bit of
a roundabout way.