### PR TITLE
Add `__private__` field to EnumValueDefinition struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148) 
+
 ## 1.7.0
 
 - POTENTIALLY BREAKING Bug Fix: [Validate variable usage in according to spec](https://github.com/absinthe-graphql/absinthe/pull/1141). This could break incoming documents previously considered valid. Skip the `Absinthe.Phase.Document.Arguments.VariableTypesMatch` phase to avoid this check. See `Absinthe.Pipeline` on adjusting the document pipeline.

--- a/lib/absinthe/blueprint/schema/enum_value_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_value_definition.ex
@@ -16,7 +16,8 @@ defmodule Absinthe.Blueprint.Schema.EnumValueDefinition do
     flags: %{},
     module: nil,
     errors: [],
-    __reference__: nil
+    __reference__: nil,
+    __private__: []
   ]
 
   @type t :: %__MODULE__{


### PR DESCRIPTION
The EnumValueDefinition is the only schema definition struct that omits the `__private__` field. 