### PR TITLE
Add SDL/macro type extensions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -14,6 +14,7 @@ locals_without_parens = [
   enum: 2,
   enum: 3,
   expand: 1,
+  extend: 1,
   field: 2,
   field: 3,
   field: 4,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -25,6 +25,8 @@ locals_without_parens = [
   import_fields: 1,
   import_types: 1,
   import_types: 2,
+  import_type_extensions: 1,
+  import_type_extensions: 2,
   import_sdl: 1,
   import_sdl: 2,
   input_object: 3,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -15,6 +15,7 @@ locals_without_parens = [
   enum: 3,
   expand: 1,
   extend: 1,
+  extend: 2,
   field: 2,
   field: 3,
   field: 4,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 - Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
+- Feature: [Add support for type extensions](https://github.com/absinthe-graphql/absinthe/pull/1157)
 - Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)
-- Bug Fix: [Fix bug in Schema.__absinthe_types__(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
+- Bug Fix: [Fix bug in Schema.**absinthe_types**(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
 - Feature: [Add `import_directives` macro](https://github.com/absinthe-graphql/absinthe/pull/1158)
 
 ## 1.7.0
@@ -23,6 +24,7 @@
 
 Originally included the items from 1.7.0, but the spec validation fix was considered
 too impactful for a patch release.
+
 ## 1.6.6
 
 - Feature: [Update telemetry dependency to stable ~> 1.0](https://github.com/absinthe-graphql/absinthe/pull/1097)

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -69,6 +69,17 @@ defmodule Absinthe.Blueprint.Schema do
     build_types(attrs, [bp], [])
   end
 
+  def struct_to_kind(Blueprint.Schema.DirectiveDefinition), do: "directive"
+  def struct_to_kind(Blueprint.Schema.EnumTypeDefinition), do: "enum type"
+  def struct_to_kind(Blueprint.Schema.EnumValueDefinition), do: "enum value"
+  def struct_to_kind(Blueprint.Schema.FieldDefinition), do: "field"
+  def struct_to_kind(Blueprint.Schema.InputObjectTypeDefinition), do: "input object"
+  def struct_to_kind(Blueprint.Schema.InputValueDefinition), do: "argument"
+  def struct_to_kind(Blueprint.Schema.ObjectTypeDefinition), do: "object"
+  def struct_to_kind(Blueprint.Schema.ScalarTypeDefinition), do: "scalar"
+  def struct_to_kind(Blueprint.Schema.UnionTypeDefinition), do: "union"
+  def struct_to_kind(_), do: "type"
+
   defp build_types([], [bp], buffer) do
     if buffer != [] do
       raise """

--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -78,6 +78,7 @@ defmodule Absinthe.Blueprint.Schema do
   def struct_to_kind(Blueprint.Schema.ObjectTypeDefinition), do: "object"
   def struct_to_kind(Blueprint.Schema.ScalarTypeDefinition), do: "scalar"
   def struct_to_kind(Blueprint.Schema.UnionTypeDefinition), do: "union"
+  def struct_to_kind(Blueprint.Schema.TypeExtensionDefinition), do: "type extension"
   def struct_to_kind(_), do: "type"
 
   defp build_types([], [bp], buffer) do

--- a/lib/absinthe/blueprint/schema/schema_definition.ex
+++ b/lib/absinthe/blueprint/schema/schema_definition.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Blueprint.Schema.SchemaDefinition do
             type_extensions: [],
             directives: [],
             source_location: nil,
+            type_extension_imports: [],
             # Added by phases
             schema_declaration: nil,
             flags: %{},

--- a/lib/absinthe/blueprint/schema/type_extension_definition.ex
+++ b/lib/absinthe/blueprint/schema/type_extension_definition.ex
@@ -1,0 +1,10 @@
+defmodule Absinthe.Blueprint.Schema.TypeExtensionDefinition do
+  defstruct definition: nil,
+            module: nil,
+            source_location: nil,
+            # # Added by phases
+            flags: %{},
+            errors: [],
+            __private__: [],
+            __reference__: nil
+end

--- a/lib/absinthe/blueprint/transform.ex
+++ b/lib/absinthe/blueprint/transform.ex
@@ -92,6 +92,7 @@ defmodule Absinthe.Blueprint.Transform do
       :type_extensions,
       :directives
     ],
+    Blueprint.Schema.TypeExtensionDefinition => [:definition],
     Blueprint.Schema.UnionTypeDefinition => [:directives, :types]
   }
 

--- a/lib/absinthe/blueprint/transform.ex
+++ b/lib/absinthe/blueprint/transform.ex
@@ -86,7 +86,12 @@ defmodule Absinthe.Blueprint.Transform do
     Blueprint.Schema.InterfaceTypeDefinition => [:interfaces, :fields, :directives],
     Blueprint.Schema.ObjectTypeDefinition => [:interfaces, :fields, :directives],
     Blueprint.Schema.ScalarTypeDefinition => [:directives],
-    Blueprint.Schema.SchemaDefinition => [:directive_definitions, :type_definitions, :directives],
+    Blueprint.Schema.SchemaDefinition => [
+      :directive_definitions,
+      :type_definitions,
+      :type_extensions,
+      :directives
+    ],
     Blueprint.Schema.UnionTypeDefinition => [:directives, :types]
   }
 

--- a/lib/absinthe/language/document.ex
+++ b/lib/absinthe/language/document.ex
@@ -54,7 +54,8 @@ defmodule Absinthe.Language.Document do
       Language.InterfaceTypeDefinition,
       Language.ObjectTypeDefinition,
       Language.ScalarTypeDefinition,
-      Language.UnionTypeDefinition
+      Language.UnionTypeDefinition,
+      Language.TypeExtensionDefinition
     ]
     @directives [
       Language.DirectiveDefinition

--- a/lib/absinthe/language/type_extension_definition.ex
+++ b/lib/absinthe/language/type_extension_definition.ex
@@ -12,14 +12,14 @@ defmodule Absinthe.Language.TypeExtensionDefinition do
         }
 
   defimpl Blueprint.Draft do
-    def convert(node, _doc) do
-      raise Absinthe.Schema.Notation.Error,
-            """
-            \n
-            SDL Compilation failed:
-            -----------------------
-            Keyword `extend` is not yet supported (#{inspect(node.loc)})
-            """
+    def convert(node, doc) do
+      %Absinthe.Blueprint.Schema.TypeExtensionDefinition{
+        definition: Blueprint.Draft.convert(node.definition, doc),
+        source_location: source_location(node)
+      }
     end
+
+    defp source_location(%{loc: nil}), do: nil
+    defp source_location(%{loc: loc}), do: Blueprint.SourceLocation.at(loc)
   end
 end

--- a/lib/absinthe/middleware.ex
+++ b/lib/absinthe/middleware.ex
@@ -310,7 +310,7 @@ defmodule Absinthe.Middleware do
       [{:ref, Absinthe.Type.BuiltIns.Introspection, _}] ->
         expanded
 
-      [{:ref, Absinthe.Phase.Schema.DeprecatedDirectiveFields, _}] ->
+      [{:ref, Absinthe.Type.BuiltIns.DeprecatedDirectiveFields, _}] ->
         expanded
 
       _ ->

--- a/lib/absinthe/phase/schema/apply_type_extensions.ex
+++ b/lib/absinthe/phase/schema/apply_type_extensions.ex
@@ -1,0 +1,155 @@
+defmodule Absinthe.Phase.Schema.ApplyTypeExtensions do
+  @moduledoc false
+
+  @behaviour Absinthe.Phase
+  alias Absinthe.Blueprint
+  alias Absinthe.Blueprint.Schema
+
+  @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(input, _options \\ []) do
+    blueprint = process(input)
+    {:ok, blueprint}
+  end
+
+  defp process(blueprint = %Blueprint{}) do
+    %{blueprint | schema_definitions: update_schema_defs(blueprint.schema_definitions)}
+  end
+
+  def update_schema_defs(schema_definitions) do
+    for schema_def = %{type_definitions: type_definitions, type_extensions: type_extensions} <-
+          schema_definitions do
+      {type_definitions, type_extensions} =
+        apply_type_extensions(type_definitions, type_extensions, [])
+
+      %{
+        schema_def
+        | type_definitions: type_definitions,
+          type_extensions: type_extensions
+      }
+    end
+  end
+
+  defp apply_type_extensions([type_definition | type_definitions], type_extensions, type_defs) do
+    {type_extensions, type_definition} =
+      Enum.map_reduce(type_extensions, type_definition, &apply_extension/2)
+
+    apply_type_extensions(type_definitions, type_extensions, [type_definition | type_defs])
+  end
+
+  defp apply_type_extensions([], type_extensions, type_definitions) do
+    {type_definitions, type_extensions}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.InputObjectTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.InputObjectTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | directives: definition.directives ++ extension.definition.directives,
+         fields: definition.fields ++ extension.definition.fields
+     }}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.InterfaceTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.InterfaceTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | directives: definition.directives ++ extension.definition.directives,
+         fields: definition.fields ++ extension.definition.fields,
+         interfaces: definition.interfaces ++ extension.definition.interfaces
+     }}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.ObjectTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.ObjectTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | directives: definition.directives ++ extension.definition.directives,
+         fields: definition.fields ++ extension.definition.fields,
+         interfaces: definition.interfaces ++ extension.definition.interfaces
+     }}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.ScalarTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.ScalarTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | directives: definition.directives ++ extension.definition.directives
+     }}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.UnionTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.UnionTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | types: definition.types ++ extension.definition.types,
+         directives: definition.directives ++ extension.definition.directives
+     }}
+  end
+
+  defp apply_extension(
+         %Schema.TypeExtensionDefinition{
+           definition: %Schema.EnumTypeDefinition{identifier: identifier}
+         } = extension,
+         %Schema.EnumTypeDefinition{identifier: identifier} = definition
+       ) do
+    {extension,
+     %{
+       definition
+       | values: definition.values ++ extension.definition.values,
+         directives: definition.directives ++ extension.definition.directives
+     }}
+  end
+
+  defp apply_extension(
+         %{definition: %{identifier: identifier} = extension},
+         %{identifier: identifier} = definition
+       ) do
+    extension = Absinthe.Phase.put_error(extension, error(definition, extension))
+
+    {extension, definition}
+  end
+
+  defp apply_extension(extension, definition) do
+    {extension, definition}
+  end
+
+  defp error(%definition_type{} = definition, %extension_type{} = extension_definition) do
+    expected_type = Schema.struct_to_kind(definition_type)
+    extension_type = Schema.struct_to_kind(extension_type)
+
+    %Absinthe.Phase.Error{
+      message: """
+      Type extension type does not match definition type for #{inspect(definition.identifier)}.
+
+      Expected an #{expected_type} but got a #{extension_type}.
+      """,
+      locations: [extension_definition.__reference__.location],
+      phase: __MODULE__
+    }
+  end
+end

--- a/lib/absinthe/phase/schema/directive_imports.ex
+++ b/lib/absinthe/phase/schema/directive_imports.ex
@@ -6,18 +6,17 @@ defmodule Absinthe.Phase.Schema.DirectiveImports do
 
   alias Absinthe.Blueprint.Schema
 
-  def run(blueprint, _opts) do
-    blueprint = Blueprint.prewalk(blueprint, &handle_imports/1)
+  def run(blueprint, opts) do
+    blueprint = Blueprint.prewalk(blueprint, &handle_imports(&1, opts))
     {:ok, blueprint}
   end
 
-  @default_imports [
-    {Absinthe.Type.BuiltIns.Directives, []}
-  ]
-  def handle_imports(%Schema.SchemaDefinition{} = schema) do
+  def handle_imports(%Schema.SchemaDefinition{} = schema, opts) do
+    default_imports = Keyword.get(opts, :directive_imports, [])
+
     {directives, schema} =
       do_imports(
-        @default_imports ++ schema.directive_imports,
+        default_imports ++ schema.directive_imports,
         schema.directive_definitions,
         schema
       )

--- a/lib/absinthe/phase/schema/directive_imports.ex
+++ b/lib/absinthe/phase/schema/directive_imports.ex
@@ -24,7 +24,7 @@ defmodule Absinthe.Phase.Schema.DirectiveImports do
     {:halt, %{schema | directive_definitions: directives}}
   end
 
-  def handle_imports(node), do: node
+  def handle_imports(node, _opts), do: node
 
   defp do_imports([], types, schema) do
     {types, schema}

--- a/lib/absinthe/phase/schema/type_extension_imports.ex
+++ b/lib/absinthe/phase/schema/type_extension_imports.ex
@@ -6,21 +6,27 @@ defmodule Absinthe.Phase.Schema.TypeExtensionImports do
 
   alias Absinthe.Blueprint.Schema
 
-  def run(blueprint, _opts) do
-    blueprint = Blueprint.prewalk(blueprint, &handle_imports/1)
+  def run(blueprint, opts) do
+    blueprint = Blueprint.prewalk(blueprint, &handle_imports(&1, opts))
     {:ok, blueprint}
   end
 
-  def handle_imports(%Schema.SchemaDefinition{} = schema) do
+  def handle_imports(%Schema.SchemaDefinition{} = schema, opts) do
+    default_type_extension_imports = Keyword.get(opts, :type_extension_imports, [])
+
     {type_extensions, schema} =
-      do_imports(schema.type_extension_imports, schema.type_extensions, schema)
+      do_imports(
+        default_type_extension_imports ++ schema.type_extension_imports,
+        schema.type_extensions,
+        schema
+      )
 
     schema = %{schema | type_extensions: type_extensions}
 
     {:halt, schema}
   end
 
-  def handle_imports(node), do: node
+  def handle_imports(node, _), do: node
 
   defp do_imports([], type_extensions, schema) do
     {type_extensions, schema}

--- a/lib/absinthe/phase/schema/type_extension_imports.ex
+++ b/lib/absinthe/phase/schema/type_extension_imports.ex
@@ -11,18 +11,9 @@ defmodule Absinthe.Phase.Schema.TypeExtensionImports do
     {:ok, blueprint}
   end
 
-  @default_imports [
-    # {Absinthe.Type.BuiltIns.Scalars, []},
-    # {Absinthe.Type.BuiltIns.Directives, []},
-    # {Absinthe.Type.BuiltIns.Introspection, []}
-  ]
   def handle_imports(%Schema.SchemaDefinition{} = schema) do
     {type_extensions, schema} =
-      do_imports(
-        @default_imports ++ schema.type_extension_imports,
-        schema.type_extensions,
-        schema
-      )
+      do_imports(schema.type_extension_imports, schema.type_extensions, schema)
 
     schema = %{schema | type_extensions: type_extensions}
 

--- a/lib/absinthe/phase/schema/type_extension_imports.ex
+++ b/lib/absinthe/phase/schema/type_extension_imports.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Phase.Schema.TypeImports do
+defmodule Absinthe.Phase.Schema.TypeExtensionImports do
   @moduledoc false
 
   use Absinthe.Phase
@@ -12,51 +12,58 @@ defmodule Absinthe.Phase.Schema.TypeImports do
   end
 
   @default_imports [
-    {Absinthe.Type.BuiltIns.Scalars, []},
-    {Absinthe.Type.BuiltIns.Introspection, []}
+    # {Absinthe.Type.BuiltIns.Scalars, []},
+    # {Absinthe.Type.BuiltIns.Directives, []},
+    # {Absinthe.Type.BuiltIns.Introspection, []}
   ]
   def handle_imports(%Schema.SchemaDefinition{} = schema) do
-    {types, schema} =
-      do_imports(@default_imports ++ schema.imports, schema.type_definitions, schema)
+    {type_extensions, schema} =
+      do_imports(
+        @default_imports ++ schema.type_extension_imports,
+        schema.type_extensions,
+        schema
+      )
 
-    {:halt, %{schema | type_definitions: types}}
+    schema = %{schema | type_extensions: type_extensions}
+
+    {:halt, schema}
   end
 
   def handle_imports(node), do: node
 
-  defp do_imports([], types, schema) do
-    {types, schema}
+  defp do_imports([], type_extensions, schema) do
+    {type_extensions, schema}
   end
 
-  defp do_imports([{module, opts} | rest], types_acc, schema) do
+  defp do_imports([{module, opts} | rest], type_extensions_acc, schema) do
     case ensure_compiled(module) do
       {:module, module} ->
         [other_def] = module.__absinthe_blueprint__.schema_definitions
 
-        rejections =
-          MapSet.new([:query, :mutation, :subscription] ++ Keyword.get(opts, :except, []))
+        rejections = Keyword.get(opts, :except, []) |> MapSet.new()
 
-        types = Enum.reject(other_def.type_definitions, &(&1.identifier in rejections))
+        type_extensions =
+          Enum.reject(other_def.type_extensions, &(&1.definition.identifier in rejections))
 
-        types =
+        type_extensions =
           case Keyword.fetch(opts, :only) do
             {:ok, selections} ->
-              Enum.filter(types, &(&1.identifier in selections))
+              Enum.filter(type_extensions, &(&1.definition.identifier in selections))
 
             _ ->
-              types
+              type_extensions
           end
 
         do_imports(
-          other_def.imports ++ rest,
-          types ++ types_acc,
+          other_def.type_extension_imports ++ rest,
+          type_extensions ++ type_extensions_acc,
           schema
         )
 
       {:error, reason} ->
         do_imports(
           rest,
-          types_acc,
+          type_extensions_acc,
           schema |> put_error(error(module, reason))
         )
     end

--- a/lib/absinthe/phase/schema/type_imports.ex
+++ b/lib/absinthe/phase/schema/type_imports.ex
@@ -24,11 +24,11 @@ defmodule Absinthe.Phase.Schema.TypeImports do
 
   def handle_imports(node), do: node
 
-  defp do_imports([], types, schema) do
-    {types, schema}
+  defp do_imports([], types, type_extensions, schema) do
+    {types, type_extensions, schema}
   end
 
-  defp do_imports([{module, opts} | rest], acc, schema) do
+  defp do_imports([{module, opts} | rest], types_acc, type_extensions_acc, schema) do
     case ensure_compiled(module) do
       {:module, module} ->
         [other_def] = module.__absinthe_blueprint__.schema_definitions
@@ -47,10 +47,22 @@ defmodule Absinthe.Phase.Schema.TypeImports do
               types
           end
 
-        do_imports(other_def.imports ++ rest, types ++ acc, schema)
+        type_extensions = other_def.type_extensions
+
+        do_imports(
+          other_def.imports ++ rest,
+          types ++ types_acc,
+          type_extensions ++ type_extensions_acc,
+          schema
+        )
 
       {:error, reason} ->
-        do_imports(rest, acc, schema |> put_error(error(module, reason)))
+        do_imports(
+          rest,
+          types_acc,
+          type_extensions_acc,
+          schema |> put_error(error(module, reason))
+        )
     end
   end
 

--- a/lib/absinthe/phase/schema/type_imports.ex
+++ b/lib/absinthe/phase/schema/type_imports.ex
@@ -6,23 +6,27 @@ defmodule Absinthe.Phase.Schema.TypeImports do
 
   alias Absinthe.Blueprint.Schema
 
-  def run(blueprint, _opts) do
-    blueprint = Blueprint.prewalk(blueprint, &handle_imports/1)
+  def run(blueprint, opts) do
+    blueprint = Blueprint.prewalk(blueprint, &handle_imports(&1, opts))
     {:ok, blueprint}
   end
 
-  @default_imports [
-    {Absinthe.Type.BuiltIns.Scalars, []},
-    {Absinthe.Type.BuiltIns.Introspection, []}
-  ]
-  def handle_imports(%Schema.SchemaDefinition{} = schema) do
+  def handle_imports(%Schema.SchemaDefinition{} = schema, opts) do
+    default_imports = Keyword.get(opts, :type_imports, [])
+
     {types, schema} =
-      do_imports(@default_imports ++ schema.imports, schema.type_definitions, schema)
+      do_imports(
+        default_imports ++ schema.imports,
+        schema.type_definitions,
+        schema
+      )
+
+    schema = %{schema | type_definitions: types}
 
     {:halt, %{schema | type_definitions: types}}
   end
 
-  def handle_imports(node), do: node
+  def handle_imports(node, _), do: node
 
   defp do_imports([], types, schema) do
     {types, schema}

--- a/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
+++ b/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
@@ -3,7 +3,6 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
 
   use Absinthe.Phase
   alias Absinthe.Blueprint
-  alias Absinthe.Blueprint.Schema
 
   @valid_name_regex ~r/^[_A-Za-z][_0-9A-Za-z]*$/
 
@@ -20,7 +19,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
     if valid_name?(name) do
       entity
     else
-      kind = struct_to_kind(struct)
+      kind = Absinthe.Blueprint.Schema.struct_to_kind(struct)
       detail = %{artifact: "#{kind} name", value: entity.name}
       entity |> put_error(error(entity, detail))
     end
@@ -42,15 +41,6 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
       extra: data
     }
   end
-
-  defp struct_to_kind(Schema.InputValueDefinition), do: "argument"
-  defp struct_to_kind(Schema.FieldDefinition), do: "field"
-  defp struct_to_kind(Schema.DirectiveDefinition), do: "directive"
-  defp struct_to_kind(Schema.ScalarTypeDefinition), do: "scalar"
-  defp struct_to_kind(Schema.ObjectTypeDefinition), do: "object"
-  defp struct_to_kind(Schema.InputObjectTypeDefinition), do: "input object"
-  defp struct_to_kind(Schema.EnumValueDefinition), do: "enum value"
-  defp struct_to_kind(_), do: "type"
 
   @description """
   Name does not match possible #{inspect(@valid_name_regex)} regex.

--- a/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_implement_interfaces.ex
@@ -30,6 +30,11 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustImplementInterfaces do
     Blueprint.Schema.InterfaceTypeDefinition
   ]
 
+  # Do not walk type extension definition as they are allowed to be invalid
+  defp validate_objects(%Blueprint.Schema.TypeExtensionDefinition{} = extension, _, _) do
+    {:halt, extension}
+  end
+
   defp validate_objects(%struct{} = object, ifaces, types) when struct in @interface_types do
     Enum.reduce(object.interfaces, object, fn ident, object ->
       case Map.fetch(ifaces, ident) do

--- a/lib/absinthe/phase/schema/validation/type_names_are_reserved.ex
+++ b/lib/absinthe/phase/schema/validation/type_names_are_reserved.ex
@@ -37,6 +37,10 @@ defmodule Absinthe.Phase.Schema.Validation.TypeNamesAreReserved do
     allow_reserved(node)
   end
 
+  defp validate_reserved(%Blueprint.Schema.TypeExtensionDefinition{} = node) do
+    {:halt, node}
+  end
+
   defp validate_reserved(%struct{name: "__" <> _} = entity) do
     reserved_ok =
       Absinthe.Type.built_in_module?(entity.__reference__.module) ||

--- a/lib/absinthe/phase/schema/validation/type_names_are_unique.ex
+++ b/lib/absinthe/phase/schema/validation/type_names_are_unique.ex
@@ -35,6 +35,11 @@ defmodule Absinthe.Phase.Schema.Validation.TypeNamesAreUnique do
     obj
   end
 
+  # We do not need to validate type extension names
+  defp validate_types(%Blueprint.Schema.TypeExtensionDefinition{} = object, _types, _key) do
+    {:halt, object}
+  end
+
   @types [
     Blueprint.Schema.DirectiveDefinition,
     Blueprint.Schema.EnumTypeDefinition,

--- a/lib/absinthe/phase/schema/validation/type_references_exist.ex
+++ b/lib/absinthe/phase/schema/validation/type_references_exist.ex
@@ -49,6 +49,10 @@ defmodule Absinthe.Phase.Schema.Validation.TypeReferencesExist do
     check_types(union, :types, &check_or_error(&2, &1, types))
   end
 
+  def validate_types(%Blueprint.Schema.TypeExtensionDefinition{} = extension, types) do
+    check_or_error(extension, extension.definition.identifier, types)
+  end
+
   @no_types [
     Blueprint.Schema.DirectiveDefinition,
     Blueprint.Schema.EnumTypeDefinition,
@@ -104,16 +108,30 @@ defmodule Absinthe.Phase.Schema.Validation.TypeReferencesExist do
   end
 
   defp error(thing, type) do
-    artifact_name = String.capitalize(thing.name)
-
     %Absinthe.Phase.Error{
-      message: """
-      In #{artifact_name}, #{inspect(type)} is not defined in your schema.
-
-      Types must exist if referenced.
-      """,
+      message: message(thing, type),
       locations: [thing.__reference__.location],
       phase: __MODULE__
     }
+  end
+
+  defp message(%Blueprint.Schema.TypeExtensionDefinition{}, type) do
+    """
+    In type extension the target type #{inspect(type)} is not
+    defined in your schema.
+
+    Types must exist if referenced.
+    """
+  end
+
+  defp message(thing, type) do
+    kind = Absinthe.Blueprint.Schema.struct_to_kind(thing.__struct__)
+    artifact_name = String.capitalize(thing.name)
+
+    """
+    In #{kind} #{artifact_name}, #{inspect(type)} is not defined in your schema.
+
+    Types must exist if referenced.
+    """
   end
 end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -120,6 +120,21 @@ defmodule Absinthe.Pipeline do
     ]
   end
 
+  def default_schema_options() do
+    [
+      type_imports: [
+        {Absinthe.Type.BuiltIns.Scalars, []},
+        {Absinthe.Type.BuiltIns.Introspection, []}
+      ],
+      directive_imports: [
+        {Absinthe.Type.BuiltIns.Directives, []}
+      ],
+      type_extension_imports: [
+        {Absinthe.Type.BuiltIns.DeprecatedDirectiveFields, []}
+      ]
+    ]
+  end
+
   @default_prototype_schema Absinthe.Schema.Prototype
 
   @spec for_schema(nil | Absinthe.Schema.t()) :: t
@@ -129,16 +144,16 @@ defmodule Absinthe.Pipeline do
   """
   def for_schema(schema, options \\ []) do
     options =
-      options
+      default_schema_options()
+      |> Keyword.merge(options)
       |> Enum.reject(fn {_, v} -> is_nil(v) end)
       |> Keyword.put(:schema, schema)
       |> Keyword.put_new(:prototype_schema, @default_prototype_schema)
 
     [
-      Phase.Schema.DirectiveImports,
-      Phase.Schema.TypeImports,
-      Phase.Schema.DeprecatedDirectiveFields,
-      Phase.Schema.TypeExtensionImports,
+      {Phase.Schema.DirectiveImports, options},
+      {Phase.Schema.TypeImports, options},
+      {Phase.Schema.TypeExtensionImports, options},
       Phase.Schema.ApplyTypeExtensions,
       Phase.Schema.ApplyDeclaration,
       Phase.Schema.Introspection,

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -137,6 +137,7 @@ defmodule Absinthe.Pipeline do
     [
       Phase.Schema.DirectiveImports,
       Phase.Schema.TypeImports,
+      Phase.Schema.TypeExtensionImports,
       Phase.Schema.DeprecatedDirectiveFields,
       Phase.Schema.ApplyTypeExtensions,
       Phase.Schema.ApplyDeclaration,

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -138,6 +138,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.DirectiveImports,
       Phase.Schema.TypeImports,
       Phase.Schema.DeprecatedDirectiveFields,
+      Phase.Schema.ApplyTypeExtensions,
       Phase.Schema.ApplyDeclaration,
       Phase.Schema.Introspection,
       {Phase.Schema.Hydrate, options},

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -137,8 +137,8 @@ defmodule Absinthe.Pipeline do
     [
       Phase.Schema.DirectiveImports,
       Phase.Schema.TypeImports,
-      Phase.Schema.TypeExtensionImports,
       Phase.Schema.DeprecatedDirectiveFields,
+      Phase.Schema.TypeExtensionImports,
       Phase.Schema.ApplyTypeExtensions,
       Phase.Schema.ApplyDeclaration,
       Phase.Schema.Introspection,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -2172,8 +2172,8 @@ defmodule Absinthe.Schema.Notation do
         other -> other
       end)
 
-    type_extensions_imports =
-      (Module.get_attribute(env.module, :__absinthe_type_extensions_imports__) || [])
+    type_extension_imports =
+      (Module.get_attribute(env.module, :__absinthe_type_extension_imports__) || [])
       |> Enum.uniq()
       |> Enum.map(fn
         module when is_atom(module) -> {module, []}

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -817,6 +817,7 @@ defmodule Absinthe.Schema.Notation do
   @placement {:private,
               [
                 under: [
+                  :directive,
                   :enum,
                   :extend,
                   :field,
@@ -837,6 +838,7 @@ defmodule Absinthe.Schema.Notation do
   @placement {:meta,
               [
                 under: [
+                  :directive,
                   :enum,
                   :extend,
                   :field,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -271,8 +271,7 @@ defmodule Absinthe.Schema.Notation do
     # ...
   end
 
-  extend do
-    object :user do
+  extend object :user do
       field :nick_name, :string
       # ...
     end

--- a/lib/absinthe/schema/notation/sdl.ex
+++ b/lib/absinthe/schema/notation/sdl.ex
@@ -60,6 +60,11 @@ defmodule Absinthe.Schema.Notation.SDL do
     |> do_put_ref(ref, opts)
   end
 
+  defp put_ref(%{definition: definition} = node, ref, opts) do
+    %{node | definition: put_ref(definition, ref, opts)}
+    |> do_put_ref(ref, opts)
+  end
+
   defp put_ref(%{directives: directives} = node, ref, opts) do
     %{node | directives: Enum.map(directives, &put_ref(&1, ref, opts))}
     |> do_put_ref(ref, opts)

--- a/lib/absinthe/schema/prototype/notation.ex
+++ b/lib/absinthe/schema/prototype/notation.ex
@@ -34,7 +34,10 @@ defmodule Absinthe.Schema.Prototype.Notation do
       def pipeline(pipeline) do
         pipeline
         |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.Validation.QueryTypeMustBeObject)
-        |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.DeprecatedDirectiveFields)
+        |> Absinthe.Pipeline.replace(
+          Absinthe.Phase.Schema.TypeExtensionImports,
+          {Absinthe.Phase.Schema.TypeExtensionImports, []}
+        )
       end
 
       @doc """

--- a/lib/absinthe/type/built_ins/deprecated_directive_fields.ex
+++ b/lib/absinthe/type/built_ins/deprecated_directive_fields.ex
@@ -1,30 +1,11 @@
-defmodule Absinthe.Phase.Schema.DeprecatedDirectiveFields do
+defmodule Absinthe.Type.BuiltIns.DeprecatedDirectiveFields do
   @moduledoc false
   # The spec of Oct 2015 has the onOperation, onFragment and onField
   # fields for directives (https://spec.graphql.org/October2015/#sec-Schema-Introspection)
   # See https://github.com/graphql/graphql-spec/pull/152 for the rationale.
   # These fields are deprecated and can be removed in the future.
-  alias Absinthe.Blueprint
 
   use Absinthe.Schema.Notation
-
-  @behaviour Absinthe.Phase
-
-  def run(input, _options \\ []) do
-    blueprint = process(input)
-    {:ok, blueprint}
-  end
-
-  defp process(blueprint = %Blueprint{}) do
-    %{blueprint | schema_definitions: update_schema_defs(blueprint.schema_definitions)}
-  end
-
-  def update_schema_defs(schema_definitions) do
-    for schema_def = %{type_extension_imports: type_extension_imports} <-
-          schema_definitions do
-      %{schema_def | type_extension_imports: [{__MODULE__, []}] ++ type_extension_imports}
-    end
-  end
 
   extend object(:__directive) do
     field :on_operation, :boolean do

--- a/lib/absinthe/utils.ex
+++ b/lib/absinthe/utils.ex
@@ -86,6 +86,12 @@ defmodule Absinthe.Utils do
     """
   end
 
+  defp do_placement_docs(toplevel: true, extend: true) do
+    """
+    Top level in module or in an `extend` block.
+    """
+  end
+
   defp do_placement_docs(under: under) when is_list(under) do
     under =
       under

--- a/test/absinthe/blueprint/type_reference_test.exs
+++ b/test/absinthe/blueprint/type_reference_test.exs
@@ -2,7 +2,6 @@ defmodule Absinthe.Blueprint.TypeReferenceTest do
   use Absinthe.Case, async: true
 
   alias Absinthe.Blueprint
-  @moduletag :f
 
   describe ".unwrap of Name" do
     test "is left intact" do

--- a/test/absinthe/schema/notation/experimental/import_sdl_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_sdl_test.exs
@@ -540,30 +540,6 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportSdlTest do
     end
   end
 
-  test "Keyword extend not yet supported" do
-    schema = """
-    defmodule KeywordExtend do
-      use Absinthe.Schema
-
-      import_sdl "
-      type Movie {
-        title: String!
-      }
-
-      extend type Movie {
-        year: Int
-      }
-      "
-    end
-    """
-
-    error = ~r/Keyword `extend` is not yet supported/
-
-    assert_raise(Absinthe.Schema.Notation.Error, error, fn ->
-      Code.eval_string(schema)
-    end)
-  end
-
   test "Validate known directive arguments in SDL schema" do
     schema = """
     defmodule SchemaWithDirectivesWithNestedArgs do

--- a/test/absinthe/schema/notation/experimental/import_type_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_type_extensions_test.exs
@@ -1,0 +1,112 @@
+defmodule Absinthe.Schema.Notation.Experimental.ImportTypeExtensionsTest do
+  use Absinthe.Case, async: true
+
+  @moduletag :experimental
+
+  defmodule Source do
+    use Absinthe.Schema.Notation
+
+    extend object(:one) do
+      field :one, :string
+    end
+
+    extend object(:two) do
+      field :two, :string
+    end
+
+    extend object(:three) do
+      field :three, :string
+    end
+  end
+
+  defmodule WithoutOptions do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    object :one do
+    end
+
+    object :two do
+    end
+
+    object :three do
+    end
+
+    import_type_extensions Source
+  end
+
+  defmodule UsingOnlyOption do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    object :one do
+    end
+
+    object :two do
+    end
+
+    object :three do
+    end
+
+    import_type_extensions Source, only: [:one, :two]
+  end
+
+  defmodule UsingExceptOption do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    object :one do
+    end
+
+    object :two do
+    end
+
+    object :three do
+    end
+
+    import_type_extensions Source, except: [:one, :two]
+  end
+
+  describe "import_types" do
+    test "without options" do
+      assert [{Source, []}] == imports(WithoutOptions)
+
+      assert [%{identifier: :one}] = fields(WithoutOptions, :one)
+      assert [%{identifier: :two}] = fields(WithoutOptions, :two)
+      assert [%{identifier: :three}] = fields(WithoutOptions, :three)
+    end
+
+    test "with :only" do
+      assert [{Source, only: [:one, :two]}] == imports(UsingOnlyOption)
+
+      assert [%{identifier: :one}] = fields(UsingOnlyOption, :one)
+      assert [%{identifier: :two}] = fields(UsingOnlyOption, :two)
+      assert [] = fields(UsingOnlyOption, :three)
+    end
+
+    test "with :except" do
+      assert [{Source, except: [:one, :two]}] == imports(UsingExceptOption)
+
+      assert [] = fields(UsingExceptOption, :one)
+      assert [] = fields(UsingExceptOption, :two)
+      assert [%{identifier: :three}] = fields(UsingExceptOption, :three)
+    end
+  end
+
+  defp imports(module) do
+    %{schema_definitions: [schema]} = module.__absinthe_blueprint__
+    schema.type_extension_imports
+  end
+
+  defp fields(module, type) do
+    module.__absinthe_type__(type).fields
+    |> Map.values()
+    |> Enum.reject(&match?(%{identifier: :__typename}, &1))
+  end
+end

--- a/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
@@ -262,6 +262,29 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
     end)
   end
 
+  test "raises when extend has unknown type" do
+    schema = """
+    defmodule InvalidKeywordExtend do
+      use Absinthe.Schema
+
+      query do
+      end
+
+      extend do
+        enum :foo do
+          value :south
+        end
+      end
+    end
+    """
+
+    error = ~r/In type extension the target type :foo is not\ndefined in your schema./
+
+    assert_raise(Absinthe.Schema.Error, error, fn ->
+      Code.eval_string(schema, [], __ENV__)
+    end)
+  end
+
   defmodule ImportedSchema do
     use Absinthe.Schema.Notation
 

--- a/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
@@ -60,50 +60,36 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
       field :x, :float
     end
 
-    extend do
-      enum :direction do
-        value :south
-      end
+    extend enum(:direction) do
+      value :south
     end
 
-    extend do
-      enum :direction do
-        value :west
-      end
+    extend enum(:direction) do
+      value :west
     end
 
-    extend do
-      union :search_result do
-        types [:person]
-      end
+    extend union(:search_result) do
+      types [:person]
     end
 
-    extend do
-      scalar :my_custom_scalar do
-        directive :feature
-      end
+    extend scalar(:my_custom_scalar) do
+      directive :feature
     end
 
-    extend do
-      interface :named_entity do
-        interface :valued_entity
-        field :nickname, :string
-        field :value, :integer
-      end
+    extend interface :named_entity do
+      interface :valued_entity
+      field :nickname, :string
+      field :value, :integer
     end
 
-    extend do
-      object :photo do
-        interface :valued_entity
-        field :width, :integer
-        field :value, :integer
-      end
+    extend object(:photo) do
+      interface :valued_entity
+      field :width, :integer
+      field :value, :integer
     end
 
-    extend do
-      input_object :point do
-        field :y, :float
-      end
+    extend input_object(:point) do
+      field :y, :float
     end
   end
 
@@ -216,10 +202,8 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
         value :east
       end
 
-      extend do
-        union :direction do
-          types [:west]
-        end
+      extend union :direction do
+        types [:west]
       end
     end
     """
@@ -231,37 +215,6 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
     end)
   end
 
-  test "raises when extend has multiple definitions" do
-    schema = """
-    defmodule MultipleDefinitionExtend do
-      use Absinthe.Schema
-
-      query do
-      end
-
-      enum :direction do
-        value :north
-        value :east
-      end
-
-      extend do
-        enum :direction do
-          value :south
-        end
-        enum :direction do
-          value :west
-        end
-      end
-    end
-    """
-
-    error = ~r/Only one definition allowed in `extend` block./
-
-    assert_raise(Absinthe.Schema.Notation.Error, error, fn ->
-      Code.eval_string(schema, [], __ENV__)
-    end)
-  end
-
   test "raises when extend has unknown type" do
     schema = """
     defmodule UnknownTypeExtend do
@@ -270,10 +223,8 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
       query do
       end
 
-      extend do
-        enum :foo do
-          value :south
-        end
+      extend enum :foo do
+        value :south
       end
     end
     """
@@ -288,10 +239,8 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
   defmodule ImportedSchema do
     use Absinthe.Schema.Notation
 
-    extend do
-      enum :direction do
-        value :north
-      end
+    extend enum(:direction) do
+      value :north
     end
   end
 

--- a/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
@@ -250,7 +250,7 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
     query do
     end
 
-    import_types ImportedSchema
+    import_type_extensions ImportedSchema
 
     enum :direction do
       value :south

--- a/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
@@ -233,7 +233,7 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
 
   test "raises when extend has multiple definitions" do
     schema = """
-    defmodule InvalidKeywordExtend do
+    defmodule MultipleDefinitionExtend do
       use Absinthe.Schema
 
       query do
@@ -264,7 +264,7 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
 
   test "raises when extend has unknown type" do
     schema = """
-    defmodule InvalidKeywordExtend do
+    defmodule UnknownTypeExtend do
       use Absinthe.Schema
 
       query do

--- a/test/absinthe/schema/notation/experimental/sdl_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/sdl_extensions_test.exs
@@ -231,7 +231,7 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
     query do
     end
 
-    import_types ImportedSchema
+    import_type_extensions ImportedSchema
 
     import_sdl """
     enum Direction {

--- a/test/absinthe/schema/notation/experimental/sdl_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/sdl_extensions_test.exs
@@ -29,7 +29,6 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
     import_sdl """
     type Person {
       name: String
-      age: Int
     }
 
     type Photo {
@@ -39,12 +38,10 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
 
     enum Direction {
       NORTH
-      EAST
     }
 
     input Point {
       x: Float
-      y: Float
     }
 
     union SearchResult = Photo
@@ -72,7 +69,6 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
     extend scalar MyCustomScalar @feature
 
     extend type Photo implements ValuedEntity {
-      description: String
       value: Int
     }
 
@@ -82,7 +78,7 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
     }
 
     extend input Point {
-      z: Float
+      y: Float
     }
     """
 
@@ -101,10 +97,6 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
     object = lookup_compiled_type(ExtendedSchema, :direction)
 
     assert %{
-             east: %Absinthe.Type.Enum.Value{
-               name: "EAST",
-               value: :east
-             },
              north: %Absinthe.Type.Enum.Value{
                name: "NORTH",
                value: :north
@@ -141,10 +133,6 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
                type: :string
              },
              %{
-               name: "description",
-               type: :string
-             },
-             %{
                name: "height",
                type: :integer
              },
@@ -171,10 +159,6 @@ defmodule Absinthe.Schema.Notation.Experimental.SdlExtensionsTest do
              },
              %{
                name: "y",
-               type: :float
-             },
-             %{
-               name: "z",
                type: :float
              }
            ] = Map.values(object.fields)

--- a/test/absinthe/schema/notation/import_test.exs
+++ b/test/absinthe/schema/notation/import_test.exs
@@ -131,7 +131,7 @@ defmodule Absinthe.Schema.Notation.ImportTest do
                   extra: %{},
                   locations: [_],
                   message:
-                    "In Bar, :asdf is not defined in your schema.\n\nTypes must exist if referenced.\n",
+                    "In object Bar, :asdf is not defined in your schema.\n\nTypes must exist if referenced.\n",
                   path: [],
                   phase: Absinthe.Phase.Schema.Validation.TypeReferencesExist
                 }

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -554,6 +554,10 @@ defmodule Absinthe.Schema.NotationTest do
   describe "extend" do
     test "can be toplevel" do
       assert_no_notation_error("ExtendValid", """
+      enum :foo do
+        value :baz
+      end
+
       extend do
         enum :foo do
           value :bar

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -558,10 +558,8 @@ defmodule Absinthe.Schema.NotationTest do
         value :baz
       end
 
-      extend do
-        enum :foo do
-          value :bar
-        end
+      extend enum :foo do
+        value :bar
       end
       """)
     end
@@ -571,10 +569,8 @@ defmodule Absinthe.Schema.NotationTest do
         "ExtendInvalid",
         """
         enum :foo do
-          extend do
-            enum :bar do
-              value :baz
-            end
+          extend enum :bar do
+            value :baz
           end
         end
         """,

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -51,7 +51,7 @@ defmodule Absinthe.Schema.NotationTest do
           end
         end
         """,
-        "Invalid schema notation: `directive` must only be used toplevel. Was used in `directive`."
+        "Invalid schema notation: `directive` must only be used toplevel or in an `extend` block. Was used in `directive`."
       )
     end
   end
@@ -73,7 +73,7 @@ defmodule Absinthe.Schema.NotationTest do
           end
         end
         """,
-        "Invalid schema notation: `enum` must only be used toplevel. Was used in `enum`."
+        "Invalid schema notation: `enum` must only be used toplevel or in an `extend` block. Was used in `enum`."
       )
     end
   end
@@ -131,7 +131,7 @@ defmodule Absinthe.Schema.NotationTest do
           end
         end
         """,
-        "Invalid schema notation: `input_object` must only be used toplevel. Was used in `input_object`."
+        "Invalid schema notation: `input_object` must only be used toplevel or in an `extend` block. Was used in `input_object`."
       )
     end
   end
@@ -299,7 +299,7 @@ defmodule Absinthe.Schema.NotationTest do
           end
         end
         """,
-        "Invalid schema notation: `object` must only be used toplevel. Was used in `object`."
+        "Invalid schema notation: `object` must only be used toplevel or in an `extend` block. Was used in `object`."
       )
     end
 
@@ -464,7 +464,7 @@ defmodule Absinthe.Schema.NotationTest do
           end
         end
         """,
-        "Invalid schema notation: `scalar` must only be used toplevel. Was used in `scalar`."
+        "Invalid schema notation: `scalar` must only be used toplevel or in an `extend` block. Was used in `scalar`."
       )
     end
   end
@@ -547,6 +547,34 @@ defmodule Absinthe.Schema.NotationTest do
         "DescriptionInvalid",
         ~s(description "test"),
         "Invalid schema notation: `description` must not be used toplevel. Was used in `schema`."
+      )
+    end
+  end
+
+  describe "extend" do
+    test "can be toplevel" do
+      assert_no_notation_error("ExtendValid", """
+      extend do
+        enum :foo do
+          value :bar
+        end
+      end
+      """)
+    end
+
+    test "cannot be non-toplevel" do
+      assert_notation_error(
+        "ExtendInvalid",
+        """
+        enum :foo do
+          extend do
+            enum :bar do
+              value :baz
+            end
+          end
+        end
+        """,
+        "Invalid schema notation: `extend` must only be used toplevel. Was used in `enum`."
       )
     end
   end

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -352,6 +352,12 @@ defmodule Absinthe.SchemaTest do
       end
     end
 
+    directive :foo do
+      meta :is_directive, true
+
+      on :field
+    end
+
     input_object :input_foo do
       meta :is_input, true
 
@@ -423,6 +429,12 @@ defmodule Absinthe.SchemaTest do
       color = Schema.lookup_type(MetadataSchema, :color)
       assert %{__private__: [meta: [rgb_only: true]]} = color
       assert Type.meta(color, :rgb_only) == true
+    end
+
+    test "sets directive metadata" do
+      directive = Schema.lookup_directive(MetadataSchema, :foo)
+      assert %{__private__: [meta: [is_directive: true]]} = directive
+      assert Type.meta(directive, :is_directive) == true
     end
 
     test "sets scalar metadata" do

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -362,7 +362,6 @@ defmodule Absinthe.SchemaTest do
 
     enum :color do
       meta :rgb_only, true
-      value :red
       value :blue
       value :green
     end
@@ -383,6 +382,10 @@ defmodule Absinthe.SchemaTest do
     union :result do
       types [:foo]
       meta :is_union, true
+    end
+
+    extend enum(:color), meta: [is_extend: true] do
+      value :red
     end
   end
 
@@ -444,6 +447,16 @@ defmodule Absinthe.SchemaTest do
       result = Schema.lookup_type(MetadataSchema, :result)
       assert %{__private__: [meta: [is_union: true]]} = result
       assert Type.meta(result, :is_union) == true
+    end
+
+    test "sets extend metadata" do
+      [schema_def] = MetadataSchema.__absinthe_blueprint__().schema_definitions
+
+      type_extension =
+        Enum.find(schema_def.type_extensions, &(&1.definition.identifier == :color))
+
+      assert %{__private__: [meta: [is_extend: true]]} = type_extension
+      assert Type.meta(type_extension, :is_extend) == true
     end
   end
 end


### PR DESCRIPTION
Gave it a shot to add support for `extend` to SDL. Once that was running, adding macro support was not that difficult.
It follows the graphql spec for the most part, though schema declarations cannot be extended as of yet. The validations are done by the currently existing validation phases.

I looked at https://github.com/absinthe-graphql/absinthe/pull/821 but decided against the 
```elixir
extend :foo do
   field :name, :string
end
```
 syntax in favor of 
```elixir
extend do 
   object :foo do
      field :name, :string
   end
end
```
since it was easier to implement and is closer to the graphql syntax. I also think it will work better with imports.

Imports across modules work as well, using the `type_extensions` field. It uses the `TypeImports` phase, though it could be moved to a different module if necessary or even a separate `import_type_extensions` macro instead of the `import_types` macro.

Fixes https://github.com/absinthe-graphql/absinthe/issues/772
