### PR TITLE
Start Absinthe.Schema for persistent term schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ missing_rules.rb
 .DS_Store
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+/tmp

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -80,6 +80,12 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
 
     opts = parse_options(argv)
 
+    # Start for Absinthe.Schema.PersistentTerm
+    Supervisor.start_link([{Absinthe.Schema, opts.schema}],
+      name: Absinthe.Schema.JsonTaskSupervisor,
+      strategy: :one_for_one
+    )
+
     case generate_schema(opts) do
       {:ok, content} -> write_schema(content, opts.filename)
       {:error, error} -> raise error

--- a/lib/mix/tasks/absinthe.schema.json.ex
+++ b/lib/mix/tasks/absinthe.schema.json.ex
@@ -80,11 +80,10 @@ defmodule Mix.Tasks.Absinthe.Schema.Json do
 
     opts = parse_options(argv)
 
-    # Start for Absinthe.Schema.PersistentTerm
-    Supervisor.start_link([{Absinthe.Schema, opts.schema}],
-      name: Absinthe.Schema.JsonTaskSupervisor,
-      strategy: :one_for_one
-    )
+    # Start Absinthe.Schema if using persistent term provider
+    if opts.schema.__absinthe_schema_provider__() == Absinthe.Schema.PersistentTerm do
+      Supervisor.start_link([{Absinthe.Schema, opts.schema}], strategy: :one_for_one)
+    end
 
     case generate_schema(opts) do
       {:ok, content} -> write_schema(content, opts.filename)

--- a/lib/mix/tasks/absinthe.schema.sdl.ex
+++ b/lib/mix/tasks/absinthe.schema.sdl.ex
@@ -49,6 +49,11 @@ defmodule Mix.Tasks.Absinthe.Schema.Sdl do
 
     opts = parse_options(argv)
 
+    # Start Absinthe.Schema if using persistent term provider
+    if opts.schema.__absinthe_schema_provider__() == Absinthe.Schema.PersistentTerm do
+      Supervisor.start_link([{Absinthe.Schema, opts.schema}], strategy: :one_for_one)
+    end
+
     case generate_schema(opts) do
       {:ok, content} -> write_schema(content, opts.filename)
       {:error, error} -> raise error

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -95,7 +95,12 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
       assert ugly_content == "test-encoder-ugly"
     end
 
-    @tag :tmp_dir
+    if Version.compare(System.version(), "1.11.0") == :lt do
+      setup :tmp_dir_fallback
+    else
+      @tag :tmp_dir
+    end
+
     test "generates a JSON file", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.json")
 
@@ -105,7 +110,12 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
       assert File.exists?(path)
     end
 
-    @tag :tmp_dir
+    if Version.compare(System.version(), "1.11.0") == :lt do
+      setup :tmp_dir_fallback
+    else
+      @tag :tmp_dir
+    end
+
     test "generates a JSON file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.json")
 
@@ -114,5 +124,12 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
 
       assert File.exists?(path)
     end
+  end
+
+  defp tmp_dir_fallback(_) do
+    path = Path.join("tmp", "#{__MODULE__}")
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf!(path) end)
+    [tmp_dir: path]
   end
 end

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -17,6 +17,22 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
     end
   end
 
+  defmodule PersistentTermTestSchema do
+    use Absinthe.Schema
+
+    @schema_provider Absinthe.Schema.PersistentTerm
+
+    query do
+      field :item, :item
+    end
+
+    object :item do
+      description "A Basic Type"
+      field :id, :id
+      field :name, :string
+    end
+  end
+
   defmodule TestEncoder do
     def encode!(_map, opts) do
       pretty_flag = Keyword.get(opts, :pretty, false)
@@ -27,6 +43,12 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
 
   @test_schema "Mix.Tasks.Absinthe.Schema.JsonTest.TestSchema"
   @test_encoder "Mix.Tasks.Absinthe.Schema.JsonTest.TestEncoder"
+
+  setup_all do
+    shell = Mix.shell()
+    Mix.shell(Mix.Shell.Quiet)
+    on_exit(fn -> Mix.shell(shell) end)
+  end
 
   describe "absinthe.schema.json" do
     test "parses options" do
@@ -71,6 +93,26 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
 
       assert pretty_content == "test-encoder-pretty"
       assert ugly_content == "test-encoder-ugly"
+    end
+
+    @tag :tmp_dir
+    test "generates a JSON file", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "schema.json")
+
+      argv = ["--schema", @test_schema, "--json-codec", @test_encoder, path]
+      assert Task.run(argv)
+
+      assert File.exists?(path)
+    end
+
+    @tag :tmp_dir
+    test "generates a JSON file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "schema.json")
+
+      argv = ["--schema", "#{PersistentTermTestSchema}", "--json-codec", @test_encoder, path]
+      assert Task.run(argv)
+
+      assert File.exists?(path)
     end
   end
 end

--- a/test/mix/tasks/absinthe.schema.sdl_test.exs
+++ b/test/mix/tasks/absinthe.schema.sdl_test.exs
@@ -107,7 +107,29 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
     end
   end
 
+  defmodule PersistentTermTestSchema do
+    use Absinthe.Schema
+
+    @schema_provider Absinthe.Schema.PersistentTerm
+
+    query do
+      field :item, :item
+    end
+
+    object :item do
+      description "A Basic Type"
+      field :id, :id
+      field :name, :string
+    end
+  end
+
   @test_mod_schema "Mix.Tasks.Absinthe.Schema.SdlTest.TestSchemaWithMods"
+
+  setup_all do
+    shell = Mix.shell()
+    Mix.shell(Mix.Shell.Quiet)
+    on_exit(fn -> Mix.shell(shell) end)
+  end
 
   describe "absinthe.schema.sdl" do
     test "parses options" do
@@ -150,6 +172,26 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert schema =~ "type Mod {"
       assert schema =~ "modField: String"
       assert schema =~ "type Robot implements Being"
+    end
+
+    @tag :tmp_dir
+    test "generates an SDL file", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "schema.sdl")
+
+      argv = ["--schema", @test_schema, path]
+      assert Task.run(argv)
+
+      assert File.exists?(path)
+    end
+
+    @tag :tmp_dir
+    test "generates an SDL file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "schema.sdl")
+
+      argv = ["--schema", "#{PersistentTermTestSchema}", path]
+      assert Task.run(argv)
+
+      assert File.exists?(path)
     end
   end
 end

--- a/test/mix/tasks/absinthe.schema.sdl_test.exs
+++ b/test/mix/tasks/absinthe.schema.sdl_test.exs
@@ -174,7 +174,12 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert schema =~ "type Robot implements Being"
     end
 
-    @tag :tmp_dir
+    if Version.compare(System.version(), "1.11.0") == :lt do
+      setup :tmp_dir_fallback
+    else
+      @tag :tmp_dir
+    end
+
     test "generates an SDL file", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.sdl")
 
@@ -184,7 +189,12 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert File.exists?(path)
     end
 
-    @tag :tmp_dir
+    if Version.compare(System.version(), "1.11.0") == :lt do
+      setup :tmp_dir_fallback
+    else
+      @tag :tmp_dir
+    end
+
     test "generates an SDL file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.sdl")
 
@@ -193,5 +203,12 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
 
       assert File.exists?(path)
     end
+  end
+
+  defp tmp_dir_fallback(_) do
+    path = Path.join("tmp", "#{__MODULE__}")
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf!(path) end)
+    [tmp_dir: path]
   end
 end


### PR DESCRIPTION
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->

Locally we ran into an error generating a JSON schema file. We're using `Absinthe.Schema.PersistentTerm`

```elixir
@schema_provider Absinthe.Schema.PersistentTerm
```

Error:
```
mix absinthe.schema.json --schema OurSchema --pretty path/to/schema.json
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: no persistent term stored with this key

    :persistent_term.get({Absinthe.Schema.PersistentTerm, OurSchema})
    (absinthe 1.6.6) lib/absinthe/schema/persistent_term.ex:94: Absinthe.Schema.PersistentTerm.get/1
    (absinthe 1.6.6) lib/absinthe/schema/persistent_term.ex:54: Absinthe.Schema.PersistentTerm.__absinthe_type__/2
    (absinthe 1.6.6) lib/absinthe/phase/schema.ex:107: Absinthe.Phase.Schema.set_schema_node/4
    (absinthe 1.6.6) lib/absinthe/phase/schema.ex:71: anonymous fn/4 in Absinthe.Phase.Schema.set_children/3
    (absinthe 1.6.6) lib/absinthe/blueprint/transform.ex:16: anonymous fn/3 in Absinthe.Blueprint.Transform.prewalk/2
    (absinthe 1.6.6) lib/absinthe/blueprint/transform.ex:109: Absinthe.Blueprint.Transform.walk/4
    (elixir 1.13.0) lib/enum.ex:1715: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```

I was able to get it to generate by wrapping the task
```elixir

defmodule Mix.Tasks.Wrapper do
  use Mix.Task

  def run(argv) do
    children = [{Absinthe.Schema, OurSchema}]
    Supervisor.start_link(children, strategy: :one_for_one, name: Our.Supervisor)
    Mix.Tasks.Absinthe.Schema.Json.run(argv)
  end
end
```

I apologize if there was already a built-in or a better way to do this :)
