### PR TITLE
Convert SDL Language.* structs to SDL notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-- Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148) 
+
+- Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)
+- Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
 
 ## 1.7.0
 

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -453,14 +453,6 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
 
   # Algebra Helpers
 
-  defp multiline(docs, true) do
-    force_unfit(docs)
-  end
-
-  defp multiline(docs, false) do
-    docs
-  end
-
   defp block(kind, name, docs) do
     glue(
       kind,

--- a/lib/absinthe/utils/render.ex
+++ b/lib/absinthe/utils/render.ex
@@ -3,6 +3,14 @@ defmodule Absinthe.Utils.Render do
 
   import Inspect.Algebra
 
+  def multiline(docs, true) do
+    force_unfit(docs)
+  end
+
+  def multiline(docs, false) do
+    docs
+  end
+
   def join(docs, joiner) do
     fold_doc(docs, fn doc, acc ->
       concat([doc, concat(List.wrap(joiner)), acc])

--- a/test/absinthe/language/render_test.exs
+++ b/test/absinthe/language/render_test.exs
@@ -117,6 +117,170 @@ defmodule Absinthe.Language.RenderTest do
     end
   end
 
+  describe "renders sdl" do
+    test "for a type" do
+      assert_rendered("""
+      type Person implements Entity {
+        name: String!
+        baz: Int
+      }
+      """)
+    end
+
+    test "for an interface" do
+      assert_rendered("""
+      interface Entity implements Node {
+        name: String!
+      }
+      """)
+    end
+
+    test "for an input" do
+      assert_rendered("""
+      "Description for Profile"
+      input Profile {
+        "Description for name"
+        name: String!
+      }
+      """)
+    end
+
+    test "for a union with types" do
+      assert_rendered("""
+      union Foo = Bar | Baz
+      """)
+    end
+
+    test "for a union without types" do
+      assert_rendered("""
+      union Foo
+      """)
+    end
+
+    test "for a scalar" do
+      assert_rendered("""
+      scalar MyGreatScalar
+      """)
+    end
+
+    test "for a directive" do
+      assert_rendered("""
+      directive @foo(name: String!) on OBJECT | SCALAR
+      """)
+    end
+
+    test "for a type extension" do
+      assert_rendered("""
+      extend union Direction = North | South
+      """)
+    end
+
+    test "for a schema declaration" do
+      assert_rendered("""
+      schema {
+        query: Query
+      }
+      """)
+    end
+  end
+
+  @sdl """
+  "Schema description"
+  schema {
+    query: Query
+  }
+
+  directive @foo(name: String!) repeatable on OBJECT | SCALAR
+
+  interface Animal {
+    legCount: Int!
+  }
+
+  \"""
+  A submitted post
+  Multiline description
+  \"""
+  type Post {
+    old: String @deprecated(reason: \"""
+      It's old
+      Really old
+    \""")
+
+    sweet: SweetScalar
+
+    "Something"
+    title: String!
+  }
+
+  input ComplexInput {
+    foo: String
+  }
+
+  scalar SweetScalar
+
+  type Query {
+    echo(
+      category: Category!
+
+      "The number of times"
+      times: Int = 10
+    ): [Category!]!
+    posts: Post
+    search(limit: Int, sort: SorterInput!): [SearchResult]
+    defaultBooleanArg(boolean: Boolean = false): String
+    defaultInputArg(input: ComplexInput = { foo: "bar" }): String
+    defaultListArg(things: [String] = ["ThisThing"]): [String]
+    defaultEnumArg(category: Category = NEWS): Category
+    defaultNullStringArg(name: String = null): String
+    animal: Animal
+  }
+
+  type Dog implements Pet & Animal {
+    legCount: Int!
+    name: String!
+  }
+
+  "Simple description"
+  enum Category {
+    "Just the facts"
+    NEWS
+
+    \"""
+    What some rando thinks
+
+    Take with a grain of salt
+    \"""
+    OPINION
+
+    CLASSIFIED
+  }
+
+  interface Pet implements Animal {
+    name: String!
+    legCount: Int!
+  }
+
+  "One or the other"
+  union SearchResult = Post | User
+
+  "Sort this thing"
+  input SorterInput {
+    "By this field"
+    field: String!
+  }
+
+  type User {
+    name: String!
+  }
+
+  extend type User @feature {
+    nickname: String
+  }
+  """
+  test "renders SDL schema" do
+    assert_rendered(@sdl)
+  end
+
   defp assert_rendered(graphql) do
     {:ok, blueprint} = Absinthe.Phase.Parse.run(graphql, [])
     rendered_graphql = inspect(blueprint.input, pretty: true)


### PR DESCRIPTION
Followup to https://github.com/absinthe-graphql/absinthe/pull/1114

Converts the schema definition language structs back to the string representation. 