### PR TITLE
Fix bug in Schema.__absinthe_types__(:all) for Persistent Term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-- Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148) 
+
+- Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)
+- Bug Fix: [Fix bug in Schema.**absinthe_types**(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
 
 ## 1.7.0
 

--- a/lib/absinthe/phase/schema/populate_persistent_term.ex
+++ b/lib/absinthe/phase/schema/populate_persistent_term.ex
@@ -10,7 +10,7 @@ if Code.ensure_loaded?(:persistent_term) do
       type_list =
         for %{identifier: identifier} = type <- schema.type_definitions,
             into: %{},
-            do: {identifier, type.__reference__}
+            do: {identifier, type.name}
 
       types_map =
         schema.type_artifacts

--- a/test/absinthe/type/object_test.exs
+++ b/test/absinthe/type/object_test.exs
@@ -5,6 +5,7 @@ defmodule Absinthe.Type.ObjectTest do
 
   defmodule Schema do
     use Absinthe.Schema
+    use Absinthe.Fixture
 
     query do
       # Must exist


### PR DESCRIPTION
Small bug fix, the `Schema.__absinthe_types__(:all)` list contained references instead of names in the persistent term provider. It did not affect anything afaict but it triggered an error when the `test/absinthe/type/object_test.exs` used the persistent term schema provider. 

