### PR TITLE
Support types with string identifiers

### DIFF
--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -316,7 +316,7 @@ defmodule Absinthe.Type do
 
   @doc "Expand any atom type references inside a List or NonNull"
   @spec expand(reference_t, Schema.t()) :: wrapping_t | t
-  def expand(ref, schema) when is_atom(ref) do
+  def expand(ref, schema) when is_atom(ref) or is_binary(ref) do
     schema.__absinthe_lookup__(ref)
   end
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -236,7 +236,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       resolve: fn _, %{schema: schema, source: source} ->
         result =
           case source.type do
-            type when is_atom(type) ->
+            type when is_atom(type) or is_binary(type) ->
               Absinthe.Schema.lookup_type(schema, source.type)
 
             type ->

--- a/test/absinthe/type_test.exs
+++ b/test/absinthe/type_test.exs
@@ -48,12 +48,51 @@ defmodule Absinthe.TypeTest do
     end
   end
 
+  defmodule RuntimeGeneratedSchema do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    def __absinthe_types__() do
+      Map.merge(BasicSchema.__absinthe_types__(), string_type())
+    end
+
+    def __absinthe_type__(:query) do
+      %Absinthe.Type.Object{
+        description: "Runtime generated schema",
+        fields: Absinthe.Schema.lookup_type(BasicSchema, :query).fields,
+        identifier: :query,
+        interfaces: [],
+        is_type_of: nil,
+        name: "RootQueryType"
+      }
+    end
+    def __absinthe_type__("item_string"), do: string_type()
+    def __absinthe_type__(type), do: BasicSchema.__absinthe_type__(type)
+
+    defp string_type() do
+      %Absinthe.Type.Object{
+        description: "Item Type defined as string",
+        fields: Absinthe.Schema.lookup_type(BasicSchema, :item).fields,
+        identifier: "item_string",
+        interfaces: [],
+        is_type_of: nil,
+        name: "ItemString"
+      }
+    end
+  end
+
   test "definition with custom name" do
     assert %Type.Object{name: "NonFictionBook"} = BasicSchema.__absinthe_type__(:book)
   end
 
   test "that uses a name derived from the identifier" do
     assert %Type.Object{name: "Item"} = BasicSchema.__absinthe_type__(:item)
+  end
+
+  test "definition with string identifier" do
+    assert %Type.Object{name: "ItemString"} = RuntimeGeneratedSchema.__absinthe_type__("item_string")
   end
 
   test "root query type definition" do


### PR DESCRIPTION
There was another PR in the past that tried to answer this (https://github.com/absinthe-graphql/absinthe/pull/483), but it was closed in favor of 1.5. Now that the schema overhaul is done, I would like to propose allowing string type identifiers again. 

When generating a schema at runtime, it is desired that all dynamically generated identifiers be strings instead of atoms to prevent exhausting the `atom` table limit.

This does not change the macros `object` and `input_object` which still require types to be atoms, but when someone overrides the schema to provide runtime type identifiers, it resolves them properly. 

Please let me know if you would like to support string types in the macros as well and I will try to update the PR (as far as I understand, this should be possible, but may not be desirable since they are evaluated at compile time anyway) . 
