### PR TITLE
feat: Subscription priming/ordinals

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -44,9 +44,12 @@ defmodule Absinthe do
           %{message: String.t()}
           | %{message: String.t(), locations: [%{line: pos_integer, column: integer}]}
 
+  @type continuation_t :: nil | [Continuation.t()]
+
   @type result_t ::
-          %{data: nil | result_selection_t}
-          | %{data: nil | result_selection_t, errors: [result_error_t]}
+          %{required(:data) => nil | result_selection_t,
+            optional(:continuation) => continuation_t,
+            optional(:errors) => [result_error_t]}
           | %{errors: [result_error_t]}
 
   @type pipeline_modifier_fun :: (Absinthe.Pipeline.t(), Keyword.t() -> Absinthe.Pipeline.t())
@@ -98,7 +101,7 @@ defmodule Absinthe do
           pipeline_modifier: pipeline_modifier_fun()
         ]
 
-  @type run_result :: {:ok, result_t} | {:error, String.t()}
+  @type run_result :: {:ok, result_t} | {:more, result_t} | {:error, String.t()}
 
   @spec run(
           binary | Absinthe.Language.Source.t() | Absinthe.Language.Document.t(),
@@ -113,7 +116,23 @@ defmodule Absinthe do
       |> Absinthe.Pipeline.for_document(options)
       |> pipeline_modifier.(options)
 
-    case Absinthe.Pipeline.run(document, pipeline) do
+    document
+    |> Absinthe.Pipeline.run(pipeline)
+    |> build_result()
+  end
+
+  @spec continue([Continuation.t()]) :: run_result()
+  def continue(continuation) do
+    continuation
+    |> Absinthe.Pipeline.continue()
+    |> build_result()
+  end
+
+  defp build_result(output) do
+    case output do
+      {:ok, %{result: %{continuation: c} = result}, _phases} when c != [] ->
+        {:more, result}
+
       {:ok, %{result: result}, _phases} ->
         {:ok, result}
 
@@ -137,6 +156,7 @@ defmodule Absinthe do
   def run!(input, schema, options \\ []) do
     case run(input, schema, options) do
       {:ok, result} -> result
+      {:more, result} -> result
       {:error, err} -> raise ExecutionError, message: err
     end
   end

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -55,7 +55,7 @@ defmodule Absinthe do
             required(:data) => nil | result_selection_t,
             optional(:ordinal_fun) => ordinal_fun(),
             optional(:ordinal_compare_fun) => ordinal_compare_fun(),
-            optional(:continuation) => continuations_t,
+            optional(:continuations) => continuations_t,
             optional(:errors) => [result_error_t]
           }
           | %{errors: [result_error_t]}

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -105,6 +105,7 @@ defmodule Absinthe do
         ]
 
   @type run_result :: {:ok, result_t} | {:more, result_t} | {:error, String.t()}
+  @type continue_result :: run_result | :no_more_results
 
   @spec run(
           binary | Absinthe.Language.Source.t() | Absinthe.Language.Document.t(),
@@ -124,7 +125,7 @@ defmodule Absinthe do
     |> build_result()
   end
 
-  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: run_result()
+  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: continue_result
   def continue(continuation) do
     continuation
     |> Absinthe.Pipeline.continue()
@@ -133,6 +134,9 @@ defmodule Absinthe do
 
   defp build_result(output) do
     case output do
+      {:ok, %{result: :no_more_results}, _phases} ->
+        :no_more_results
+
       {:ok, %{result: %{continuation: c} = result}, _phases} when c != [] ->
         {:more, result}
 

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -44,12 +44,15 @@ defmodule Absinthe do
           %{message: String.t()}
           | %{message: String.t(), locations: [%{line: pos_integer, column: integer}]}
 
-  @type continuation_t :: nil | [Continuation.t()]
+  @type continuation_t :: nil | [Absinthe.Blueprint.Continuation.t()]
 
   @type result_t ::
-          %{required(:data) => nil | result_selection_t,
+          %{
+            required(:data) => nil | result_selection_t,
+            optional(:ordinal) => term(),
             optional(:continuation) => continuation_t,
-            optional(:errors) => [result_error_t]}
+            optional(:errors) => [result_error_t]
+          }
           | %{errors: [result_error_t]}
 
   @type pipeline_modifier_fun :: (Absinthe.Pipeline.t(), Keyword.t() -> Absinthe.Pipeline.t())
@@ -121,7 +124,7 @@ defmodule Absinthe do
     |> build_result()
   end
 
-  @spec continue([Continuation.t()]) :: run_result()
+  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: run_result()
   def continue(continuation) do
     continuation
     |> Absinthe.Pipeline.continue()

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -46,10 +46,15 @@ defmodule Absinthe do
 
   @type continuations_t :: nil | [Absinthe.Blueprint.Continuation.t()]
 
+  @type ordinal_fun :: (term() -> term())
+
+  @type ordinal_compare_fun :: (term(), term() -> {boolean(), term()})
+
   @type result_t ::
           %{
             required(:data) => nil | result_selection_t,
-            optional(:ordinal) => term(),
+            optional(:ordinal_fun) => ordinal_fun(),
+            optional(:ordinal_compare_fun) => ordinal_compare_fun(),
             optional(:continuation) => continuations_t,
             optional(:errors) => [result_error_t]
           }

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -44,13 +44,13 @@ defmodule Absinthe do
           %{message: String.t()}
           | %{message: String.t(), locations: [%{line: pos_integer, column: integer}]}
 
-  @type continuation_t :: nil | [Absinthe.Blueprint.Continuation.t()]
+  @type continuations_t :: nil | [Absinthe.Blueprint.Continuation.t()]
 
   @type result_t ::
           %{
             required(:data) => nil | result_selection_t,
             optional(:ordinal) => term(),
-            optional(:continuation) => continuation_t,
+            optional(:continuation) => continuations_t,
             optional(:errors) => [result_error_t]
           }
           | %{errors: [result_error_t]}
@@ -126,8 +126,8 @@ defmodule Absinthe do
   end
 
   @spec continue([Absinthe.Blueprint.Continuation.t()]) :: continue_result
-  def continue(continuation) do
-    continuation
+  def continue(continuations) do
+    continuations
     |> Absinthe.Pipeline.continue()
     |> build_result()
   end
@@ -137,7 +137,7 @@ defmodule Absinthe do
       {:ok, %{result: :no_more_results}, _phases} ->
         :no_more_results
 
-      {:ok, %{result: %{continuation: c} = result}, _phases} when c != [] ->
+      {:ok, %{result: %{continuations: c} = result}, _phases} when c != [] ->
         {:more, result}
 
       {:ok, %{result: result}, _phases} ->

--- a/lib/absinthe/blueprint/continuation.ex
+++ b/lib/absinthe/blueprint/continuation.ex
@@ -1,0 +1,19 @@
+defmodule Absinthe.Blueprint.Continuation do
+  @moduledoc false
+
+  # Continuations allow further resolutions after the initial result is
+  # returned
+
+  alias Absinthe.Pipeline
+
+  defstruct [
+    :phase_input,
+    :pipeline
+  ]
+
+  @type t :: %__MODULE__{
+    phase_input: Pipeline.data_t,
+    pipeline: Pipeline.t()
+  }
+
+end

--- a/lib/absinthe/blueprint/continuation.ex
+++ b/lib/absinthe/blueprint/continuation.ex
@@ -12,8 +12,7 @@ defmodule Absinthe.Blueprint.Continuation do
   ]
 
   @type t :: %__MODULE__{
-    phase_input: Pipeline.data_t,
-    pipeline: Pipeline.t()
-  }
-
+          phase_input: Pipeline.data_t(),
+          pipeline: Pipeline.t()
+        }
 end

--- a/lib/absinthe/blueprint/result/list.ex
+++ b/lib/absinthe/blueprint/result/list.ex
@@ -19,6 +19,6 @@ defmodule Absinthe.Blueprint.Result.List do
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
           extensions: %{any => any},
-          continuations: [Continuation.t()]
+          continuations: [Blueprint.Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/list.ex
+++ b/lib/absinthe/blueprint/result/list.ex
@@ -9,7 +9,8 @@ defmodule Absinthe.Blueprint.Result.List do
     :values,
     errors: [],
     flags: %{},
-    extensions: %{}
+    extensions: %{},
+    continuations: []
   ]
 
   @type t :: %__MODULE__{
@@ -17,6 +18,7 @@ defmodule Absinthe.Blueprint.Result.List do
           values: [Blueprint.Execution.node_t()],
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
-          extensions: %{any => any}
+          extensions: %{any => any},
+          continuations: [Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/object.ex
+++ b/lib/absinthe/blueprint/result/object.ex
@@ -10,7 +10,8 @@ defmodule Absinthe.Blueprint.Result.Object do
     :fields,
     errors: [],
     flags: %{},
-    extensions: %{}
+    extensions: %{},
+    continuations: []
   ]
 
   @type t :: %__MODULE__{
@@ -18,6 +19,7 @@ defmodule Absinthe.Blueprint.Result.Object do
           fields: [Blueprint.Execution.node_t()],
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
-          extensions: %{any => any}
+          extensions: %{any => any},
+          continuations: [Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/object.ex
+++ b/lib/absinthe/blueprint/result/object.ex
@@ -20,6 +20,6 @@ defmodule Absinthe.Blueprint.Result.Object do
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
           extensions: %{any => any},
-          continuations: [Continuation.t()]
+          continuations: [Blueprint.Continuation.t()]
         }
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -160,7 +160,7 @@ defmodule Absinthe.Phase.Document.Result do
   defp format_location(_), do: []
 
   defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
-    do: Map.put(result, :continuation, continuations)
+    do: Map.put(result, :continuations, continuations)
 
   defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -25,7 +25,9 @@ defmodule Absinthe.Phase.Document.Result do
           {:validation_failed, errors}
       end
 
-    format_result(result, opts)
+    result
+    |> format_result(opts)
+    |> maybe_add_continuations(blueprint.execution.result)
   end
 
   defp format_result({:ok, {data, []}}, _) do
@@ -156,4 +158,9 @@ defmodule Absinthe.Phase.Document.Result do
   end
 
   defp format_location(_), do: []
+
+  defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
+  do: Map.put(result, :continuation, continuations)
+
+  defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -160,7 +160,7 @@ defmodule Absinthe.Phase.Document.Result do
   defp format_location(_), do: []
 
   defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
-  do: Map.put(result, :continuation, continuations)
+    do: Map.put(result, :continuation, continuations)
 
   defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/subscription/get_ordinal.ex
+++ b/lib/absinthe/phase/subscription/get_ordinal.ex
@@ -11,14 +11,31 @@ defmodule Absinthe.Phase.Subscription.GetOrdinal do
   def run(blueprint, _options \\ []) do
     with %{type: :subscription, selections: [field]} <- Blueprint.current_operation(blueprint),
          {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint),
-         ordinal_fun when is_function(ordinal_fun, 1) <- config[:ordinal] do
-      result = ordinal_fun.(blueprint.execution.root_value)
-      {:ok, %{blueprint | result: Map.put(blueprint.result, :ordinal, result)}}
+         {_, ordinal_fun} when is_function(ordinal_fun, 1) <- {:ordinal_fun, config[:ordinal]},
+         {_, ordinal_compare_fun} when is_function(ordinal_compare_fun, 2) <-
+           {:ordinal_compare_fun,
+            Keyword.get(config, :ordinal_compare, &default_ordinal_compare/2)} do
+      ordinal = ordinal_fun.(blueprint.execution.root_value)
+
+      result =
+        blueprint.result
+        |> Map.put(:ordinal, ordinal)
+        |> Map.put(:ordinal_compare_fun, ordinal_compare_fun)
+
+      {:ok, %{blueprint | result: result}}
     else
-      f when is_function(f) ->
+      {:ordinal_fun, f} when is_function(f) ->
         IO.write(
           :stderr,
           "Ordinal function must be 1-arity"
+        )
+
+        {:ok, blueprint}
+
+      {:ordinal_compare_fun, f} when is_function(f) ->
+        IO.write(
+          :stderr,
+          "Ordinal compare function must be 2-arity"
         )
 
         {:ok, blueprint}
@@ -27,4 +44,11 @@ defmodule Absinthe.Phase.Subscription.GetOrdinal do
         {:ok, blueprint}
     end
   end
+
+  defp default_ordinal_compare(nil, new_ordinal), do: {true, new_ordinal}
+
+  defp default_ordinal_compare(old_ordinal, new_ordinal) when old_ordinal < new_ordinal,
+    do: {true, new_ordinal}
+
+  defp default_ordinal_compare(old_ordinal, _new_ordinal), do: {false, old_ordinal}
 end

--- a/lib/absinthe/phase/subscription/get_ordinal.ex
+++ b/lib/absinthe/phase/subscription/get_ordinal.ex
@@ -1,0 +1,42 @@
+defmodule Absinthe.Phase.Subscription.GetOrdinal do
+  use Absinthe.Phase
+
+  alias Absinthe.Phase.Subscription.SubscribeSelf
+
+  @moduledoc false
+
+  alias Absinthe.Blueprint
+
+  @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(blueprint, _options \\ []) do
+    op = Blueprint.current_operation(blueprint)
+
+    if op.type == :subscription do
+      {:ok,
+       %{blueprint | result: Map.put(blueprint.result, :ordinal, get_ordinal(op, blueprint))}}
+    else
+      {:ok, blueprint}
+    end
+  end
+
+  defp get_ordinal(op, blueprint) do
+    %{selections: [field]} = op
+    {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint)
+
+    case config[:ordinal] do
+      nil ->
+        nil
+
+      fun when is_function(fun, 1) ->
+        fun.(blueprint.execution.root_value)
+
+      _fun ->
+        IO.write(
+          :stderr,
+          "Ordinal function must be 1-arity"
+        )
+
+        nil
+    end
+  end
+end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,8 +1,46 @@
 defmodule Absinthe.Phase.Subscription.Prime do
   @moduledoc false
 
+  alias Absinthe.Blueprint.Continuation
+  alias Absinthe.Phase
+
   @spec run(any(), Keyword.t()) :: Absinthe.Phase.result_t()
-  def run(blueprint, prime_result: cr) do
-    {:ok, put_in(blueprint.execution.root_value, cr)}
+  def run(blueprint, prime_result: prime_result) do
+    {:ok, put_in(blueprint.execution.root_value, prime_result)}
+  end
+
+  def run(blueprint, prime_fun: prime_fun, resolution_options: options) do
+    {:ok, prime_results} = prime_fun.(blueprint.execution)
+
+    case prime_results do
+      [first | rest] ->
+        blueprint = put_in(blueprint.execution.root_value, first)
+        blueprint = maybe_add_continuations(blueprint, rest, options)
+        {:ok, blueprint}
+
+      [] ->
+        blueprint = put_in(blueprint.result, :no_more_results)
+        {:replace, blueprint, []}
+    end
+  end
+
+  defp maybe_add_continuations(blueprint, [], _options), do: blueprint
+
+  defp maybe_add_continuations(blueprint, remaining_results, options) do
+    continuations =
+      Enum.map(
+        remaining_results,
+        &%Continuation{
+          phase_input: blueprint,
+          pipeline: [
+            {__MODULE__, [prime_result: &1]},
+            {Phase.Document.Execution.Resolution, options},
+            Phase.Subscription.GetOrdinal,
+            Phase.Document.Result
+          ]
+        }
+      )
+
+    put_in(blueprint.result, %{continuation: continuations})
   end
 end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,0 +1,8 @@
+defmodule Absinthe.Phase.Subscription.Prime do
+  @moduledoc false
+
+  @spec run(any(), Keyword.t()) :: Phase.result_t()
+  def run(blueprint, [prime_result: cr]) do
+    {:ok, put_in(blueprint.execution.root_value, cr)}
+  end
+end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -41,6 +41,6 @@ defmodule Absinthe.Phase.Subscription.Prime do
         }
       )
 
-    put_in(blueprint.result, %{continuation: continuations})
+    put_in(blueprint.result, %{continuations: continuations})
   end
 end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,8 +1,8 @@
 defmodule Absinthe.Phase.Subscription.Prime do
   @moduledoc false
 
-  @spec run(any(), Keyword.t()) :: Phase.result_t()
-  def run(blueprint, [prime_result: cr]) do
+  @spec run(any(), Keyword.t()) :: Absinthe.Phase.result_t()
+  def run(blueprint, prime_result: cr) do
     {:ok, put_in(blueprint.execution.root_value, cr)}
   end
 end

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -5,10 +5,47 @@ defmodule Absinthe.Phase.Subscription.Result do
   # subscription
 
   alias Absinthe.Blueprint
+  alias Absinthe.Blueprint.Continuation
 
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
-  def run(blueprint, topic: topic) do
+  def run(blueprint, options) do
+    topic = Keyword.get(options, :topic)
+    prime = Keyword.get(options, :prime)
     result = %{"subscribed" => topic}
-    {:ok, put_in(blueprint.result, result)}
+    case prime do
+      nil ->
+        {:ok, put_in(blueprint.result, result)}
+
+      prime_fun when is_function(prime_fun, 0) ->
+        {:ok, prime_results} = prime_fun.()
+
+        result =
+          if prime_results != [] do
+            continuations =
+              Enum.map(prime_results, fn cr ->
+                %Continuation{
+                  phase_input: blueprint,
+                  pipeline: [
+                    {Absinthe.Phase.Subscription.Prime, [prime_result: cr]},
+                    {Absinthe.Phase.Document.Execution.Resolution, options},
+                    Absinthe.Phase.Document.Result
+                  ]
+                }
+              end)
+
+            Map.put(result, :continuation, continuations)
+          else
+            result
+          end
+
+        {:ok, put_in(blueprint.result, result)}
+
+      val ->
+        raise """
+        Invalid prime function. Must be a function of arity 0.
+
+        #{inspect(val)}
+        """
+    end
   end
 end

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -41,7 +41,7 @@ defmodule Absinthe.Phase.Subscription.Result do
       ]
     }
 
-    result = Map.put(base_result, :continuation, [continuation])
+    result = Map.put(base_result, :continuations, [continuation])
 
     {:ok, put_in(blueprint.result, result)}
   end

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -6,46 +6,53 @@ defmodule Absinthe.Phase.Subscription.Result do
 
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Continuation
+  alias Absinthe.Phase
 
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
   def run(blueprint, options) do
-    topic = Keyword.get(options, :topic)
+    topic = Keyword.fetch!(options, :topic)
     prime = Keyword.get(options, :prime)
     result = %{"subscribed" => topic}
+
     case prime do
       nil ->
         {:ok, put_in(blueprint.result, result)}
 
-      prime_fun when is_function(prime_fun, 0) ->
-        {:ok, prime_results} = prime_fun.()
-
-        result =
-          if prime_results != [] do
-            continuations =
-              Enum.map(prime_results, fn cr ->
-                %Continuation{
-                  phase_input: blueprint,
-                  pipeline: [
-                    {Absinthe.Phase.Subscription.Prime, [prime_result: cr]},
-                    {Absinthe.Phase.Document.Execution.Resolution, options},
-                    Absinthe.Phase.Document.Result
-                  ]
-                }
-              end)
-
-            Map.put(result, :continuation, continuations)
-          else
-            result
-          end
-
-        {:ok, put_in(blueprint.result, result)}
+      prime_fun when is_function(prime_fun, 1) ->
+        do_prime(prime_fun, result, blueprint, options)
 
       val ->
         raise """
-        Invalid prime function. Must be a function of arity 0.
+        Invalid prime function. Must be a function of arity 1.
 
         #{inspect(val)}
         """
     end
+  end
+
+  def do_prime(prime_fun, base_result, blueprint, options) do
+    {:ok, prime_results} = prime_fun.(blueprint.execution)
+
+    result =
+      if prime_results != [] do
+        continuations =
+          Enum.map(prime_results, fn cr ->
+            %Continuation{
+              phase_input: blueprint,
+              pipeline: [
+                {Phase.Subscription.Prime, [prime_result: cr]},
+                {Phase.Document.Execution.Resolution, options},
+                Phase.Subscription.GetOrdinal,
+                Phase.Document.Result
+              ]
+            }
+          end)
+
+        Map.put(base_result, :continuation, continuations)
+      else
+        base_result
+      end
+
+    {:ok, put_in(blueprint.result, result)}
   end
 end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -19,6 +19,8 @@ defmodule Absinthe.Pipeline do
 
   @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t() | {:http_method, String.t()}, [Phase.t()]}
 
+  @type continue_result_t :: run_result_t | :no_more_results
+
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 
   @type t :: [phase_config_t | [phase_config_t]]
@@ -30,7 +32,7 @@ defmodule Absinthe.Pipeline do
     |> run_phase(input)
   end
 
-  @spec continue([Continuation.t()]) :: run_result_t
+  @spec continue([Continuation.t()]) :: continue_result_t
   def continue([continuation | rest]) do
     result = run_phase(continuation.pipeline, continuation.phase_input)
 
@@ -41,7 +43,7 @@ defmodule Absinthe.Pipeline do
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
-        {:ok, blueprint, phases}
+        {:more, blueprint, phases}
 
       error ->
         error

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -37,11 +37,14 @@ defmodule Absinthe.Pipeline do
     case result do
       {:ok, blueprint, phases} when rest == [] ->
         {:ok, blueprint, phases}
+
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
         {:ok, blueprint, phases}
-      error -> error
+
+      error ->
+        error
     end
   end
 
@@ -132,6 +135,7 @@ defmodule Absinthe.Pipeline do
       # Execution
       {Phase.Subscription.SubscribeSelf, options},
       {Phase.Document.Execution.Resolution, options},
+      Phase.Subscription.GetOrdinal,
       # Format Result
       Phase.Document.Result,
       {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -39,7 +39,7 @@ defmodule Absinthe.Pipeline do
         {:ok, blueprint, phases}
 
       {:ok, blueprint, phases} ->
-        bp_result = Map.put(blueprint.result, :continuation, rest)
+        bp_result = Map.put(blueprint.result, :continuations, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
         {:ok, blueprint, phases}
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -17,7 +17,9 @@ defmodule Absinthe.Pipeline do
 
   @type data_t :: any
 
-  @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t() | {:http_method, String.t()}, [Phase.t()]}
+  @type run_result_t ::
+          {:ok, data_t, [Phase.t()]}
+          | {:error, String.t() | {:http_method, String.t()}, [Phase.t()]}
 
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -19,8 +19,6 @@ defmodule Absinthe.Pipeline do
 
   @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t() | {:http_method, String.t()}, [Phase.t()]}
 
-  @type continue_result_t :: run_result_t | :no_more_results
-
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 
   @type t :: [phase_config_t | [phase_config_t]]
@@ -32,7 +30,7 @@ defmodule Absinthe.Pipeline do
     |> run_phase(input)
   end
 
-  @spec continue([Continuation.t()]) :: continue_result_t
+  @spec continue([Continuation.t()]) :: run_result_t
   def continue([continuation | rest]) do
     result = run_phase(continuation.pipeline, continuation.phase_input)
 
@@ -43,7 +41,7 @@ defmodule Absinthe.Pipeline do
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
-        {:more, blueprint, phases}
+        {:ok, blueprint, phases}
 
       error ->
         error

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -82,7 +82,7 @@ defmodule Absinthe.Subscription do
 
   @type subscription_field_spec :: {atom, term | (term -> term)}
 
-  @type prime_fun :: (-> {:ok, [map()]})
+  @type prime_fun :: (Absinthe.Resolution.t() -> {:ok, [map()]})
 
   @doc """
   Publish a mutation

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -82,6 +82,8 @@ defmodule Absinthe.Subscription do
 
   @type subscription_field_spec :: {atom, term | (term -> term)}
 
+  @type prime_fun :: (-> {:ok, [map()]})
+
   @doc """
   Publish a mutation
 

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -69,7 +69,10 @@ defmodule Absinthe.Subscription.Local do
       |> Pipeline.without(Phase.Subscription.SubscribeSelf)
       |> Pipeline.insert_before(
         Phase.Document.Execution.Resolution,
-        {Phase.Document.OverrideRoot, root_value: mutation_result}
+        [
+          {Phase.Document.OverrideRoot, root_value: mutation_result},
+          Phase.Subscription.GetOrdinal
+        ]
       )
       |> Pipeline.upto(Phase.Document.Execution.Resolution)
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -955,7 +955,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
     client_id = "abc"
     prime_data = ["name1", "name2"]
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -969,17 +969,17 @@ defmodule Absinthe.Execution.SubscriptionTest do
     assert {:more,
             %{
               data: %{"prime" => %{"id" => "test_prime_id", "name" => "name1"}},
-              continuation: continuation
-            }} = Absinthe.continue(continuation)
+              continuations: continuations
+            }} = Absinthe.continue(continuations)
 
     assert {:ok, %{data: %{"prime" => %{"id" => "test_prime_id", "name" => "name2"}}}} =
-             Absinthe.continue(continuation)
+             Absinthe.continue(continuations)
   end
 
   test "continuation with no extra data" do
     client_id = "abc"
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -990,7 +990,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
                context: %{prime_id: "test_prime_id"}
              )
 
-    assert :no_more_results == Absinthe.continue(continuation)
+    assert :no_more_results == Absinthe.continue(continuations)
   end
 
   @query """
@@ -1033,7 +1033,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
   test "subscription with both priming and ordinals" do
     client_id = "abc"
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -1046,11 +1046,11 @@ defmodule Absinthe.Execution.SubscriptionTest do
             %{
               data: %{"primeOrdinal" => %{"name" => "first_user"}},
               ordinal: 1,
-              continuation: continuation
-            }} = Absinthe.continue(continuation)
+              continuations: continuations
+            }} = Absinthe.continue(continuations)
 
     assert {:ok, %{data: %{"primeOrdinal" => %{"name" => "second_user"}}, ordinal: 2}} =
-             Absinthe.continue(continuation)
+             Absinthe.continue(continuations)
   end
 
   def run_subscription(query, schema, opts \\ []) do

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -341,7 +341,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
   end
@@ -418,7 +418,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     msg = %{
       event: "subscription:data",
-      result: %{data: %{"multipleTopics" => "foo"}, ordinal: nil},
+      result: %{data: %{"multipleTopics" => "foo"}},
       topic: topic
     }
 
@@ -520,7 +520,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}, ordinal: nil},
+             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}},
              topic: topic
            } == msg
   end
@@ -593,7 +593,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
   end
@@ -612,7 +612,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
         assert %{
                  event: "subscription:data",
-                 result: %{data: %{"thing" => "foo"}, ordinal: nil},
+                 result: %{data: %{"thing" => "foo"}},
                  topic: topic
                } == msg
       end)
@@ -855,7 +855,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -976,6 +976,23 @@ defmodule Absinthe.Execution.SubscriptionTest do
              Absinthe.continue(continuation)
   end
 
+  test "continuation with no extra data" do
+    client_id = "abc"
+
+    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{
+                 "primeData" => [],
+                 "clientId" => client_id
+               },
+               context: %{prime_id: "test_prime_id"}
+             )
+
+    assert :no_more_results == Absinthe.continue(continuation)
+  end
+
   @query """
   subscription ($clientId: ID!) {
     ordinal(clientId: $clientId) {


### PR DESCRIPTION
This is the `absinthe` part of my attempt to address the issue discussed over in https://elixirforum.com/t/subscription-catchup-state-delta/47459. There will be a corresponding `absinthe_phoenix` PR shortly.

I still need to add documentation, so consider this a WIP, but I'd appreciate feedback on whether this is going to be an acceptable way forward before I spend time writing it :)

There are 3 main elements on which the solution is built:

### Continuations

This is a trimmed down version of the continuation system I wrote to implement the `@defer` directive in #559. I used this generalised system because it seems like it could be a useful addition for other features in the future (`@defer` being the obvious example) and I didn't want to just write code that was specific to subscription priming. Plus @benwilson512 mentioned at the time that he liked the idea :)

### Subscription priming

This is a rework/renaming of the subscription-catchup system I wrote a while back. Subscription configurations are given an optional `prime` parameter which is a function called when a user first subscribes. The result of that function is sent only to the subscribing user, allowing them to "catch up" to where the subscription state is for all other subscribers.

### Subscription ordinals

(Feel free to come up with a better name - "ordinals" was the best I could think of).
This feature addresses the issue of the asynchronous handling of subscription updates which have a strict semantic ordering, such as state updates. This is the specific issue that is explained in the Elixir Forum post above. Subscription configs can now be given an `ordinal` function which is passed the `root_value` of the subscription update and returns a term which will be used for ordering of updates. The actual functional bit of this (dropping out-of-date updates) is performed over in the corresponding `absinthe_phoenix` changes (which I'll reference here as soon as I've opened that PR). The key functionality here, though, is to have the user able to specify a way to determine ordering on updates. This could be a timestamp, simple integer or any other value that will be `<` when compared between older and newer updates. (I did consider allowing a customisable comparator function too but that seemed like overkill to me - happy to do so though).


For all these changes I've tried to leave everything backwards compatible, so not specifying a `prime` or `ordinal` function will behave exactly as it does now.