### PR TITLE
Add telemetry events to async middleware

### DIFF
--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -50,8 +50,14 @@ defmodule Absinthe.Middleware.Async do
   # This function inserts additional middleware into the remaining middleware
   # stack for this field. On the next resolution pass, we need to `Task.await` the
   # task so we have actual data. Thus, we prepend this module to the middleware stack.
-  def call(%{state: :unresolved} = res, {fun, opts}) when is_function(fun),
-    do: call(res, {Task.async(fun), opts})
+  def call(%{state: :unresolved} = res, {fun, opts}) when is_function(fun) do
+    task =
+      Task.async(fn ->
+        :telemetry.span([:absinthe, :middleware, :async, :task], %{}, fn -> {fun.(), %{}} end)
+      end)
+
+    call(res, {task, opts})
+  end
 
   def call(%{state: :unresolved} = res, {task, opts}) do
     task_data = {task, opts}


### PR DESCRIPTION
Introduce telemetry events to Async middleware to instrument new `Task.async/1` created inside the middleware.

The use-case for this event comes from OpenTelemetry and trace propagation. For OTel, we need to run instrumentation from inside the newly created Task to be able to connect spans. With this event in place, we can track those Tasks without introducing custom wrappers on user code.

This patch adds events only in the case of the middleware creating the task. For tasks created by user code, there is nothing the library can do, unfortunately.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
