### PR TITLE
Add end_time_mono to telemetry :stop events

### DIFF
--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -149,8 +149,9 @@ defmodule Absinthe.Middleware.Batch do
       timeout = Keyword.get(batch_opts, :timeout, 5_000)
       result = Task.await(task, timeout)
 
-      duration = System.monotonic_time() - start_time_mono
-      emit_stop_event(duration, metadata, result)
+      end_time_mono = System.monotonic_time()
+      duration = end_time_mono - start_time_mono
+      emit_stop_event(duration, end_time_mono, metadata, result)
 
       result
     end)
@@ -178,10 +179,10 @@ defmodule Absinthe.Middleware.Batch do
     metadata
   end
 
-  defp emit_stop_event(duration, metadata, result) do
+  defp emit_stop_event(duration, end_time_mono, metadata, result) do
     :telemetry.execute(
       @batch_stop,
-      %{duration: duration},
+      %{duration: duration, end_time_mono: end_time_mono},
       Map.put(metadata, :result, result)
     )
   end

--- a/lib/absinthe/middleware/telemetry.ex
+++ b/lib/absinthe/middleware/telemetry.ex
@@ -46,7 +46,7 @@ defmodule Absinthe.Middleware.Telemetry do
 
     :telemetry.execute(
       @field_stop,
-      %{duration: end_time_mono - start_time_mono},
+      %{duration: end_time_mono - start_time_mono, end_time_mono: end_time_mono},
       %{
         id: id,
         telemetry_span_context: id,

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -58,7 +58,7 @@ defmodule Absinthe.Phase.Telemetry do
     with %{id: id, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(
         @subscription_stop,
-        %{duration: end_time_mono - start_time_mono},
+        %{duration: end_time_mono - start_time_mono, end_time_mono: end_time_mono},
         %{id: id, telemetry_span_context: id, blueprint: blueprint, options: options}
       )
     end
@@ -72,7 +72,7 @@ defmodule Absinthe.Phase.Telemetry do
     with %{id: id, start_time_mono: start_time_mono} <- blueprint.telemetry do
       :telemetry.execute(
         @operation_stop,
-        %{duration: end_time_mono - start_time_mono},
+        %{duration: end_time_mono - start_time_mono, end_time_mono: end_time_mono},
         %{id: id, telemetry_span_context: id, blueprint: blueprint, options: options}
       )
     end


### PR DESCRIPTION
The Spandex library needs a 'completion_time' and it's not possible to get the start time at the beginning of the span to calculate it based on the duration

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
