### PR TITLE
fix: multiple pushes per client for subscriptions that have a context_id

### DIFF
--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -26,6 +26,9 @@ defmodule Absinthe.Subscription.Local do
           {topic, doc} <- get_docs(pubsub, field, mutation_result, key_strategy) do
         {topic, key_strategy, doc}
       end
+      |> Enum.dedup_by(fn {topic, key_strategy, _} ->
+        "#{topic}_#{:erlang.phash2(key_strategy)}"
+      end)
 
     run_docset(pubsub, docs_and_topics, mutation_result)
 


### PR DESCRIPTION
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->

Dedups the Registry entries if they all have same topics and keys.

Fixes https://github.com/absinthe-graphql/absinthe/issues/1064

Note - This is not the best solution.

Explained the bug here https://github.com/absinthe-graphql/absinthe/issues/1064#issuecomment-1166711616