### PR TITLE
Validate repeatable directives on schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)
 - Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
 - Feature: [Add support for type extensions](https://github.com/absinthe-graphql/absinthe/pull/1157)
 - Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -170,6 +170,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.FieldImports,
       Phase.Schema.Validation.KnownDirectives,
       Phase.Document.Validation.KnownArgumentNames,
+      Phase.Document.Validation.RepeatableDirectives,
       {Phase.Schema.Arguments.Parse, options},
       Phase.Schema.Arguments.Data,
       Phase.Schema.Directives,

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -330,7 +330,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
-  defmacro deprecate(msg) do
+  defmacro deprecate(msg \\ nil) do
     __CALLER__
     |> recordable!(:deprecate, @placement[:deprecate])
     |> record_deprecate!(msg)

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1769,6 +1769,7 @@ defmodule Absinthe.Schema.Notation do
       |> build_directive_arguments(env)
       |> Keyword.put(:name, name)
       |> put_reference(env)
+      |> Keyword.put(:source_location, Absinthe.Blueprint.SourceLocation.at(env.line, 0))
 
     directive = struct!(Absinthe.Blueprint.Directive, attrs)
     put_attr(env.module, {:directive, directive})

--- a/lib/absinthe/schema/prototype/notation.ex
+++ b/lib/absinthe/schema/prototype/notation.ex
@@ -14,6 +14,8 @@ defmodule Absinthe.Schema.Prototype.Notation do
       directive :deprecated do
         arg :reason, :string
 
+        repeatable false
+
         on [
           :field_definition,
           :input_field_definition,

--- a/test/absinthe/schema/rule/repeatable_directives_test.exs
+++ b/test/absinthe/schema/rule/repeatable_directives_test.exs
@@ -1,0 +1,101 @@
+defmodule Absinthe.Schema.Rule.RepeatedDirectivesTest do
+  use Absinthe.Case, async: true
+  import ExperimentalNotationHelpers
+
+  @invalid_repeated_directives_macro ~s"""
+  defmodule InvalidRepeatedDirectiveMacro do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    object :dog do
+      field :name, :string do
+        deprecate()
+        deprecate()
+      end
+    end
+  end
+  """
+
+  test "errors on invalid repeated directive on macro schemas" do
+    error = ~r/Directive `deprecated' cannot be applied repeatedly./
+
+    assert_raise(Absinthe.Schema.Error, error, fn ->
+      Code.eval_string(@invalid_repeated_directives_macro)
+    end)
+  end
+
+  @invalid_repeated_directives_sdl ~s(
+  defmodule InvalidRepeatedDirectiveSdl do
+    use Absinthe.Schema
+
+    query do
+    end
+
+    import_sdl ~s"""
+      type Dog {
+        name: String @deprecated @deprecated
+      }
+    """
+  end
+  )
+
+  test "errors on invalid repeated directive on sdl schemas" do
+    error = ~r/Directive `deprecated' cannot be applied repeatedly./
+
+    assert_raise(Absinthe.Schema.Error, error, fn ->
+      Code.eval_string(@invalid_repeated_directives_sdl)
+    end)
+  end
+
+  defmodule WithFeatureDirective do
+    use Absinthe.Schema.Prototype
+
+    directive :feature do
+      on [:field_definition]
+      repeatable true
+    end
+  end
+
+  defmodule ValidRepeatedDirectiveMacro do
+    use Absinthe.Schema
+
+    @prototype_schema WithFeatureDirective
+
+    query do
+    end
+
+    object :dog do
+      field :name, :string do
+        directive :feature
+        directive :feature
+      end
+    end
+  end
+
+  test "does not raise with repeated directive on macro schemas" do
+    assert %{directives: [%{name: "feature"}, %{name: "feature"}]} =
+             lookup_field(ValidRepeatedDirectiveMacro, :dog, :name)
+  end
+
+  defmodule ValidRepeatedDirectiveSdl do
+    use Absinthe.Schema
+
+    @prototype_schema WithFeatureDirective
+
+    query do
+    end
+
+    import_sdl ~s"""
+      type Dog {
+        name: String @feature @feature
+      }
+    """
+  end
+
+  test "does not raise with repeated directive on sdl schemas" do
+    assert %{directives: [%{name: "feature"}, %{name: "feature"}]} =
+             lookup_field(ValidRepeatedDirectiveSdl, :dog, :name)
+  end
+end


### PR DESCRIPTION
This PR adds validations to check whether a directive can be applied multiple times on a node. This was already done in the document pipeline, but not in the schema pipeline.

Also includes a small fix for the `deprecate` macro requiring a deprecation reason. In the graphql spec the reason is not required, so we can also allow `nil` here.

Fixes https://github.com/absinthe-graphql/absinthe/issues/1177