### PR TITLE
Raise informative error on batched resolver timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bug Fix: [Deduplicate directives when building schema](https://github.com/absinthe-graphql/absinthe/pull/1242)
 
 ## 1.7.1
+
 - Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)
 - Breaking Bugfix: [Add "Objects must define fields" schema validation](https://github.com/absinthe-graphql/absinthe/pull/1167)
 - Bug Fix: [Validate field identifier uniqueness](https://github.com/absinthe-graphql/absinthe/pull/1200)
@@ -46,6 +47,7 @@
 - Bug Fix: [Prevent DDOS attacks with long queries](https://github.com/absinthe-graphql/absinthe/pull/1220)
 - Feature: [pipeline_modifier option to Absinthe.run/3](https://github.com/absinthe-graphql/absinthe/pull/1221)
 - Bug Fix: [Add end_time_mono to telemetry :stop events](https://github.com/absinthe-graphql/absinthe/pull/1174)
+- BugFix: [Improved error when batches fail timeouts](https://github.com/absinthe-graphql/absinthe/pull/1180)
 
 ## 1.7.0
 


### PR DESCRIPTION
When the Task that runs a batched resolver times out we currently raise a generic error like this:
```
** (exit) exited in: Task.await(%Task{owner: #PID<0.15353.21>, pid: #PID<0.15380.21>, ref: #Reference<0.2441152191.2237136897.192020>}, 5000)
```
This provides no context to the engineer debugging the error about the resolver that timed out, making debugging much harder.

This change raises a `RuntimeError` which includes the resolver that timed out along with the arguments it received:
```
Batch resolver timed out after 1 ms.
Batch fun: {Absinthe.Middleware.BatchTest.Schema, :slow_field_by_user_id}
Batch data: [3, 2, 1]
Batch opts: [timeout: 1]
```
This should make the debugging experience a lot better.
