### PR TITLE
update old specification links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Last Updated](https://img.shields.io/github/last-commit/absinthe-graphql/absinthe.svg)](https://github.com/absinthe-graphql/absinthe/commits/master)
 
-[GraphQL](https://facebook.github.io/graphql/) implementation for Elixir.
+[GraphQL](https://github.com/graphql-elixir/graphql) implementation for Elixir.
 
 Goals:
 
@@ -61,7 +61,7 @@ We care about support for third-party frameworks, both on the back and
 front end.
 
 So far, we include specialized support for Phoenix and Plug on the backend,
-and [Relay](https://facebook.github.io/relay/) on the frontend.
+and [Relay](https://relay.dev/) on the frontend.
 
 Of course we work out of the box with other frontend frameworks and GraphQL
 clients, too.

--- a/guides/introduction/overview.md
+++ b/guides/introduction/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Absinthe is the GraphQL toolkit for Elixir, an implementation of the [GraphQL specification](https://facebook.github.io/graphql/) built to suit the language's capabilities and idiomatic style.
+Absinthe is the GraphQL toolkit for Elixir, an implementation of the [GraphQL specification](https://github.com/graphql-elixir/graphql) built to suit the language's capabilities and idiomatic style.
 
 The Absinthe project consists of several complementary packages. You can find the full listing on the [absinthe-graphql](https://github.com/absinthe-graphql) GitHub organization page.
 

--- a/guides/introspection.md
+++ b/guides/introspection.md
@@ -1,7 +1,7 @@
 # Schema Introspection
 
 You can introspect your schema using `__schema`, `__type`, and `__typename`,
-as [described in the specification](https://facebook.github.io/graphql/#sec-Introspection).
+as [described in the specification](https://spec.graphql.org/October2021/#sec-Introspection).
 
 ### Examples
 
@@ -89,7 +89,7 @@ Getting the name of the fields for a named type:
 ```
 
 Note that you may have to nest several depths of `type`/`ofType`, as
-type information includes any wrapping layers of [List](https://facebook.github.io/graphql/#sec-List) and/or [NonNull](https://facebook.github.io/graphql/#sec-Non-null).
+type information includes any wrapping layers of [List](https://spec.graphql.org/October2021/#sec-List) and/or [NonNull](https://spec.graphql.org/October2021/#sec-Non-Null).
 
 ## Using GraphiQL
 

--- a/guides/tutorial/our-first-query.md
+++ b/guides/tutorial/our-first-query.md
@@ -43,7 +43,7 @@ end
 > custom type name as a `:name` option to the `object` macro.
 
 If you're curious what the type `:id` is used by the `:id` field, see
-the [GraphQL spec](https://facebook.github.io/graphql/#sec-ID). It's
+the [GraphQL spec](https://spec.graphql.org/October2021/#sec-ID). It's
 an opaque value, and in our case is just the regular Ecto id, but
 serialized as a string.
 

--- a/guides/variables.md
+++ b/guides/variables.md
@@ -2,7 +2,7 @@
 
 GraphQL supports query documents that declare variables that can be accepted to fill-in values. This is a useful mechanism for reusing GraphQL documents---instead of attempting to interpolate values yourself.
 
-- To support variables, simply define them for your query document [as the specification expects](https://facebook.github.io/graphql/#sec-Language.Query-Document.Variables), and pass in a `variables` option to `Absinthe.run`.
+- To support variables, simply define them for your query document [as the specification expects](https://spec.graphql.org/October2021/#sec-Language.Variables), and pass in a `variables` option to `Absinthe.run`.
 - If you're using [absinthe_plug](https://github.com/absinthe-graphql/absinthe_plug), variables are passed in for you automatically after being parsed
 from the query parameters or `POST` body.
 

--- a/lib/absinthe/introspection.ex
+++ b/lib/absinthe/introspection.ex
@@ -3,7 +3,7 @@ defmodule Absinthe.Introspection do
   Introspection support.
 
   You can introspect your schema using `__schema`, `__type`, and `__typename`,
-  as [described in the specification](https://facebook.github.io/graphql/#sec-Introspection).
+  as [described in the specification](https://spec.graphql.org/October2021/#sec-Introspection).
 
   ## Examples
 
@@ -94,8 +94,8 @@ defmodule Absinthe.Introspection do
   ```
 
   (Note that you may have to nest several depths of `type`/`ofType`, as
-  type information includes any wrapping layers of [List](https://facebook.github.io/graphql/#sec-List)
-  and/or [NonNull](https://facebook.github.io/graphql/#sec-Non-null).)
+  type information includes any wrapping layers of [List](https://spec.graphql.org/October2021/#sec-List)
+  and/or [NonNull](https://spec.graphql.org/October2021/#sec-Non-Null).)
   """
 
   alias Absinthe.Type

--- a/lib/absinthe/phase/schema/validation/query_type_must_be_object.ex
+++ b/lib/absinthe/phase/schema/validation/query_type_must_be_object.ex
@@ -46,13 +46,16 @@ defmodule Absinthe.Phase.Schema.Validation.QueryTypeMustBeObject do
   --------------------------------------
   From the graqhql schema specification
 
-  A GraphQL schema includes types, indicating where query and mutation
-  operations start. This provides the initial entry points into the type system.
-  The query type must always be provided, and is an Object base type. The
-  mutation type is optional; if it is null, that means the system does not
-  support mutations. If it is provided, it must be an object base type.
+  A schema defines the initial root operation type for each kind of operation
+  it supports: query, mutation, and subscription; this determines the place in
+  the type system where those operations begin.
 
-  Reference: https://facebook.github.io/graphql/#sec-Initial-types
+  The query root operation type must be provided and must be an Object type.
+
+  The mutation root operation type is optional; if it is not provided, the service
+  does not support mutations. If it is provided, it must be an Object type.
+
+  Reference: https://spec.graphql.org/October2021/#sec-Root-Operation-Types
   """
 
   def explanation(_value) do

--- a/test/absinthe/execution/arguments/list_test.exs
+++ b/test/absinthe/execution/arguments/list_test.exs
@@ -109,7 +109,7 @@ defmodule Absinthe.Execution.Arguments.ListTest do
   }
   """
   test "it will coerce a non list item if it's of the right type" do
-    # per https://facebook.github.io/graphql/#sec-Lists
+    # per https://spec.graphql.org/October2021/#sec-List
     assert_data(%{"numbers" => [1]}, run(@graphql, @schema))
   end
 


### PR DESCRIPTION
I was reading through the tutorial and a link to the specification didn't exist so I've gone an updated all the old links to the new ones. I also updated a small snippet of text from the spec.