### PR TITLE
Ensure root objects are marked as referenced correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug Fix: [Fix bug in Schema.**absinthe_types**(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
 - Feature: [Add `import_directives` macro](https://github.com/absinthe-graphql/absinthe/pull/1158)
 - Feature: [Support type extensions on schema declarations](https://github.com/absinthe-graphql/absinthe/pull/1176)
+- Bug Fix: [Root objects are marked as referenced correctly](https://github.com/absinthe-graphql/absinthe/pull/1186)
 
 ## 1.7.0
 

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -328,10 +328,6 @@ defmodule Absinthe.SchemaTest do
                name: String
              }
 
-             type MyRootMutation {
-               name: String
-             }
-
              type RootQueryType {
                name(familyName: Boolean): String
              }


### PR DESCRIPTION
Followup to https://github.com/absinthe-graphql/absinthe/pull/1176

Since every schema will have a declared or inferred declaration, this
can be used to mark root objects as referenced.

The MarkReferenced used to mark every :query/:subscription/:mutation object
as referenced, even when it was not used in the declaration.

This fix ensures that root objects that are not used in the declaration
are not marked as referenced and thus not rendered in the SDL.
