### PR TITLE
Custom scalar parser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Feature: [Support error tuples when scalar parsing fails](https://github.com/absinthe-graphql/absinthe/pull/1187)
 - Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
 - Feature: [Add support for type extensions](https://github.com/absinthe-graphql/absinthe/pull/1157)
 - Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)

--- a/guides/custom-scalars.md
+++ b/guides/custom-scalars.md
@@ -15,7 +15,7 @@ providing `parse` and `serialize` functions.
 
 Here's the definition for `:datetime` from `Absinthe.Type.Custom`:
 
-``` elixir
+```elixir
 @desc """
 The `DateTime` scalar type represents a date and time in the UTC
 timezone. The DateTime appears in a JSON response as an ISO8601 formatted
@@ -68,7 +68,7 @@ mutation CreatePost {
 
 If our schema defines a `:published_at` argument with the `:datetime` type:
 
-``` elixir
+```elixir
 field :post, :post do
   arg :published_at, :datetime
   resolve fn _, args, _ ->
@@ -90,10 +90,9 @@ correct result. That result will be used as the value of the
 `:published_at` argument when it's passed to the `:post` field
 resolver.
 
-> It's important to note that---currently---the correct result from a
-> scalar's `parse` function in the event of the error is a lone atom,
-> `:error`, not an error tuple with a reason. In a future version of
-> Absinthe, custom parse errors may be supported.
+In the event of an error, the parse function can return either a lone
+atom `:error` or error tuple e.g. `{:error, "Reason of error"}`. The
+reason will be included in the output of the executed GraphQL document.
 
 The serializer of `:datetime` is a pretty simple affair; it uses the
 `DateTime.to_iso8601/1` utility function. It would be called to

--- a/lib/absinthe/phase.ex
+++ b/lib/absinthe/phase.ex
@@ -25,14 +25,21 @@ defmodule Absinthe.Phase do
       @behaviour Phase
       import(unquote(__MODULE__))
 
-      @spec flag_invalid(Blueprint.node_t()) :: Blueprint.node_t()
+      @spec flag_invalid(node :: Blueprint.node_t()) :: Blueprint.node_t()
       def flag_invalid(%{flags: _} = node) do
         Absinthe.Blueprint.put_flag(node, :invalid, __MODULE__)
       end
 
-      @spec flag_invalid(Blueprint.node_t(), atom) :: Blueprint.node_t()
+      @spec flag_invalid(node :: Blueprint.node_t(), flag :: atom) :: Blueprint.node_t()
       def flag_invalid(%{flags: _} = node, flag) do
         flagging = %{:invalid => __MODULE__, flag => __MODULE__}
+        update_in(node.flags, &Map.merge(&1, flagging))
+      end
+
+      @spec flag_invalid(node :: Blueprint.node_t(), flag :: atom, reason :: String.t()) ::
+              Blueprint.node_t()
+      def flag_invalid(%{flags: _} = node, flag, reason) do
+        flagging = %{:invalid => {__MODULE__, reason}, flag => __MODULE__}
         update_in(node.flags, &Map.merge(&1, flagging))
       end
 

--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -26,6 +26,10 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
 
       {:error, flag} ->
         %{node | normalized: normalized |> flag_invalid(flag)}
+
+      {:error, flag, reason} ->
+        normalized = normalized |> flag_invalid(flag, reason)
+        %{node | normalized: normalized}
     end
   end
 
@@ -41,6 +45,9 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
       :error ->
         {:error, :bad_parse}
 
+      {:error, reason} ->
+        {:error, :bad_parse, reason}
+
       {:ok, val} ->
         {:ok, val}
     end
@@ -54,6 +61,9 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
     case Type.Scalar.parse(schema_node, normalized, context) do
       :error ->
         {:error, :bad_parse}
+
+      {:error, reason} ->
+        {:error, :bad_parse, reason}
 
       {:ok, val} ->
         {:ok, val}

--- a/test/absinthe/execution/arguments/scalar_test.exs
+++ b/test/absinthe/execution/arguments/scalar_test.exs
@@ -36,6 +36,46 @@ defmodule Absinthe.Execution.Arguments.ScalarTest do
     )
   end
 
+  describe "custom scalar parsing errors" do
+    @graphql """
+    query {
+      customScalarError(simpleScalar: "bogus")
+    }
+    """
+
+    test "scalar returns custom parse error in argument input" do
+      assert_error_message(
+        "Argument \"simpleScalar\" has invalid value \"bogus\".\nCustom error 1",
+        run(@graphql, @schema)
+      )
+    end
+
+    @graphql """
+    query {
+      customScalarError(listOfScalar: ["ok", "bogus"])
+    }
+    """
+
+    test "scalar returns custom parse error in list input" do
+      assert_error_message(
+        "Argument \"listOfScalar\" has invalid value [\"ok\", \"bogus\"].\nIn element #2: Expected type \"CustomScalarError\", found \"bogus\".\nCustom error 1",
+        run(@graphql, @schema)
+      )
+    end
+
+    @graphql """
+    query {
+      customScalarError(complexScalarInput: {scalar: "bogus"})
+    }
+    """
+    test "scalar returns custom parse error in complex input" do
+      assert_error_message(
+        "Argument \"complexScalarInput\" has invalid value {scalar: \"bogus\"}.\nIn field \"scalar\": Expected type \"CustomScalarError\", found \"bogus\".\nCustom error 1",
+        run(@graphql, @schema)
+      )
+    end
+  end
+
   @graphql """
   query ($scalarVar: InputNameRaising) {
     raisingThing(name: $scalarVar)

--- a/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
@@ -1002,6 +1002,33 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectTypeTest do
         ]
       )
     end
+
+    @tag :o
+    test "Invalid scalar input on mutation, no suggestion, custom error" do
+      assert_fails_validation(
+        """
+        mutation($scalarInput: CustomScalarError!) {
+          createCat(customScalarErrorInput: $scalarInput)
+        }
+        """,
+        [
+          variables: %{
+            "scalarInput" => "Custom error output"
+          }
+        ],
+        [
+          bad_argument(
+            "customScalarErrorInput",
+            "CustomScalar",
+            ~s($scalarInput),
+            2,
+            [
+              "Custom error output"
+            ]
+          )
+        ]
+      )
+    end
   end
 
   describe "Directive arguments" do

--- a/test/support/fixtures/arguments_schema.ex
+++ b/test/support/fixtures/arguments_schema.ex
@@ -35,6 +35,22 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
     end
   end
 
+  scalar :custom_scalar_error do
+    serialize &to_string/1
+
+    parse fn
+      %{value: "ok"} ->
+        {:ok, "ok"}
+
+      _error ->
+        {:error, "Custom error 1"}
+    end
+  end
+
+  input_object :complex_scalar_input do
+    field :scalar, :custom_scalar_error
+  end
+
   input_object :boolean_input_object do
     field :flag, :boolean
   end
@@ -174,6 +190,12 @@ defmodule Absinthe.Fixtures.ArgumentsSchema do
 
     field :raising_thing, :string do
       arg :name, :input_name_raising
+    end
+
+    field :custom_scalar_error, :string do
+      arg :simple_scalar, :custom_scalar_error
+      arg :list_of_scalar, list_of(:custom_scalar_error)
+      arg :complex_scalar_input, :complex_scalar_input
     end
   end
 end

--- a/test/support/fixtures/pets_schema.ex
+++ b/test/support/fixtures/pets_schema.ex
@@ -128,6 +128,11 @@ defmodule Absinthe.Fixtures.PetsSchema do
     serialize & &1
   end
 
+  scalar :custom_scalar_error do
+    parse &{:error, &1.value}
+    serialize & &1
+  end
+
   object :complicated_args do
     field :int_arg_field, :string do
       arg :int_arg, :integer
@@ -210,6 +215,10 @@ defmodule Absinthe.Fixtures.PetsSchema do
   mutation do
     field :create_dog, :dog do
       arg :custom_scalar_input, non_null(:custom_scalar)
+    end
+
+    field :create_cat, :cat do
+      arg :custom_scalar_error_input, non_null(:custom_scalar_error)
     end
   end
 


### PR DESCRIPTION
See https://github.com/absinthe-graphql/absinthe/issues/856

The `parse/1` could only return `:error` in case of a failure when parsing a custom scalar. This PR fixes that by also allowing an error tuple as a return value. 

The error is stored in the flag instead of the `errors` field. This was more in line with how the current code was set up. The cases where the parse error handles in input objects and input lists are also handled. 