### PR TITLE
Fix default enum value present for SDL schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature: [Add support for type extensions](https://github.com/absinthe-graphql/absinthe/pull/1157)
 - Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)
 - Bug Fix: [Fix bug in Schema.**absinthe_types**(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
+- Bug Fix: [Fix default enum value check for SDL schema's](https://github.com/absinthe-graphql/absinthe/pull/1188)
 - Feature: [Add `import_directives` macro](https://github.com/absinthe-graphql/absinthe/pull/1158)
 - Feature: [Support type extensions on schema declarations](https://github.com/absinthe-graphql/absinthe/pull/1176)
 


### PR DESCRIPTION
TypeReference.unwrap/1 was passed in %TypeReference.Name{} struct in the
case of SDL schema's, and returns it. This fails in the subsequent lookup
in `enums`. We need to use TypeReference.to_type/2 to get
the actual atom type identifier for the `enums` lookup.

For macro schema's this is not an issue as the atom type identifier is
passed into TypeReference.unwrap/1.