### PR TITLE
Expose type system directives in introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
 - Feature: [Add support for type extensions](https://github.com/absinthe-graphql/absinthe/pull/1157)
+- Bug Fix: [Add type system directives to introspection results](https://github.com/absinthe-graphql/absinthe/pull/1189)
 - Bug Fix: [Add `__private__` field to EnumValueDefinition](https://github.com/absinthe-graphql/absinthe/pull/1148)
 - Bug Fix: [Fix bug in Schema.**absinthe_types**(:all) for Persistent Term](https://github.com/absinthe-graphql/absinthe/pull/1161)
 - Feature: [Add `import_directives` macro](https://github.com/absinthe-graphql/absinthe/pull/1158)

--- a/lib/absinthe/phase/schema/build.ex
+++ b/lib/absinthe/phase/schema/build.ex
@@ -5,9 +5,13 @@ defmodule Absinthe.Phase.Schema.Build do
     %{schema_definitions: [schema]} = blueprint
 
     types = build_types(blueprint)
-    directives = build_directives(blueprint)
+    directive_artifacts = build_directives(blueprint)
 
-    schema = %{schema | type_artifacts: types, directive_artifacts: directives}
+    schema = %{
+      schema
+      | type_artifacts: types,
+        directive_artifacts: schema.directive_artifacts ++ directive_artifacts
+    }
 
     blueprint = %{blueprint | schema_definitions: [schema]}
 

--- a/lib/absinthe/phase/schema/compile.ex
+++ b/lib/absinthe/phase/schema/compile.ex
@@ -23,7 +23,7 @@ defmodule Absinthe.Phase.Schema.Compile do
           do: {type_def.identifier, type_def.name}
 
     directive_list =
-      Map.new(schema.directive_definitions, fn type_def ->
+      Map.new(schema.directive_artifacts, fn type_def ->
         {type_def.identifier, type_def.name}
       end)
 

--- a/lib/absinthe/phase/schema/import_prototype_directives.ex
+++ b/lib/absinthe/phase/schema/import_prototype_directives.ex
@@ -1,0 +1,26 @@
+defmodule Absinthe.Phase.Schema.ImportPrototypeDirectives do
+  @moduledoc false
+
+  # Imports directives from the prototype schema into the current schema.
+  # This ensures the type system directives such as `deprecated` are available
+  # for introspection as per the spec.
+  #
+  # Note that this does import the (type system) directives themselves, this
+  # is already done in an earlier phase.
+
+  @behaviour Absinthe.Phase
+  alias Absinthe.Blueprint
+
+  @spec run(Blueprint.t(), Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(blueprint, _options \\ []) do
+    prototype_directives = Absinthe.Schema.directives(blueprint.prototype_schema)
+
+    %{schema_definitions: [schema]} = blueprint
+
+    schema = %{schema | directive_artifacts: prototype_directives}
+
+    blueprint = %{blueprint | schema_definitions: [schema]}
+
+    {:ok, blueprint}
+  end
+end

--- a/lib/absinthe/phase/schema/populate_persistent_term.ex
+++ b/lib/absinthe/phase/schema/populate_persistent_term.ex
@@ -24,7 +24,7 @@ if Code.ensure_loaded?(:persistent_term) do
             do: {type_def.identifier, type_def.name}
 
       directive_list =
-        Map.new(schema.directive_definitions, fn type_def ->
+        Map.new(schema.directive_artifacts, fn type_def ->
           {type_def.identifier, type_def.name}
         end)
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -188,6 +188,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.ReformatDescriptions,
       # This phase is run again now after additional validations
       {Phase.Schema.Validation.Result, pass: :final},
+      Phase.Schema.ImportPrototypeDirectives,
       Phase.Schema.Build,
       Phase.Schema.InlineFunctions,
       {Phase.Schema.Compile, options}

--- a/lib/absinthe/schema/prototype/notation.ex
+++ b/lib/absinthe/schema/prototype/notation.ex
@@ -12,6 +12,7 @@ defmodule Absinthe.Schema.Prototype.Notation do
       @pipeline_modifier __MODULE__
 
       directive :deprecated do
+        description "Marks an element of a GraphQL schema as no longer supported."
         arg :reason, :string
 
         on [
@@ -34,6 +35,7 @@ defmodule Absinthe.Schema.Prototype.Notation do
       def pipeline(pipeline) do
         pipeline
         |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.Validation.QueryTypeMustBeObject)
+        |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.ImportPrototypeDirectives)
         |> Absinthe.Pipeline.replace(
           Absinthe.Phase.Schema.TypeExtensionImports,
           {Absinthe.Phase.Schema.TypeExtensionImports, []}

--- a/test/absinthe/integration/execution/introspection/directives_test.exs
+++ b/test/absinthe/integration/execution/introspection/directives_test.exs
@@ -25,6 +25,22 @@ defmodule Elixir.Absinthe.Integration.Execution.Introspection.DirectivesTest do
                   "directives" => [
                     %{
                       "args" => [
+                        %{"name" => "reason", "type" => %{"kind" => "SCALAR", "ofType" => nil}}
+                      ],
+                      "isRepeatable" => false,
+                      "locations" => [
+                        "ARGUMENT_DEFINITION",
+                        "ENUM_VALUE",
+                        "FIELD_DEFINITION",
+                        "INPUT_FIELD_DEFINITION"
+                      ],
+                      "name" => "deprecated",
+                      "onField" => false,
+                      "onFragment" => false,
+                      "onOperation" => false
+                    },
+                    %{
+                      "args" => [
                         %{
                           "name" => "if",
                           "type" => %{

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -30,6 +30,30 @@ defmodule Absinthe.IntrospectionTest do
                     "directives" => [
                       %{
                         "description" =>
+                          "Marks an element of a GraphQL schema as no longer supported.",
+                        "isRepeatable" => false,
+                        "locations" => [
+                          "ARGUMENT_DEFINITION",
+                          "ENUM_VALUE",
+                          "FIELD_DEFINITION",
+                          "INPUT_FIELD_DEFINITION"
+                        ],
+                        "name" => "deprecated",
+                        "onField" => false,
+                        "onFragment" => false,
+                        "onOperation" => false
+                      },
+                      %{
+                        "description" => nil,
+                        "isRepeatable" => false,
+                        "locations" => ["FIELD_DEFINITION"],
+                        "name" => "external",
+                        "onField" => false,
+                        "onFragment" => false,
+                        "onOperation" => false
+                      },
+                      %{
+                        "description" =>
                           "Directs the executor to include this field or fragment only when the `if` argument is true.",
                         "isRepeatable" => false,
                         "locations" => ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],

--- a/test/support/fixtures/color_schema.ex
+++ b/test/support/fixtures/color_schema.ex
@@ -2,6 +2,16 @@ defmodule Absinthe.Fixtures.ColorSchema do
   use Absinthe.Schema
   use Absinthe.Fixture
 
+  defmodule WithTypeSystemDirective do
+    use Absinthe.Schema.Prototype
+
+    directive :external do
+      on [:field_definition]
+    end
+  end
+
+  @prototype_schema WithTypeSystemDirective
+
   @names %{
     r: "RED",
     g: "GREEN",


### PR DESCRIPTION
Previously type system directives such as `deprecated` or those created by users were not available in introspection. The spec itself is not really clear in this but afaict they should be exposed.

I've  checked out the reference ](https://44c20.sse.codesandbox.io/?query=query%20%7B%0A%20%20__schema%7B%0A%20%20%20%20directives%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)`graphql` implementation and it does expose the type system directives.

This PR adds a phase to add the prototype directive list to the schema directive list so they are available through introspection. In the prototype schema itself this phase is skipped to prevent an infinite loop.

