### PR TITLE
Raise for non-toplevel root object definitions

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -92,6 +92,8 @@ defmodule Absinthe.Schema do
   ```
   """
 
+  Module.register_attribute(__MODULE__, :placement, accumulate: true)
+
   defmacro __using__(opts) do
     Module.register_attribute(__CALLER__.module, :pipeline_modifier,
       accumulate: true,
@@ -151,6 +153,7 @@ defmodule Absinthe.Schema do
   @object_type Absinthe.Blueprint.Schema.ObjectTypeDefinition
 
   @default_query_name "RootQueryType"
+  @placement {:query, [toplevel: true, extend: true]}
   @doc """
   Defines a root Query object
   """
@@ -163,10 +166,13 @@ defmodule Absinthe.Schema do
       raw_attrs
       |> Keyword.put_new(:name, @default_query_name)
 
-    Absinthe.Schema.Notation.record!(env, @object_type, :query, attrs, block)
+    env
+    |> Absinthe.Schema.Notation.recordable!(:query, @placement[:query])
+    |> Absinthe.Schema.Notation.record!(@object_type, :query, attrs, block)
   end
 
   @default_mutation_name "RootMutationType"
+  @placement {:mutation, [toplevel: true, extend: true]}
   @doc """
   Defines a root Mutation object
 
@@ -190,10 +196,13 @@ defmodule Absinthe.Schema do
       raw_attrs
       |> Keyword.put_new(:name, @default_mutation_name)
 
-    Absinthe.Schema.Notation.record!(env, @object_type, :mutation, attrs, block)
+    env
+    |> Absinthe.Schema.Notation.recordable!(:mutation, @placement[:mutation])
+    |> Absinthe.Schema.Notation.record!(@object_type, :mutation, attrs, block)
   end
 
   @default_subscription_name "RootSubscriptionType"
+  @placement {:subscription, [toplevel: true, extend: true]}
   @doc """
   Defines a root Subscription object
 
@@ -291,7 +300,9 @@ defmodule Absinthe.Schema do
       raw_attrs
       |> Keyword.put_new(:name, @default_subscription_name)
 
-    Absinthe.Schema.Notation.record!(env, @object_type, :subscription, attrs, block)
+    env
+    |> Absinthe.Schema.Notation.recordable!(:subscription, @placement[:subscription])
+    |> Absinthe.Schema.Notation.record!(@object_type, :subscription, attrs, block)
   end
 
   defmacro __before_compile__(_) do

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -1,6 +1,51 @@
 defmodule Absinthe.Schema.NotationTest do
   use Absinthe.Case, async: true
 
+  describe "query" do
+    test "cannot be non-toplevel" do
+      assert_notation_error(
+        "QueryInvalid",
+        """
+        query do
+          mutation do
+          end
+        end
+        """,
+        "Invalid schema notation: `mutation` must only be used toplevel or in an `extend` block. Was used in `object`."
+      )
+    end
+  end
+
+  describe "subscription" do
+    test "cannot be non-toplevel" do
+      assert_notation_error(
+        "SubscriptionInvalid",
+        """
+        subscription do
+          subscription do
+          end
+        end
+        """,
+        "Invalid schema notation: `subscription` must only be used toplevel or in an `extend` block. Was used in `object`."
+      )
+    end
+  end
+
+  describe "mutation" do
+    test "cannot be non-toplevel" do
+      assert_notation_error(
+        "MutationInvalid",
+        """
+        mutation do
+          mutation do
+          end
+        end
+        """,
+        "Invalid schema notation: `mutation` must only be used toplevel or in an `extend` block. Was used in `object`."
+      )
+    end
+  end
+
   describe "arg" do
     test "can be under field as an attribute" do
       assert_no_notation_error("ArgFieldValid", """


### PR DESCRIPTION
As seen in https://github.com/absinthe-graphql/absinthe/issues/1190#issuecomment-1231589935 a more informative error can be shown when root objects are note used in the toplevel.

