### PR TITLE
Ignore subscription publish with empty subscribed_fields

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -74,6 +74,8 @@ defmodule Absinthe.Subscription do
           term,
           Absinthe.Resolution.t() | [subscription_field_spec]
         ) :: :ok
+  def publish(_pubsub, _mutation_result, []), do: :ok
+
   def publish(pubsub, mutation_result, %Absinthe.Resolution{} = info) do
     subscribed_fields = get_subscription_fields(info)
     publish(pubsub, mutation_result, subscribed_fields)


### PR DESCRIPTION
As written, `Absinthe.Subscribe.publish()` will broadcast (via pubsub) every mutation results, even if the subscribed fields is empty. This is because get_subscription_info() will return an empty array if it does not find any subscribed fields. The mutation results with the empty subscribed_fields are passed down all the way to the pubsub and broadcasted to all participating nodes. Absinthe.Subscription.Local ultimately ignores this when attempting to iterate over an empty list.

This can result in significant network traffic among nodes, yet it ultimately does nothing. When deployed on the cloud in a multi-az deployment, this can result in significant increase in network traffic charges.

This patch adds a clause where empty subscribed_fields is ignored.

### Production Case Study

On our production servers, we were seeing empty 2000 publish/s against 1-5 publish/s for actual subscriptions during our idle times. We have a multi-az setup, so node-to-node network usage is charged to us. We were seeing about 1.5TB of node-to-node traffic during a 4 hour operational window of a typical day. It was significantly larger than ingress traffic coming in from our load balancers by an order of magnitude.

I had implemented something similar to this patch using a custom behavior implementation for the `Absinthe.Phoenix.Endpoint` behavior, and our node-to-node traffic during the 4-hour window dropped to around 300 MB. 

I can't imagine why the `Absinthe.Subscription.publish()` call should publish with an empty list for the `subscribed_fields`. If that characteristic needs to be retained, I can instead push up a PR for a similar fix on `absinthe_phoenix`. 