### PR TITLE
Add support for OTP-25 and Elixir 1.14

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,20 +14,25 @@ jobs:
     strategy:
       matrix:
         elixir:
-          - "1.10"
           - "1.11"
           - "1.12"
           - "1.13"
+          - "1.14"
         otp:
           - "22"
           - "23"
           - "24"
+          - "25"
         exclude:
-          - elixir: "1.10"
-            otp: "24"
+          - elixir: "1.11"
+            otp: "25"
+          - elixir: "1.12"
+            otp: "25"
+          - elixir: "1.14"
+            otp: "22"
         include:
-          - elixir: "1.13"
-            otp: "24"
+          - elixir: "1.14"
+            otp: "25"
             format: true
 
     steps:

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Absinthe.Mixfile do
     [
       app: :absinthe,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/absinthe/schema/notation/import_test.exs
+++ b/test/absinthe/schema/notation/import_test.exs
@@ -159,18 +159,6 @@ defmodule Absinthe.Schema.Notation.ImportTest do
       assert {:error,
               [
                 %Absinthe.Phase.Error{
-                  extra: :bar,
-                  locations: [
-                    %{
-                      line: _
-                    }
-                  ],
-                  message:
-                    "Field Import Cycle Error\n\nField Import in object `bar' `import_fields([foo: []]) forms a cycle via: ([:bar, :foo, :bar])",
-                  path: [],
-                  phase: Absinthe.Phase.Schema.Validation.NoCircularFieldImports
-                },
-                %Absinthe.Phase.Error{
                   extra: :foo,
                   locations: [
                     %{
@@ -179,6 +167,18 @@ defmodule Absinthe.Schema.Notation.ImportTest do
                   ],
                   message:
                     "Field Import Cycle Error\n\nField Import in object `foo' `import_fields([bar: []]) forms a cycle via: ([:foo, :bar, :foo])",
+                  path: [],
+                  phase: Absinthe.Phase.Schema.Validation.NoCircularFieldImports
+                },
+                %Absinthe.Phase.Error{
+                  extra: :bar,
+                  locations: [
+                    %{
+                      line: _
+                    }
+                  ],
+                  message:
+                    "Field Import Cycle Error\n\nField Import in object `bar' `import_fields([foo: []]) forms a cycle via: ([:bar, :foo, :bar])",
                   path: [],
                   phase: Absinthe.Phase.Schema.Validation.NoCircularFieldImports
                 }

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -246,10 +246,10 @@ defmodule Absinthe.Schema.SdlRenderTest do
 
              directive @foo(baz: String) on FIELD
 
-             "Escaped\\t\\\"descrição\\/description\\\""
+             \"Escaped\\t\\\"descrição\\/description\\\"\"
              type RootQueryType {
                echo(
-                 "The number of times"
+                 \"The number of times\"
                  times: Int
 
                  timeInterval: Int
@@ -257,22 +257,16 @@ defmodule Absinthe.Schema.SdlRenderTest do
                search: SearchResult
              }
 
-             type Category {
-               name: String
+             enum OrderStatus {
+               DELIVERED
+               PROCESSING
+               PICKING
              }
-
-             union SearchResult = Order | Category
 
              enum Status {
                ONE
                TWO
                THREE
-             }
-
-             enum OrderStatus {
-               DELIVERED
-               PROCESSING
-               PICKING
              }
 
              type Order {
@@ -282,6 +276,12 @@ defmodule Absinthe.Schema.SdlRenderTest do
                status: OrderStatus
                otherStatus: Status
              }
+
+             type Category {
+               name: String
+             }
+
+             union SearchResult = Order | Category
              """
   end
 end

--- a/test/absinthe/schema/type_system_directive_test.exs
+++ b/test/absinthe/schema/type_system_directive_test.exs
@@ -184,33 +184,35 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
   end
 
   @macro_schema_sdl """
-  schema @feature(name: ":schema") {
+  schema @feature(name: \":schema\") {
     query: RootQueryType
   }
 
-  interface Animal @feature(name: ":interface") {
+  type RootQueryType {
+    post: Post @feature(name: \":field_definition\")
+    sweet: SweetScalar
+    which: Category
+    pet: Dog
+    search(filter: SearchFilter @feature(name: \":argument_definition\")): SearchResult @feature(name: \":argument_definition\")
+  }
+
+  type Post @feature(name: \":object\", number: 3) {
+    name: String @deprecated(reason: \"Bye\")
+  }
+
+  scalar SweetScalar @feature(name: \":scalar\")
+
+  enum Category @feature(name: \":enum\") {
+    THIS
+    THAT @feature(name: \":enum_value\")
+    THE_OTHER @deprecated(reason: \"It's old\")
+  }
+
+  interface Animal @feature(name: \":interface\") {
     legCount: Int! @feature(name: \"\"\"
       Multiline here?
       Second line
     \"\"\")
-  }
-
-  input SearchFilter @feature(name: ":input_object") {
-    query: String @feature(name: ":input_field_definition")
-  }
-
-  type Post @feature(name: ":object", number: 3) {
-    name: String @deprecated(reason: "Bye")
-  }
-
-  scalar SweetScalar @feature(name: ":scalar")
-
-  type RootQueryType {
-    post: Post @feature(name: ":field_definition")
-    sweet: SweetScalar
-    which: Category
-    pet: Dog
-    search(filter: SearchFilter @feature(name: ":argument_definition")): SearchResult @feature(name: ":argument_definition")
   }
 
   type Dog implements Animal {
@@ -218,13 +220,11 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
     name: String! @external
   }
 
-  enum Category @feature(name: ":enum") {
-    THIS
-    THAT @feature(name: ":enum_value")
-    THE_OTHER @deprecated(reason: "It's old")
+  input SearchFilter @feature(name: \":input_object\") {
+    query: String @feature(name: \":input_field_definition\")
   }
 
-  union SearchResult @feature(name: ":union") = Dog | Post
+  union SearchResult @feature(name: \":union\") = Dog | Post
   """
   describe "with macro schema" do
     test "Render SDL with Type System Directives applied" do

--- a/test/absinthe/schema_test.exs
+++ b/test/absinthe/schema_test.exs
@@ -324,12 +324,12 @@ defmodule Absinthe.SchemaTest do
                query: RootQueryType
              }
 
-             type RootSubscriptionTypeThing {
-               name: String
-             }
-
              type RootQueryType {
                name(familyName: Boolean): String
+             }
+
+             type RootSubscriptionTypeThing {
+               name: String
              }
              """ == Schema.to_sdl(RootsSchemaDeclaration)
     end
@@ -356,7 +356,18 @@ defmodule Absinthe.SchemaTest do
   describe "to_sdl/1" do
     test "return schema sdl" do
       assert Schema.to_sdl(SourceSchema) == """
-             schema {\n  query: RootQueryType\n}\n\ntype Foo {\n  name: String\n}\n\n\"can describe query\"\ntype RootQueryType {\n  foo: Foo\n}
+             schema {
+               query: RootQueryType
+             }
+
+             \"can describe query\"
+             type RootQueryType {
+               foo: Foo
+             }
+
+             type Foo {
+               name: String
+             }
              """
     end
   end

--- a/test/mix/tasks/absinthe.schema.json_test.exs
+++ b/test/mix/tasks/absinthe.schema.json_test.exs
@@ -95,12 +95,7 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
       assert ugly_content == "test-encoder-ugly"
     end
 
-    if Version.compare(System.version(), "1.11.0") == :lt do
-      setup :tmp_dir_fallback
-    else
-      @tag :tmp_dir
-    end
-
+    @tag :tmp_dir
     test "generates a JSON file", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.json")
 
@@ -110,12 +105,7 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
       assert File.exists?(path)
     end
 
-    if Version.compare(System.version(), "1.11.0") == :lt do
-      setup :tmp_dir_fallback
-    else
-      @tag :tmp_dir
-    end
-
+    @tag :tmp_dir
     test "generates a JSON file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.json")
 
@@ -124,12 +114,5 @@ defmodule Mix.Tasks.Absinthe.Schema.JsonTest do
 
       assert File.exists?(path)
     end
-  end
-
-  defp tmp_dir_fallback(_) do
-    path = Path.join("tmp", "#{__MODULE__}")
-    File.mkdir_p!(path)
-    on_exit(fn -> File.rm_rf!(path) end)
-    [tmp_dir: path]
   end
 end

--- a/test/mix/tasks/absinthe.schema.sdl_test.exs
+++ b/test/mix/tasks/absinthe.schema.sdl_test.exs
@@ -174,12 +174,7 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert schema =~ "type Robot implements Being"
     end
 
-    if Version.compare(System.version(), "1.11.0") == :lt do
-      setup :tmp_dir_fallback
-    else
-      @tag :tmp_dir
-    end
-
+    @tag :tmp_dir
     test "generates an SDL file", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.sdl")
 
@@ -189,12 +184,7 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert File.exists?(path)
     end
 
-    if Version.compare(System.version(), "1.11.0") == :lt do
-      setup :tmp_dir_fallback
-    else
-      @tag :tmp_dir
-    end
-
+    @tag :tmp_dir
     test "generates an SDL file for a persistent term schema provider", %{tmp_dir: tmp_dir} do
       path = Path.join(tmp_dir, "schema.sdl")
 
@@ -203,12 +193,5 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
 
       assert File.exists?(path)
     end
-  end
-
-  defp tmp_dir_fallback(_) do
-    path = Path.join("tmp", "#{__MODULE__}")
-    File.mkdir_p!(path)
-    on_exit(fn -> File.rm_rf!(path) end)
-    [tmp_dir: path]
   end
 end


### PR DESCRIPTION
This PR adds support for OTP-25 and Elixir 1.14 in the test matrix. In addition it removes support for Elixir 1.10. Support is kept for Elixir 1.11 which seems plenty.

One change in OTP-25 caused some [test failures](https://github.com/maartenvanvliet/absinthe/actions/runs/3051327865) in the SDL rendering. See f64dd3866162b316b41258c6558290e57ff2f601 for an explanation.