### PR TITLE
Allow `Registry` compression to be configured by users

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -36,7 +36,7 @@ line:
       {Phoenix.PubSub, name: :my_pubsub},
       # Start the endpoint when the application starts
       MyAppWeb.Endpoint,
-      {Absinthe.Subscription, MyAppWeb.Endpoint}
+      {Absinthe.Subscription, pubsub: MyAppWeb.Endpoint}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -44,6 +44,9 @@ line:
     opts = [strategy: :one_for_one, name: MyAppWeb.Supervisor]
     Supervisor.start_link(children, opts)
 ```
+
+See `Absinthe.Subscription.child_spec/1` for more information on the supported
+options.
 
 In your `MyAppWeb.Endpoint` module add:
 

--- a/guides/tutorial/subscriptions.md
+++ b/guides/tutorial/subscriptions.md
@@ -33,7 +33,7 @@ In `lib/blog/application.ex`:
   children = [
     # other children ...
     {BlogWeb.Endpoint, []}, # this line should already exist
-    {Absinthe.Subscription, [BlogWeb.Endpoint]}, # add this line
+    {Absinthe.Subscription, pubsub: BlogWeb.Endpoint}, # add this line
     # other children ...
   ]
 ```

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -35,12 +35,42 @@ defmodule Absinthe.Subscription do
   @doc """
   Add Absinthe.Subscription to your process tree.
   """
-  defdelegate start_link(pubsub), to: Subscription.Supervisor
+  defdelegate start_link(opts), to: Subscription.Supervisor
 
-  def child_spec(pubsub) do
+  @type opt() ::
+          {:pubsub, atom()} | {:compress_registry?, boolean()} | {:pool_size, pos_integer()}
+
+  @doc """
+  Build a child specification for subscriptions.
+
+  In order to use supscriptions in your application, you must add
+  `Absinthe.Subscription` to your supervision tree after your endpoint.
+
+  See `guides/subscriptions.md` for more information on how to get up and
+  running with subscriptions.
+
+  ## Options
+
+  * `:pubsub` - (Required) The `Phoenix.Pubsub` that should be used to publish
+    subscriptions. Typically this will be your `Phoenix.Endpoint`.
+  * `:compress_registry?` - (Optional - default `true`) A boolean controlling
+    whether the Registry used to keep track of subscriptions will should be
+    compressed or not.
+  * `:pool_size` - (Optional - default `System.schedulers() * 2`) An integer
+    specifying the number of `Absinthe.Subscription.Proxy` processes to start.
+  """
+  @spec child_spec(atom() | [opt()]) :: Supervisor.child_spec()
+  def child_spec(pubsub) when is_atom(pubsub) do
+    # child_spec/1 used to take a single argument - the pub-sub - so in order
+    # to maintain compatibility for existing users of the library we still
+    # accept this argument and transform it into a keyword list.
+    child_spec(pubsub: pubsub)
+  end
+
+  def child_spec(opts) when is_list(opts) do
     %{
       id: __MODULE__,
-      start: {Subscription.Supervisor, :start_link, [pubsub]},
+      start: {Subscription.Supervisor, :start_link, [opts]},
       type: :supervisor
     }
   end

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -35,7 +35,8 @@ defmodule Absinthe.Subscription do
   @doc """
   Add Absinthe.Subscription to your process tree.
   """
-  defdelegate start_link(opts), to: Subscription.Supervisor
+  @spec start_link(atom() | [opt()]) :: Supervisor.on_start()
+  defdelegate start_link(opts_or_pubsub), to: Subscription.Supervisor
 
   @type opt() ::
           {:pubsub, atom()} | {:compress_registry?, boolean()} | {:pool_size, pos_integer()}

--- a/lib/absinthe/subscription/supervisor.ex
+++ b/lib/absinthe/subscription/supervisor.ex
@@ -3,7 +3,15 @@ defmodule Absinthe.Subscription.Supervisor do
 
   use Supervisor
 
-  def start_link(opts) do
+  @spec start_link(atom() | [Absinthe.Subscription.opt()]) :: Supervisor.on_start()
+  def start_link(pubsub) when is_atom(pubsub) do
+    # start_link/1 used to take a single argument - the pub-sub - so in order
+    # to maintain compatibility for existing users of the library we still
+    # accept this argument and transform it into a keyword list.
+    start_link(pubsub: pubsub)
+  end
+
+  def start_link(opts) when is_list(opts) do
     pubsub =
       case Keyword.fetch!(opts, :pubsub) do
         [module] when is_atom(module) ->

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -146,7 +146,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
   setup_all do
     {:ok, _} = PubSub.start_link()
-    {:ok, _} = Absinthe.Subscription.start_link(pubsub: PubSub)
+    {:ok, _} = Absinthe.Subscription.start_link(PubSub)
     :ok
   end
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -146,7 +146,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
   setup_all do
     {:ok, _} = PubSub.start_link()
-    {:ok, _} = Absinthe.Subscription.start_link(PubSub)
+    {:ok, _} = Absinthe.Subscription.start_link(pubsub: PubSub)
     :ok
   end
 


### PR DESCRIPTION
At the moment `Registry` is started with `compressed: true` hard coded.

This presented problems when we updated absinthe some time ago, we are running an application with a large number of subscriptions and so the added CPU utilization was quite large. To avoid having to scale up we pinned absinthe to a pre-compression version.

We'd like to be able to keep up to date, and so propose this change to allow users to opt-out of compression and would welcome your feedback.

This PR alters the type signature of `Absinthe.Subscription.child_spec/1` so users can pass more configuration options. The original argument (a single pub-sub) is still supported for backwards compatibility.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
