### PR TITLE
Fix broken links and documentation improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,4 +39,4 @@ Some things that will increase the chance that your pull request is accepted:
 
 Thanks again for helping!
 
-[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[commit]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Goals:
 - Detailed error messages and documentation.
 - A focus on robustness and production-level performance.
 
-Please see the website at [http://absinthe-graphql.org](http://absinthe-graphql.org).
+Please see the website at [https://absinthe-graphql.org](https://absinthe-graphql.org).
 
 ## Why Use Absinthe?
 
@@ -86,7 +86,7 @@ See [CHANGELOG](./CHANGELOG.md) for upgrade steps between versions.
 
 - [Absinthe hexdocs](https://hexdocs.pm/absinthe).
 - For the tutorial, guides, and general information about Absinthe-related
-  projects, see [http://absinthe-graphql.org](http://absinthe-graphql.org).
+  projects, see [https://absinthe-graphql.org](https://absinthe-graphql.org).
 
 ### Mix Tasks
 

--- a/guides/introduction/learning.md
+++ b/guides/introduction/learning.md
@@ -8,7 +8,7 @@ The following are some Absinthe-specific educational resources that are availabl
 
 ## Online Resources
 
-* [Website](http://absinthe-graphql.org) (mostly just links elsewhere)
+* [Website](https://absinthe-graphql.org) (mostly just links elsewhere)
 * [Documentation](https://hexdocs.pm/absinthe) (current stable release)
 * [How to GraphQL (with Absinthe)](https://www.howtographql.com/graphql-elixir/0-introduction/)
 
@@ -21,4 +21,4 @@ The following are some Absinthe-specific educational resources that are availabl
 
 There's a ton of GraphQL resources on the web.
 
-The [official website](http://graphql.org/) and [How to GraphQL](https://www.howtographql.com) are good places to start.
+The [official website](https://graphql.org/) and [How to GraphQL](https://www.howtographql.com) are good places to start.

--- a/guides/introduction/overview.md
+++ b/guides/introduction/overview.md
@@ -10,7 +10,7 @@ If you're new to GraphQL, we suggest you read up a bit on GraphQL's foundational
 
 Here are a few resources that might be helpful:
 
-- The official [GraphQL](http://graphql.org/) website
+- The official [GraphQL](https://graphql.org/) website
 - [How to GraphQL](https://www.howtographql.com/), which includes a [brief tutorial](https://www.howtographql.com/graphql-elixir/0-introduction/) using Absinthe
 
 ## Absinthe

--- a/guides/introspection.md
+++ b/guides/introspection.md
@@ -121,7 +121,7 @@ end
 ```
 
 If you'd prefer to use a desktop application, we recommend using the pre-built
-[Electron](http://electron.atom.io)-based wrapper application,
+[Electron](https://electron.atom.io)-based wrapper application,
 [GraphiQL.app](https://github.com/skevy/graphiql-app).
 
 ### GraphQL Hub

--- a/guides/plug-phoenix.md
+++ b/guides/plug-phoenix.md
@@ -100,7 +100,7 @@ With a query string:
 ?query=query+GetItem($id:ID!){item(id:$id){name}}&variables={id:"foo"}
 ```
 
-Due to [varying limits on the maximum size of URLs](http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers),
+Due to [varying limits on the maximum size of URLs](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers),
 we recommend using one of the POST options below instead, putting the `query` into the body of the request.
 
 ### Via an `application/json` POST

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -89,7 +89,7 @@ end
 ```
 
 Phoenix generates the `MyAppWeb.ConnCase` test helper module. This supplies the
-`conn` variable containing the request and response.  It also has helper functions 
+`conn` variable containing the request and response. It also has helper functions 
 such as [`post/3`](https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#post/3)
 and [`json_response/2`](https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#json_response/2).
 

--- a/guides/tutorial/our-first-query.md
+++ b/guides/tutorial/our-first-query.md
@@ -110,7 +110,7 @@ which is where all the domain logic for posts lives, invoking its
 > for [advanced plugins](middleware-and-plugins.md) that further process the data.
 >
 > If you're asking yourself what the implementation of the domain logic looks like, and exactly how
-> the related Ecto schemas are built, read through the code in the [absinthe_tutorial](http://github.com/absinthe-graphql/absinthe_tutorial)
+> the related Ecto schemas are built, read through the code in the [absinthe_tutorial](https://github.com/absinthe-graphql/absinthe_tutorial)
 > repository. The tutorial content here is intentionally focused on the Absinthe-specific code.
 
 Now that we have the functional pieces in place, let's configure our

--- a/guides/tutorial/start.md
+++ b/guides/tutorial/start.md
@@ -7,7 +7,7 @@ Absinthe.
 
 Before you start, it's a good idea to have some background into GraphQL in general. Here are a few resources that might be helpful:
 
-- The official [GraphQL](http://graphql.org/) website
+- The official [GraphQL](https://graphql.org/) website
 - [How to GraphQL](https://www.howtographql.com/) (this includes another [brief tutorial](https://www.howtographql.com/graphql-elixir/0-introduction/) using Absinthe)
 
 ## The Example

--- a/guides/upgrading/v1.4.md
+++ b/guides/upgrading/v1.4.md
@@ -97,7 +97,7 @@ The reason for this is that you can also access the `context` within the `exec` 
 
 ## Calling All Resolvers: The Null Literal Has Arrived
 
-Absinthe now supports [GraphQL `null` literals](http://facebook.github.io/graphql/October2016/#sec-Null-Value).
+Absinthe now supports [GraphQL `null` literals](https://spec.graphql.org/October2016/#sec-Null-Value).
 
 `null` values, when provided as arguments, are passed on to Absinthe resolvers as `nil` (provided they don't run afoul of a `non_null/1` argument constraint).
 

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -3,7 +3,7 @@ defmodule Absinthe do
   Documentation for the Absinthe package, a toolkit for building GraphQL
   APIs with Elixir.
 
-  For usage information, see [the documentation](http://hexdocs.pm/absinthe), which
+  For usage information, see [the documentation](https://hexdocs.pm/absinthe), which
   includes guides, API information for important modules, and links to useful resources.
   """
 

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -790,9 +790,9 @@ defmodule Absinthe.Schema.Notation do
 
   ## Examples
   ```
-  scalar :time, description: "ISOz time" do
-    parse &Timex.parse(&1.value, "{ISOz}")
-    serialize &Timex.format!(&1, "{ISOz}")
+  scalar :isoz_datetime, description: "UTC only ISO8601 date time" do
+    parse &Timex.parse(&1, "{ISO:Extended:Z}")
+    serialize &Timex.format!(&1, "{ISO:Extended:Z}")
   end
   ```
   """

--- a/lib/absinthe/type/built_ins/spec_compliant_int.ex
+++ b/lib/absinthe/type/built_ins/spec_compliant_int.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Type.BuiltIns.SpecCompliantInt do
     description """
     The `Int` scalar type represents non-fractional signed whole numeric
     values between `-2^31` and `2^31 - 1`, as outlined in the
-    [GraphQl spec](ttps://spec.graphql.org/October2021/#sec-Int).
+    [GraphQl spec](https://spec.graphql.org/October2021/#sec-Int).
     """
 
     serialize &__MODULE__.serialize_int/1

--- a/lib/absinthe/type/custom.ex
+++ b/lib/absinthe/type/custom.ex
@@ -61,7 +61,7 @@ defmodule Absinthe.Type.Custom do
     scalar :decimal do
       description """
       The `Decimal` scalar type represents signed double-precision fractional
-      values parsed by the `Decimal` library.  The Decimal appears in a JSON
+      values parsed by the `Decimal` library. The Decimal appears in a JSON
       response as a string to preserve precision.
       """
 

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -19,7 +19,7 @@ defmodule Absinthe.Type.Scalar do
 
   ## Examples
 
-  Supporting a time format in ISOz format, using [Timex](http://hexdocs.pm/timex):
+  Supporting a time format in ISOz format, using [Timex](https://hexdocs.pm/timex):
 
   ```
   scalar :time do

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -19,13 +19,13 @@ defmodule Absinthe.Type.Scalar do
 
   ## Examples
 
-  Supporting a time format in ISOz format, using [Timex](https://hexdocs.pm/timex):
+  Supporting datetime in the ISO8601 format for UTC only, using [Timex](https://hexdocs.pm/timex):
 
   ```
-  scalar :time do
-    description "Time (in ISOz format)"
-    parse &Timex.DateFormat.parse(&1, "{ISOz}")
-    serialize &Timex.DateFormat.format!(&1, "{ISOz}")
+  scalar :isoz_datetime do
+    description "UTC only ISO8601 date time"
+    parse &Timex.parse(&1, "{ISO:Extended:Z}")
+    serialize &Timex.format!(&1, "{ISO:Extended:Z}")
   end
   ```
   """

--- a/mix.exs
+++ b/mix.exs
@@ -152,7 +152,6 @@ defmodule Absinthe.Mixfile do
         Absinthe.Type,
         Absinthe.Type.Custom,
         Absinthe.Type.Argument,
-        Absinthe.Type.Custom,
         Absinthe.Type.Directive,
         Absinthe.Type.Enum,
         Absinthe.Type.Enum.Value,

--- a/test/support/fixtures/fake_definition.graphql
+++ b/test/support/fixtures/fake_definition.graphql
@@ -184,7 +184,7 @@ input fake__options {
   # Only for type `lorem`
   loremSize: fake__loremSize
   # Only for types `*Date`. Example value: `YYYY MM DD`.
-  # [Full Specification](http://momentjs.com/docs/#/displaying/format/)
+  # [Full Specification](https://momentjs.com/docs/#/displaying/format/)
   dateFormat: String
   # Only for type `colorHex`. [Details here](https://stackoverflow.com/a/43235/4989887)
   baseColor: fake__color = { red255: 0, green255: 0, blue255: 0 }


### PR DESCRIPTION
It was raised up by a college of mine that the feature I added a while ago via the PR #1131 had a broken URL in the documentation.
I didn't want to create a PR just to add an `h`, so I went around the documentation and tried to fix/improve a few things:

- 85c5138ddf4f2d8410e8f5daa74c6ffa56052eac Fixed my typo and also found a legacy link in the changelog, updated it to the correct version at the time;
- e4d83b6e2280680558f992e51232a4dded777e9c Updated HTTP links to HTTP**S**. This reduces redirects and avoids having links in the documentation that downgrade the connection to HTTP;
- c652ae8c5954c6e1afb3761fb3a51354f9574704 Removed double spacing;
- d5af25848cedfc0875e12ef4466b089c04a55a60 Timex examples in the documentation were using the old syntax. Updated them to match the latest version (and made a couple naming adjustments);
- 6975b45621f19d5723bc4864ac112f988e7873c8 Removed duplicate module from the documentation index.

Hopefully this will make the documentation better. Please provide your feedback.
