### PR TITLE
Move import_types etc to Absinthe.Schema 

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -180,6 +180,19 @@ defmodule Absinthe.Schema do
   @placement {:query, [toplevel: true, extend: true]}
   @doc """
   Defines a root Query object
+
+  ## Options
+    * `:name` - The name of the root query type. Defaults to `#{@default_query_name}`
+
+  ## Example
+
+  ```elixir
+  query do
+    field :posts, list_of(:post) do
+      resolve &Resolvers.Content.list_posts/3
+    end
+  end
+  ```
   """
   @doc group: :notation
   defmacro query(raw_attrs \\ [name: @default_query_name], do: block) do
@@ -201,7 +214,12 @@ defmodule Absinthe.Schema do
   @doc """
   Defines a root Mutation object
 
-  ```
+  ## Options
+    * `:name` - The name of the root mutation type. Defaults to `#{@default_mutation_name}`
+
+  ## Example
+
+  ```elixir
   mutation do
     field :create_user, :user do
       arg :name, non_null(:string)
@@ -270,7 +288,7 @@ defmodule Absinthe.Schema do
   In your schema you articulate the interests of a subscription via the `config`
   macro:
 
-  ```
+  ```elixir
   subscription do
     field :new_users, :user do
       arg :account_id, non_null(:id)
@@ -284,7 +302,7 @@ defmodule Absinthe.Schema do
   The topic can be any term. You can broadcast a value manually to this subscription
   by doing
 
-  ```
+  ```elixir
   Absinthe.Subscription.publish(pubsub, user, [new_users: user.account_id])
   ```
 
@@ -292,7 +310,7 @@ defmodule Absinthe.Schema do
   for one or more subscriptions, so Absinthe provides some macros to help with
   that too.
 
-  ```
+  ```elixir
   subscription do
     field :new_users, :user do
       arg :account_id, non_null(:id)
@@ -316,6 +334,10 @@ defmodule Absinthe.Schema do
   Note that a subscription field can have `trigger` as many trigger blocks as you
   need, in the event that different groups of mutations return different results
   that require different topic functions.
+
+  ## Options
+    * `:name` - The name of the root subscription type. Defaults to `#{@default_subscription_name}`
+
   """
   @doc group: :notation
   defmacro subscription(raw_attrs \\ [name: @default_subscription_name], do: block) do

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -301,33 +301,6 @@ defmodule Absinthe.Schema.Notation do
     |> record_extend!([], block, [])
   end
 
-  @placement {:schema, [toplevel: true, extend: true]}
-  @doc """
-  Declare a schema
-
-  Optional declaration of the schema. Useful if you want to add directives
-  to your schema declaration
-
-  ## Placement
-
-  #{Utils.placement_docs(@placement)}
-
-  ## Examples
-
-  ```
-  schema do
-    directive :feature
-    field :query, :query
-    # ...
-  end
-  ```
-  """
-  defmacro schema(do: block) do
-    __CALLER__
-    |> recordable!(:schema, @placement[:schema])
-    |> record_schema!(block)
-  end
-
   @placement {:deprecate, [under: [:field]]}
   @doc """
   Mark a field as deprecated
@@ -1382,94 +1355,25 @@ defmodule Absinthe.Schema.Notation do
     put_attr(__CALLER__.module, {:import_fields, {source_criteria, opts}})
   end
 
-  @placement {:import_types, [toplevel: true]}
-  @doc """
-  Import types from another module
-
-  Very frequently your schema module will simply have the `query` and `mutation`
-  blocks, and you'll want to break out your other types into other modules. This
-  macro imports those types for use the current module.
-
-  To selectively import types you can use the `:only` and `:except` opts.
-
-  ## Placement
-
-  #{Utils.placement_docs(@placement)}
-
-  ## Examples
-  ```
-  import_types MyApp.Schema.Types
-
-  import_types MyApp.Schema.Types.{TypesA, TypesB}
-
-  import_types MyApp.Schema.Types, only: [:foo]
-
-  import_types MyApp.Schema.Types, except: [:bar]
-  ```
-  """
-  defmacro import_types(type_module_ast, opts \\ []) do
-    env = __CALLER__
-
-    type_module_ast
-    |> Macro.expand(env)
-    |> do_import_types(env, opts)
+  @doc false
+  defmacro import_types(_type_module_ast, _opts \\ []) do
+    raise Absinthe.Schema.Notation.Error,
+          "Cannot use `import_types` outside of a schema module. " <>
+            "Make sure you are using `use Absinthe.Schema`"
   end
 
-  @placement {:import_directives, [toplevel: true]}
-  @doc """
-  Import directives from another module
-
-  To selectively import directives you can use the `:only` and `:except` opts.
-
-  ## Placement
-  #{Utils.placement_docs(@placement)}
-
-  ## Examples
-  ```
-  import_directives MyApp.Schema.Directives
-
-  import_directives MyApp.Schema.Directives.{DirectivesA, DirectivesB}
-
-  import_directives MyApp.Schema.Directives, only: [:foo]
-
-  import_directives MyApp.Schema.Directives, except: [:bar]
-  ```
-  """
-
-  defmacro import_directives(type_module_ast, opts \\ []) do
-    env = __CALLER__
-
-    type_module_ast
-    |> Macro.expand(env)
-    |> do_import_directives(env, opts)
+  @doc false
+  defmacro import_directives(_type_module_ast, _opts \\ []) do
+    raise Absinthe.Schema.Notation.Error,
+          "Cannot use `import_directives` outside of a schema module. " <>
+            "Make sure you are using `use Absinthe.Schema`"
   end
 
-  @placement {:import_type_extensions, [toplevel: true]}
-  @doc """
-  Import type_extensions from another module
-
-  To selectively import type_extensions you can use the `:only` and `:except` opts.
-
-  ## Placement
-  #{Utils.placement_docs(@placement)}
-
-  ## Examples
-  ```
-  import_type_extensions MyApp.Schema.TypeExtensions
-
-  import_type_extensions MyApp.Schema.TypeExtensions.{TypeExtensionsA, TypeExtensionsB}
-
-  import_type_extensions MyApp.Schema.TypeExtensions, only: [:foo]
-
-  import_type_extensions MyApp.Schema.TypeExtensions, except: [:bar]
-  ```
-  """
-  defmacro import_type_extensions(type_module_ast, opts \\ []) do
-    env = __CALLER__
-
-    type_module_ast
-    |> Macro.expand(env)
-    |> do_import_type_extensions(env, opts)
+  @doc false
+  defmacro import_type_extensions(_type_module_ast, _opts \\ []) do
+    raise Absinthe.Schema.Notation.Error,
+          "Cannot use `import_type_extensions` outside of a schema module. " <>
+            "Make sure you are using `use Absinthe.Schema`"
   end
 
   @placement {:import_sdl, [toplevel: true]}
@@ -1983,142 +1887,6 @@ defmodule Absinthe.Schema.Notation do
     identifier
     |> Atom.to_string()
     |> Absinthe.Utils.camelize()
-  end
-
-  defp do_import_types({{:., _, [{:__MODULE__, _, _}, :{}]}, _, modules_ast_list}, env, opts) do
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([env.module | leaf])
-
-      do_import_types(type_module, env, opts)
-    end
-  end
-
-  defp do_import_types(
-         {{:., _, [{:__aliases__, _, [{:__MODULE__, _, _} | tail]}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    root_module = Module.concat([env.module | tail])
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module | leaf])
-
-      do_import_types(type_module, env, opts)
-    end
-  end
-
-  defp do_import_types({{:., _, [{:__aliases__, _, root}, :{}]}, _, modules_ast_list}, env, opts) do
-    root_module = Module.concat(root)
-    root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module_with_alias | leaf])
-
-      do_import_types(type_module, env, opts)
-    end
-  end
-
-  defp do_import_types(module, env, opts) do
-    Module.put_attribute(env.module, :__absinthe_type_imports__, [
-      {module, opts} | Module.get_attribute(env.module, :__absinthe_type_imports__) || []
-    ])
-
-    []
-  end
-
-  defp do_import_directives({{:., _, [{:__MODULE__, _, _}, :{}]}, _, modules_ast_list}, env, opts) do
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([env.module | leaf])
-
-      do_import_directives(type_module, env, opts)
-    end
-  end
-
-  defp do_import_directives(
-         {{:., _, [{:__aliases__, _, [{:__MODULE__, _, _} | tail]}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    root_module = Module.concat([env.module | tail])
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module | leaf])
-
-      do_import_directives(type_module, env, opts)
-    end
-  end
-
-  defp do_import_directives(
-         {{:., _, [{:__aliases__, _, root}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    root_module = Module.concat(root)
-    root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module_with_alias | leaf])
-
-      do_import_directives(type_module, env, opts)
-    end
-  end
-
-  defp do_import_directives(module, env, opts) do
-    Module.put_attribute(env.module, :__absinthe_directive_imports__, [
-      {module, opts} | Module.get_attribute(env.module, :__absinthe_directive_imports__) || []
-    ])
-
-    []
-  end
-
-  defp do_import_type_extensions(
-         {{:., _, [{:__MODULE__, _, _}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([env.module | leaf])
-
-      do_import_type_extensions(type_module, env, opts)
-    end
-  end
-
-  defp do_import_type_extensions(
-         {{:., _, [{:__aliases__, _, [{:__MODULE__, _, _} | tail]}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    root_module = Module.concat([env.module | tail])
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module | leaf])
-
-      do_import_type_extensions(type_module, env, opts)
-    end
-  end
-
-  defp do_import_type_extensions(
-         {{:., _, [{:__aliases__, _, root}, :{}]}, _, modules_ast_list},
-         env,
-         opts
-       ) do
-    root_module = Module.concat(root)
-    root_module_with_alias = Keyword.get(env.aliases, root_module, root_module)
-
-    for {_, _, leaf} <- modules_ast_list do
-      type_module = Module.concat([root_module_with_alias | leaf])
-
-      do_import_type_extensions(type_module, env, opts)
-    end
-  end
-
-  defp do_import_type_extensions(module, env, opts) do
-    Module.put_attribute(env.module, :__absinthe_type_extension_imports__, [
-      {module, opts}
-      | Module.get_attribute(env.module, :__absinthe_type_extension_imports__) || []
-    ])
-
-    []
   end
 
   @spec do_import_sdl(Macro.Env.t(), nil | String.t() | Macro.t(), [import_sdl_option()]) ::

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -95,6 +95,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `Absinthe.Schema.subscription/1` for details
   """
+  @doc group: :notation
   defmacro config(config_fun) do
     __CALLER__
     |> recordable!(:config, @placement[:config])
@@ -149,6 +150,7 @@ defmodule Absinthe.Schema.Notation do
 
   See the `Absinthe.Schema.subscription/2` macro docs for additional details
   """
+  @doc group: :notation
   defmacro trigger(mutations, attrs) do
     __CALLER__
     |> recordable!(:trigger, @placement[:trigger])
@@ -185,6 +187,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro object(identifier, attrs \\ [], block)
 
   defmacro object(identifier, attrs, do: block) do
@@ -235,6 +238,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro interfaces(ifaces) when is_list(ifaces) do
     __CALLER__
     |> recordable!(:interfaces, @placement[:interfaces])
@@ -274,6 +278,7 @@ defmodule Absinthe.Schema.Notation do
     :scalar,
     :union
   ]
+  @doc group: :notation
   defmacro extend({type, meta, [attr]}, attrs, do: block)
            when type in @extendable_types and is_list(attrs) do
     block = {type, meta, [attr] ++ [[do: block]]}
@@ -293,6 +298,7 @@ defmodule Absinthe.Schema.Notation do
     |> record_extend!([], block, [])
   end
 
+  @doc group: :notation
   defmacro extend({:schema, meta, _}, do: block) do
     block = {:schema, meta, [] ++ [[do: block]]}
 
@@ -331,6 +337,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro deprecate(msg \\ nil) do
     __CALLER__
     |> recordable!(:deprecate, @placement[:deprecate])
@@ -359,6 +366,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro interface(identifier) do
     __CALLER__
     |> recordable!(:interface_attribute, @placement[:interface_attribute])
@@ -393,6 +401,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro interface(identifier, attrs \\ [], do: block) do
     __CALLER__
     |> recordable!(:interface, @placement[:interface])
@@ -425,6 +434,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro resolve_type(func_ast) do
     __CALLER__
     |> recordable!(:resolve_type, @placement[:resolve_type])
@@ -488,7 +498,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `field/4`
   """
-
+  @doc group: :notation
   defmacro field(identifier, attrs) when is_list(attrs) do
     {attrs, block} = handle_field_attrs(attrs, __CALLER__)
 
@@ -510,6 +520,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `field/4`
   """
+  @doc group: :notation
   defmacro field(identifier, attrs, do: block) when is_list(attrs) do
     {attrs, more_block} = handle_field_attrs(attrs, __CALLER__)
     block = more_block ++ List.wrap(block)
@@ -556,6 +567,7 @@ defmodule Absinthe.Schema.Notation do
   field :location, type: :location
   ```
   """
+  @doc group: :notation
   defmacro field(identifier, type, attrs, do: block) do
     attrs = Keyword.put(attrs, :type, type)
     {attrs, more_block} = handle_field_attrs(attrs, __CALLER__)
@@ -637,6 +649,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro resolve(func_ast) do
     __CALLER__
     |> recordable!(:resolve, @placement[:resolve])
@@ -675,6 +688,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro complexity(func_ast) do
     __CALLER__
     |> recordable!(:complexity, @placement[:complexity])
@@ -682,6 +696,7 @@ defmodule Absinthe.Schema.Notation do
   end
 
   @placement {:middleware, [under: [:field]]}
+  @doc group: :notation
   defmacro middleware(new_middleware, opts \\ []) do
     __CALLER__
     |> recordable!(:middleware, @placement[:middleware])
@@ -695,6 +710,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro is_type_of(func_ast) do
     __CALLER__
     |> recordable!(:is_type_of, @placement[:is_type_of])
@@ -720,6 +736,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro arg(identifier, type, attrs) do
     {attrs, block} = handle_arg_attrs(identifier, type, attrs)
 
@@ -733,6 +750,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `arg/3`
   """
+  @doc group: :notation
   defmacro arg(identifier, attrs) when is_list(attrs) do
     {attrs, block} = handle_arg_attrs(identifier, nil, attrs)
 
@@ -769,6 +787,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro scalar(identifier, attrs, do: block) do
     __CALLER__
     |> recordable!(:scalar, @placement[:scalar])
@@ -780,6 +799,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `scalar/3`
   """
+  @doc group: :notation
   defmacro scalar(identifier, do: block) do
     __CALLER__
     |> recordable!(:scalar, @placement[:scalar])
@@ -803,6 +823,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro serialize(func_ast) do
     __CALLER__
     |> recordable!(:serialize, @placement[:serialize])
@@ -824,6 +845,7 @@ defmodule Absinthe.Schema.Notation do
                 ]
               ]}
   @doc false
+  @doc group: :notation
   defmacro private(owner, key, value) do
     __CALLER__
     |> recordable!(:private, @placement[:private])
@@ -859,6 +881,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro meta(key, value) do
     __CALLER__
     |> recordable!(:meta, @placement[:meta])
@@ -899,6 +922,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro meta(keyword_list) do
     __CALLER__
     |> recordable!(:meta, @placement[:meta])
@@ -918,6 +942,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro parse(func_ast) do
     __CALLER__
     |> recordable!(:parse, @placement[:parse])
@@ -999,12 +1024,14 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro directive(identifier, attrs, do: block) when is_list(attrs) when not is_nil(block) do
     __CALLER__
     |> recordable!(:directive, @placement[:directive])
     |> record_directive!(identifier, attrs, block)
   end
 
+  @doc group: :notation
   defmacro directive(identifier, do: block) when not is_nil(block) do
     __CALLER__
     |> recordable!(:directive, @placement[:directive])
@@ -1017,6 +1044,7 @@ defmodule Absinthe.Schema.Notation do
     |> record_applied_directive!(identifier, attrs)
   end
 
+  @doc group: :notation
   defmacro directive(identifier) do
     __CALLER__
     |> recordable!(:directive, @placement[:applied_directive])
@@ -1033,6 +1061,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro on(ast_node) do
     __CALLER__
     |> recordable!(:on, @placement[:on])
@@ -1047,6 +1076,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro expand(func_ast) do
     __CALLER__
     |> recordable!(:expand, @placement[:expand])
@@ -1064,6 +1094,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro repeatable(bool) do
     __CALLER__
     |> recordable!(:repeatable, @placement[:repeatable])
@@ -1089,6 +1120,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro input_object(identifier, attrs \\ [], do: block) do
     __CALLER__
     |> recordable!(:input_object, @placement[:input_object])
@@ -1125,6 +1157,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro union(identifier, attrs \\ [], do: block) do
     __CALLER__
     |> recordable!(:union, @placement[:union])
@@ -1146,6 +1179,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro types(types) do
     __CALLER__
     |> recordable!(:types, @placement[:types])
@@ -1205,6 +1239,7 @@ defmodule Absinthe.Schema.Notation do
   ```
 
   """
+  @doc group: :notation
   defmacro enum(identifier, attrs, do: block) do
     attrs = handle_enum_attrs(attrs, __CALLER__)
 
@@ -1218,6 +1253,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `enum/3`
   """
+  @doc group: :notation
   defmacro enum(identifier, do: block) do
     __CALLER__
     |> recordable!(:enum, @placement[:enum])
@@ -1249,6 +1285,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro value(identifier, raw_attrs \\ []) do
     attrs = expand_ast(raw_attrs, __CALLER__)
 
@@ -1272,6 +1309,7 @@ defmodule Absinthe.Schema.Notation do
 
   #{Utils.placement_docs(@placement)}
   """
+  @doc group: :notation
   defmacro description(text) do
     __CALLER__
     |> recordable!(:description, @placement[:description])
@@ -1284,7 +1322,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `field/3` for examples
   """
-
+  @doc group: :notation
   defmacro non_null({:non_null, _, _}) do
     raise Absinthe.Schema.Notation.Error,
           "Invalid schema notation: `non_null` must not be nested"
@@ -1299,6 +1337,7 @@ defmodule Absinthe.Schema.Notation do
 
   See `field/3` for examples
   """
+  @doc group: :notation
   defmacro list_of(type) do
     %Absinthe.Blueprint.TypeReference.List{of_type: expand_ast(type, __CALLER__)}
   end
@@ -1349,6 +1388,7 @@ defmodule Absinthe.Schema.Notation do
   end
   ```
   """
+  @doc group: :notation
   defmacro import_fields(source_criteria, opts \\ []) do
     source_criteria = expand_ast(source_criteria, __CALLER__)
 
@@ -1413,17 +1453,20 @@ defmodule Absinthe.Schema.Notation do
   TODO: Example for dynamic loading during init
   """
   @spec import_sdl([import_sdl_option(), ...]) :: Macro.t()
+  @doc group: :notation
   defmacro import_sdl(opts) when is_list(opts) do
     __CALLER__
     |> do_import_sdl(nil, opts)
   end
 
   @spec import_sdl(String.t() | Macro.t(), [import_sdl_option()]) :: Macro.t()
+  @doc group: :notation
   defmacro import_sdl(sdl, opts \\ []) do
     __CALLER__
     |> do_import_sdl(sdl, opts)
   end
 
+  @doc group: :notation
   defmacro values(values) do
     __CALLER__
     |> record_values!(values)

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,10 @@ defmodule Absinthe.Mixfile do
         formatters: ["html", "epub"],
         groups_for_modules: groups_for_modules(),
         extras: extras(),
-        groups_for_extras: groups_for_extras()
+        groups_for_extras: groups_for_extras(),
+        groups_for_functions: [
+          Notation: &(&1[:group] == :notation)
+        ]
       ],
       deps: deps(),
       dialyzer: [

--- a/test/absinthe/schema/notation_test.exs
+++ b/test/absinthe/schema/notation_test.exs
@@ -637,6 +637,56 @@ defmodule Absinthe.Schema.NotationTest do
     )
   end
 
+  describe "imports" do
+    test "Cannot use import_types in Absinthe.Schema.Notation module" do
+      message =
+        "Cannot use `import_types` outside of a schema module. Make sure you are using `use Absinthe.Schema`"
+
+      assert_raise(Absinthe.Schema.Notation.Error, message, fn ->
+        """
+        defmodule MyTestSchema.ImportTypesError do
+          use Absinthe.Schema.Notation
+
+          import_types Foo
+        end
+        """
+        |> Code.eval_string([], __ENV__)
+      end)
+    end
+
+    test "Cannot use import_directives in Absinthe.Schema.Notation module" do
+      message =
+        "Cannot use `import_directives` outside of a schema module. Make sure you are using `use Absinthe.Schema`"
+
+      assert_raise(Absinthe.Schema.Notation.Error, message, fn ->
+        """
+        defmodule MyTestSchema.ImportTypesError do
+          use Absinthe.Schema.Notation
+
+          import_directives Foo
+        end
+        """
+        |> Code.eval_string([], __ENV__)
+      end)
+    end
+
+    test "Cannot use import_type_extensions in Absinthe.Schema.Notation module" do
+      message =
+        "Cannot use `import_type_extensions` outside of a schema module. Make sure you are using `use Absinthe.Schema`"
+
+      assert_raise(Absinthe.Schema.Notation.Error, message, fn ->
+        """
+        defmodule MyTestSchema.ImportTypesError do
+          use Absinthe.Schema.Notation
+
+          import_type_extensions Foo
+        end
+        """
+        |> Code.eval_string([], __ENV__)
+      end)
+    end
+  end
+
   defmodule WithFeatureDirective do
     use Absinthe.Schema.Prototype
 


### PR DESCRIPTION
Following a discussion https://elixirforum.com/t/can-you-create-circular-dependancies-when-using-import-types/51620/3
the `import_types` etc. macro's can be confusing as to where they can be placed.

In this PR they are moved to the Absinthe.Schema file so they cannot be used in the type modules. Instead an error is raised when they are used there. Since usage in the type modules was never supported this is a non-breaking change.

The `schema` macro is also moved to Absinthe.Schema, this also does not make sense to use in the type modules.

Furthermore, the `group: :notation` was added to all notation macro's to make it clearer in the docs.

<img width="276" alt="Screenshot 2022-11-08 at 14 23 29" src="https://user-images.githubusercontent.com/54566/200576177-65167a83-8d3e-4e2c-81ef-21e7fcc7dc7b.png">
