### PR TITLE
Fix const parsing of empty lists

### DIFF
--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -178,6 +178,7 @@ ValueConst -> ObjectValueConst :   build_ast_node('ObjectValue',  #{'fields' => 
 
 EnumValue -> Name : extract_binary('$1').
 
+ListValueConst -> '[' ']' : [].
 ListValueConst -> '[' ValuesConst ']' : '$2'.
 ValuesConst -> ValueConst : ['$1'].
 ValuesConst -> ValueConst ValuesConst : ['$1'|'$2'].

--- a/test/absinthe/phase/parse/const_usage_test.exs
+++ b/test/absinthe/phase/parse/const_usage_test.exs
@@ -4,6 +4,18 @@ defmodule Absinthe.Phase.Parse.ConstUsageTest do
   @moduletag :parser
 
   describe "composed constants" do
+    test "list in a constant location can be empty " do
+      result =
+        """
+          schema @feature(name: []){
+            query: Query
+          }
+        """
+        |> run
+
+      assert {:ok, _} = result
+    end
+
     test "list in a constant location cannot contain variables " do
       result =
         """
@@ -181,7 +193,9 @@ defmodule Absinthe.Phase.Parse.ConstUsageTest do
   end
 
   def run(input) do
-    {:error, blueprint} = Absinthe.Phase.Parse.run(input)
-    {:error, blueprint.execution.validation_errors}
+    case Absinthe.Phase.Parse.run(input) do
+      {:error, blueprint} -> {:error, blueprint.execution.validation_errors}
+      {:ok, blueprint} -> {:ok, blueprint}
+    end
   end
 end


### PR DESCRIPTION
An empty list is a valid const value. This fixes the parsing of empty lists.