### PR TITLE
Fix bookkeeping of Resolution path when resolving

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -115,7 +115,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     walk_results(values, bp_node, inner_type, res, [i + 1 | sub_path], [result | acc])
   end
 
-  defp walk_results([], _, _, res = %{path: [_ | sub_path]}, _, acc), do: {:lists.reverse(acc), %{res | path: sub_path}}
+  defp walk_results([], _, _, res = %{path: [_ | sub_path]}, _, acc),
+    do: {:lists.reverse(acc), %{res | path: sub_path}}
 
   defp resolve_fields(parent, res, source, path) do
     # parent is the parent field, we need to get the return type of that field

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -111,11 +111,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   # walk list results
   defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path] = path, acc) do
-    {result, res} = walk_result(value, bp_node, inner_type, res, path)
+    {result, res} = walk_result(value, bp_node, inner_type, %{res | path: path}, path)
     walk_results(values, bp_node, inner_type, res, [i + 1 | sub_path], [result | acc])
   end
 
-  defp walk_results([], _, _, res, _, acc), do: {:lists.reverse(acc), res}
+  defp walk_results([], _, _, res = %{path: [_ | sub_path]}, _, acc), do: {:lists.reverse(acc), %{res | path: sub_path}}
 
   defp resolve_fields(parent, res, source, path) do
     # parent is the parent field, we need to get the return type of that field
@@ -139,7 +139,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
         res = %{res | fields_cache: fields_cache}
 
-        do_resolve_fields(fields, res, source, parent_type, path, [])
+        {values, res} = do_resolve_fields(fields, res, source, parent_type, path, [])
+        {values, %{res | path: path}}
     end
   end
 

--- a/test/absinthe/type/interface_test.exs
+++ b/test/absinthe/type/interface_test.exs
@@ -316,4 +316,129 @@ defmodule Absinthe.Type.InterfaceTest do
   test "resolved type of nested interfaces" do
     assert_data(%{"root" => %{"__typename" => "ZChild"}}, run(@graphql, NestedInterfacesSchema))
   end
+
+  defmodule PrivacyUsingNestedSchema do
+    @moduledoc """
+    Schema in which we return
+    public or private view of collections depending on auth status, and for
+    items depending on collection. PrivateItem will be returned for items in
+    PrivateCollection
+
+    """
+    use Absinthe.Schema
+
+    @data [
+      %{
+        name: "Travel Books",
+        items: [
+          %{title: "To the moon and back", content: "How to build a rocket"},
+          %{title: "Ends of the world", content: "How it looks in the end?"}
+        ]
+      },
+      %{
+        name: "Cuisine",
+        items: [
+          %{title: "Polish soups", content: "All on pomidorowa soup"},
+          %{title: "Only sweets", content: "Carb diet for the win!"}
+        ]
+      }
+    ]
+
+    def data(), do: @data
+
+    query do
+      field :collections, list_of(:collection) do
+        resolve fn _, _, _ ->
+          {:ok, @data}
+        end
+      end
+    end
+
+    interface :collection do
+      description "A collection"
+      field :name, non_null(:string)
+
+      resolve_type fn value, %{context: %{auth: is_auth}} ->
+        if is_auth, do: :private_collection, else: :public_collection
+      end
+    end
+
+    object :public_collection do
+      interface :collection
+      import_fields :collection
+    end
+
+    object :private_collection do
+      interface :collection
+      import_fields :collection
+      field :items, list_of(:item)
+    end
+
+    interface :item do
+      description "An item"
+      field :title, non_null(:string)
+
+      resolve_type fn value, %{path: path} ->
+        assert [
+                 idx,
+                 %{name: "items", parent_type: %{identifier: parent_id}},
+                 outer_idx,
+                 %{name: "collections"} | _
+               ] = path
+
+        assert idx in 0..1
+        assert outer_idx in 0..1
+        assert parent_id == :private_collection
+
+        if parent_id == :private_collection, do: :private_item, else: :public_item
+      end
+    end
+
+    object :public_item do
+      interface :item
+      import_fields :item
+    end
+
+    object :private_item do
+      interface :item
+      import_fields :item
+      field :content, :string
+    end
+  end
+
+  # deep convert keys from atoms to strings - is it available somewhere in library?
+  defp stringify_keys(v) when is_list(v) do
+    Enum.map(v, &stringify_keys/1)
+  end
+
+  defp stringify_keys(v) when is_map(v) do
+    Enum.into(Enum.map(v, fn {k, v} -> {Atom.to_string(k), stringify_keys(v)} end), %{})
+  end
+
+  defp stringify_keys(v) do
+    v
+  end
+
+  @graphql """
+  query books {
+    collections {
+      name
+      ... on PrivateCollection {
+        items {
+          ... on PrivateItem {
+            title content
+          }
+        }
+      }
+    }
+  }
+  """
+  test "Nested interface resolution passes correct data to resolve_type" do
+    stringified_data = stringify_keys(PrivacyUsingNestedSchema.data())
+
+    assert_data(
+      %{"collections" => stringified_data},
+      run(@graphql, PrivacyUsingNestedSchema, context: %{auth: true})
+    )
+  end
 end


### PR DESCRIPTION
Addresses issue #1149 
module `Absinthe.Phase.Document.Execution.Resolution` walks the result tree and tracks `path` using a function parameter. At the same time, a `Resolution` struct is passed, which `path` field is not consistently tracked.

The problem manifests itself in bogus Resolution path passed onto `resolve_type` function as described in function #1149.

The reason for not updating the resolution.path in the walk process can be explained by comment of @benwilson512: `Traditionally the reason we pass in the env has more to do with making the schema available and the context available, I don't know that the other values in that struct have been validated in this situation.` Perhaps path parameter was used in the beginning and later resolution paramter was added, but not used to track current tree walk in it's path field.

Nevertheless, the resolution is passed on to user code - into `resolve_type(value, resolution)` callback, which might use path to understand the context of value (eg. what is the type of parent?).

This PR fixes the bookkeeping of `resolution.path` field. I have not inspected the use of other field, I am not sure which ones would change during the value walk (`parent_type` maybe?).

One could consider to just use `resolution.path` instead of `path` parameter - so there is not double bookkeeping of this value. This is up to maintainers to decide, I did not make such a change.
