### PR TITLE
Limiting token count in parse phase to prevent DoS

### DIFF
--- a/guides/complexity-analysis.md
+++ b/guides/complexity-analysis.md
@@ -121,8 +121,7 @@ calculated and maximum complexities.
 ## Token Limits
 
 To protect a service from invalid queries that could take considerable resources to parse, 
-Absinthe includes a maximum limit on tokens in the GraphQL request document. If the lexer
-encounters more tokens than this, it will stop the parse phase and return a phase error 
-with the message `"Token limit exceeded"`. This limit is 15,000 by default and can be
-overridden by providing the option `token_limit` to `Absinthe.run`. `token_limit` could
-be an integer or `:infinity` for no limit.
+Absinthe offers the option to configure a maximum limit on tokens in the GraphQL request document. 
+If the lexer encounters more tokens than this, it will stop the parse phase and return a phase error 
+with the message `"Token limit exceeded"`. This limit is `:infinity` by default (no limit) 
+and can be overridden by providing an integer to the option `token_limit` to `Absinthe.run`.

--- a/guides/complexity-analysis.md
+++ b/guides/complexity-analysis.md
@@ -1,11 +1,12 @@
-# Complexity Analysis and Token Limits
+# Safety Limits
 
 A misbehaving client might send a very complex GraphQL query that would require
 considerable resources to handle. There are two variations of this problem:
 
-- Complex queries that overwhelm resolution resources
-- Long, invalid queries that could take considerable resources to parse, even if 
-the response is only validation errors.
+- Complex queries that overwhelm resolution resources.
+- Extremely long queries that could take considerable resources to parse. 
+(For example, an attacker could craft a long query including thousands of 
+undefined fields or directives.)
 
 Either of these could be a vector for a denial-of-service attack in any GraphQL 
 service. Absinthe includes mechanisms to protect services each of these.

--- a/guides/complexity-analysis.md
+++ b/guides/complexity-analysis.md
@@ -122,6 +122,6 @@ calculated and maximum complexities.
 To protect a service from invalid queries that could take considerable resources to parse, 
 Absinthe includes a maximum limit on tokens in the GraphQL request document. If the lexer
 encounters more tokens than this, it will stop the parse phase and return a phase error 
-with the message `"Token limit exceeded"`. This limit is 10,000 by default and can be
+with the message `"Token limit exceeded"`. This limit is 15,000 by default and can be
 overridden by providing the option `token_limit` to `Absinthe.run`. `token_limit` could
 be an integer or `:infinity` for no limit.

--- a/guides/complexity-analysis.md
+++ b/guides/complexity-analysis.md
@@ -1,7 +1,18 @@
-# Complexity Analysis
+# Complexity Analysis and Token Limits
 
 A misbehaving client might send a very complex GraphQL query that would require
-considerable resources to handle. In order to protect against this scenario, the
+considerable resources to handle. There are two variations of this problem:
+
+- Complex queries that overwhelm resolution resources
+- Long, invalid queries that could take considerable resources to parse, even if 
+the response is only validation errors.
+
+Either of these could be a vector for a denial-of-service attack in any GraphQL 
+service. Absinthe includes mechanisms to protect services each of these.
+
+## Complexity Analysis
+
+In order to protect against queries that could overwhel scenario, the
 complexity of a query can be estimated before it is resolved and limited to a
 specified maximum.
 
@@ -105,3 +116,12 @@ But this, at a complexity of `60`, wouldn't:
 If a document's calculated complexity exceeds the configured limit, resolution
 will be skipped and an error will be returned in the result detailing the
 calculated and maximum complexities.
+
+## Token Limits
+
+To protect a service from invalid queries that could take considerable resources to parse, 
+Absinthe includes a maximum limit on tokens in the GraphQL request document. If the lexer
+encounters more tokens than this, it will stop the parse phase and return a phase error 
+with the message `"Token limit exceeded"`. This limit is 10,000 by default and can be
+overridden by providing the option `token_limit` to `Absinthe.run`. `token_limit` could
+be an integer or `:infinity` for no limit.

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -347,7 +347,7 @@ defmodule Absinthe.Lexer do
     {rest, [{:name, line_and_column(loc, byte_offset, length(value)), value}], context}
   end
 
-  defp labeled_token(_, _, %{token_count: count, token_limit: limit} = _context, _, _)
+  defp labeled_token(_, _, %{token_count: count, token_limit: limit} = _context, _, _, _)
        when count >= limit,
        do: {:error, :stopped_at_token_limit}
 

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -227,8 +227,8 @@ defmodule Absinthe.Lexer do
     {:cont, context}
   end
 
-  @spec tokenize(binary(), Map.t()) :: {:ok, [any()]} | {:error, binary(), {integer(), non_neg_integer()}}
-  def tokenize(input, options \\ %{}) do
+  @spec tokenize(binary(), Keyword.t()) :: {:ok, [any()]} | {:error, binary(), {integer(), non_neg_integer()}}
+  def tokenize(input, options \\ []) do
     lines = String.split(input, ~r/\r?\n/)
 
     case do_tokenize(input) do
@@ -241,8 +241,8 @@ defmodule Absinthe.Lexer do
   end
 
   defp check_limit_and_process_tokens(tokens, options, lines) do
-    limit = Map.get(options, :token_limit, 15_000)
-    if Enum.count(tokens) > limit do
+    limit = Keyword.get(options, :token_limit, 15_000)
+    if length(tokens) > limit do
       {:error, :exceeded_token_limit}
     else
       tokens = Enum.map(tokens, &convert_token_column(&1, lines))

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -227,13 +227,15 @@ defmodule Absinthe.Lexer do
     {:cont, context}
   end
 
-  @spec tokenize(binary(), Keyword.t()) :: {:ok, [any()]} | {:error, binary(), {integer(), non_neg_integer()}}
+  @spec tokenize(binary(), Keyword.t()) ::
+          {:ok, [any()]} | {:error, binary(), {integer(), non_neg_integer()}}
   def tokenize(input, options \\ []) do
     lines = String.split(input, ~r/\r?\n/)
 
     case do_tokenize(input) do
       {:ok, tokens, "", _, _, _} ->
         check_limit_and_process_tokens(tokens, options, lines)
+
       {:ok, _, rest, _, {line, line_offset}, byte_offset} ->
         byte_column = byte_offset - line_offset + 1
         {:error, rest, byte_loc_to_char_loc({line, byte_column}, lines)}
@@ -242,6 +244,7 @@ defmodule Absinthe.Lexer do
 
   defp check_limit_and_process_tokens(tokens, options, lines) do
     limit = Keyword.get(options, :token_limit, 15_000)
+
     if length(tokens) > limit do
       {:error, :exceeded_token_limit}
     else

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -232,7 +232,7 @@ defmodule Absinthe.Lexer do
   def tokenize(input, options \\ []) do
     lines = String.split(input, ~r/\r?\n/)
 
-    tokenize_opts = [context: %{token_limit: Keyword.get(options, :token_limit, 15_000)}]
+    tokenize_opts = [context: %{token_limit: Keyword.get(options, :token_limit, :infinity)}]
 
     case do_tokenize(input, tokenize_opts) do
       {:error, :stopped_at_token_limit, _, _, _, _} ->

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -42,7 +42,6 @@ defmodule Absinthe.Lexer do
   comment =
     string("#")
     |> repeat_while(any_unicode, {:not_line_terminator, []})
-    |> post_traverse({:check_token_limit, []})
 
   # Comma :: ,
   comma = ascii_char([?,])
@@ -271,7 +270,6 @@ defmodule Absinthe.Lexer do
     repeat(
       choice([
         ignore(ignored),
-        comment,
         punctuator,
         block_string_value,
         string_value,
@@ -400,15 +398,6 @@ defmodule Absinthe.Lexer do
     token_atom = value |> List.to_atom()
 
     {rest, [{token_atom, line_and_column(loc, byte_offset, length(value))}], context}
-  end
-
-  defp check_token_limit(_, _, %{token_count: count, token_limit: limit} = _context, _, _)
-       when count >= limit,
-       do: {:error, :stopped_at_token_limit}
-
-  defp check_token_limit(rest, chars, context, _loc, _byte_offset) do
-    context = Map.update(context, :token_count, 1, &(&1 + 1))
-    {rest, [chars], context}
   end
 
   def line_and_column({line, line_offset}, byte_offset, column_correction) do

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -241,7 +241,7 @@ defmodule Absinthe.Lexer do
   end
 
   defp check_limit_and_process_tokens(tokens, options, lines) do
-    limit = Map.get(options, :token_limit, 2000)
+    limit = Map.get(options, :token_limit, 15_000)
     if Enum.count(tokens) > limit do
       {:error, :exceeded_token_limit}
     else

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -12,8 +12,6 @@ defmodule Absinthe.Phase.Parse do
   def run(input, options \\ [])
 
   def run(%Absinthe.Blueprint{} = blueprint, options) do
-    options = Map.new(options)
-
     case parse(blueprint.input, options) do
       {:ok, value} ->
         {:ok, %{blueprint | input: value}}
@@ -21,7 +19,7 @@ defmodule Absinthe.Phase.Parse do
       {:error, error} ->
         blueprint
         |> add_validation_error(error)
-        |> handle_error(options)
+        |> handle_error(Map.new(options))
     end
   end
 
@@ -44,8 +42,8 @@ defmodule Absinthe.Phase.Parse do
     {:error, blueprint}
   end
 
-  @spec tokenize(binary, Map.t()) :: {:ok, [tuple]} | {:error, String.t()}
-  def tokenize(input, options \\ %{}) do
+  @spec tokenize(binary, Keyword.t()) :: {:ok, [tuple]} | {:error, String.t()}
+  def tokenize(input, options \\ []) do
     case Absinthe.Lexer.tokenize(input, options) do
       {:error, rest, loc} ->
         {:error, format_raw_parse_error({:lexer, rest, loc})}

--- a/lib/absinthe/phase/parse.ex
+++ b/lib/absinthe/phase/parse.ex
@@ -59,7 +59,8 @@ defmodule Absinthe.Phase.Parse do
   # This is because Dialyzer is telling us tokenizing can never fail,
   # but we know it's possible.
   @dialyzer {:no_match, parse: 2}
-  @spec parse(binary | Language.Source.t(), Map.t()) :: {:ok, Language.Document.t()} | {:error, tuple}
+  @spec parse(binary | Language.Source.t(), Map.t()) ::
+          {:ok, Language.Document.t()} | {:error, tuple}
   defp parse(input, options) when is_binary(input) do
     parse(%Language.Source{body: input}, options)
   end

--- a/test/absinthe/integration/execution/token_limit_enforcement.exs
+++ b/test/absinthe/integration/execution/token_limit_enforcement.exs
@@ -1,0 +1,13 @@
+defmodule Elixir.Absinthe.Integration.Execution.TokenLimitEnforcement do
+    use Absinthe.Case, async: true
+
+    @query """
+    {
+      __typename @a @b @c @d @e
+    }
+    """
+    test "Token limit lexer enforcement" do
+      assert {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
+        Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, [token_limit: 4])
+    end
+  end

--- a/test/absinthe/integration/execution/token_limit_enforcement.exs
+++ b/test/absinthe/integration/execution/token_limit_enforcement.exs
@@ -1,13 +1,13 @@
 defmodule Elixir.Absinthe.Integration.Execution.TokenLimitEnforcement do
-    use Absinthe.Case, async: true
+  use Absinthe.Case, async: true
 
-    @query """
-    {
-      __typename @a @b @c @d @e
-    }
-    """
-    test "Token limit lexer enforcement" do
-      assert {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
-        Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, [token_limit: 4])
-    end
+  @query """
+  {
+    __typename @a @b @c @d @e
+  }
+  """
+  test "Token limit lexer enforcement" do
+    assert {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
+             Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 4)
   end
+end

--- a/test/absinthe/integration/execution/token_limit_enforcement.exs
+++ b/test/absinthe/integration/execution/token_limit_enforcement.exs
@@ -1,13 +1,41 @@
 defmodule Elixir.Absinthe.Integration.Execution.TokenLimitEnforcement do
   use Absinthe.Case, async: true
 
-  @query """
-  {
-    __typename @a @b @c @d @e
-  }
-  """
-  test "Token limit lexer enforcement" do
+  test "Token limit lexer enforcement is precise" do
+    query = """
+    {
+      __typename @a @b @c @d @e
+    }
+    """
+
     assert {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
-             Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 4)
+             Absinthe.run(query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 12)
+
+    refute {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
+             Absinthe.run(query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 13)
+
+    query = """
+    {
+      test(arg1: false, arg2: ["hi \u1F600", "hello", null], arg3: 3.14) {
+        results {
+          id #it's a guid
+          name @fakedirective
+
+          ... on SomeType {
+            some\u0046ield #should expand to someField without an extra token
+          }
+        }
+      }
+    }
+    """
+
+    # token count 33 = 8 braces + 2 parens + 2 brackets + 2 string values + 1 null + 1 float + 1 bool +
+    # 3 colons + 1 ... + 1 on + 0 ignroed comment + 1@ + 1 directive + 9 names
+
+    assert {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
+             Absinthe.run(query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 32)
+
+    refute {:ok, %{errors: [%{message: "Token limit exceeded"}]}} ==
+             Absinthe.run(query, Absinthe.Fixtures.Things.MacroSchema, token_limit: 33)
   end
 end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -94,4 +94,19 @@ defmodule Absinthe.LexerTest do
               {:"}", {7, 1}}
             ]} == Absinthe.Lexer.tokenize(@query)
   end
+
+  test "document with tokens exceeding limit" do
+    assert {:error, :exceeded_token_limit} == Absinthe.Lexer.tokenize(too_long_query())
+  end
+
+  defp too_long_query do
+    Enum.to_list(for n <- 1..10000, do: "test#{n}")
+    |> deep_query()
+  end
+
+  defp deep_query([]), do: ""
+  defp deep_query([field | rest]) do
+    "{ #{field} #{deep_query(rest)} }"
+  end
+
 end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -105,8 +105,8 @@ defmodule Absinthe.LexerTest do
   end
 
   defp deep_query([]), do: ""
+
   defp deep_query([field | rest]) do
     "{ #{field} #{deep_query(rest)} }"
   end
-
 end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -106,7 +106,13 @@ defmodule Absinthe.LexerTest do
   end
 
   test "document with tokens exceeding limit" do
-    assert {:error, :exceeded_token_limit} == Absinthe.Lexer.tokenize(too_long_query())
+    query = too_long_query()
+
+    assert {:error, :exceeded_token_limit} ==
+             Absinthe.Lexer.tokenize(query, token_limit: 15_000)
+
+    refute {:error, :exceeded_token_limit} ==
+             Absinthe.Lexer.tokenize(query)
   end
 
   defp too_long_query do


### PR DESCRIPTION
Hi! I'm opening this PR to start a conversation about how best to address this vulnerability that could lead to a denial-of-service attack.

An attacker could craft a very long query (which doesn't need to be valid), mentioning thousands of undefined or real fields or directives, which could require a lot of resources to parse. [This same vulnerability was identified and fixed in graphql-java last year](https://github.com/graphql-java/graphql-java/pull/2549).

I saw in my benchmarking that Absinthe will spend a long time in the parse phase for such queries. The lexer's tokenization and the parser themselves are quite performant even on very long queries, but the lexer has an extra step, `convert_token_column`, that processes line number information (for error reporting later?) This routine is O(n^2) and performs poorly for long, single-line queries.

[Here is a sample app I made to demonstrate the issue with Absinthe 1.7.0](https://github.com/stellanor/absinthe_parser_perf_demo)

My Absinthe PR adds a safety check after the lexer tokenizes but before performing `convert_token_column`. The limit is, of course, configurable, with a default.

I don't intend for this to be merged as-is without discussion. I am seeking input on the following:
- The change itself, of course
- What the default token limit should be. This is a tradeoff between safety by default and making a breaking change. I chose a default limit of 15,000 to start the discussion, since [this is what graphql-java chose](https://github.com/graphql-java/graphql-java/pull/2549/files#diff-cc1fab9887f0cf77d8caf9afdf45a006206cf0a572a09b1c4992af7c06ce53f6R23). However, in my tests, it still took over 30 seconds to parse a 15k token single-line query, so we may want to discuss a lower limit.
- The error message used in the phase error when this limit is enforced (I chose a concise error message; should we consider something that is more verbose? I did mention the exact error string in the docs so that someone googling it should find it).
- The documentation: I folded a new section into the existing complexity analysis guide page, but I'm open to making this its own page.
- Coordinating this change with absinthe_plug ([I'm concerned about this file and its docs](https://github.com/absinthe-graphql/absinthe_plug/blob/624696372cdcf72f4cff5ddd8a6bb2f1c89de9df/lib/absinthe/plug.ex#L127))
 
As a separate change, I am also curious about the possibility of managing the line/column attribution differently. Could this somehow be delayed and only performed during error rendering? Perhaps the number of validation errors returned can also be limited? I haven't explored this possibility yet or whether that's even within spec. I'm unlikely to have time to work on that anytime soon, but I wanted to throw the idea out.

My change was pre-reviewed by my colleague @mattbaker . Given the potentially sensitive nature of this, I tried to reach out to @benwilson512 on the Elixir slack last week but we realized Ben's not active there, so we decided to proceed with opening the PR.

Thank you! Any feedback, ideas, or questions are welcome.
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
