### PR TITLE
allow changing result phase for subscriptions

### DIFF
--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -3,6 +3,48 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
   import ExUnit.CaptureLog
 
+  defmodule ResultPase do
+    @moduledoc false
+
+    alias Absinthe.Blueprint
+    use Absinthe.Phase
+
+    def run(%Blueprint{} = bp, _options \\ []) do
+      result = Map.merge(bp.result, process(bp))
+      {:ok, %{bp | result: result}}
+    end
+
+    defp process(blueprint) do
+      data = data(blueprint.execution.result)
+      %{data: data}
+    end
+
+    defp data(%{value: value}), do: value
+
+    defp data(%{fields: []} = result) do
+      result.root_value
+    end
+
+    defp data(%{fields: fields, emitter: emitter, root_value: root_value}) do
+      with %{put: _} <- emitter.flags,
+           true <- is_map(root_value) do
+        data = field_data(fields)
+        Map.merge(root_value, data)
+      else
+        _ ->
+          field_data(fields)
+      end
+    end
+
+    defp field_data(fields, acc \\ [])
+    defp field_data([], acc), do: Map.new(acc)
+
+    defp field_data([field | fields], acc) do
+      value = data(field)
+      field_data(fields, [{String.to_existing_atom(field.emitter.name), value} | acc])
+    end
+  end
+
   defmodule PubSub do
     @behaviour Absinthe.Subscription.Pubsub
 
@@ -148,6 +190,34 @@ defmodule Absinthe.Execution.SubscriptionTest do
     {:ok, _} = PubSub.start_link()
     {:ok, _} = Absinthe.Subscription.start_link(PubSub)
     :ok
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    thing(clientId: $clientId)
+  }
+  """
+  test "should use result_phase from main pipeline" do
+    client_id = "abc"
+
+    assert {:ok, %{"subscribed" => topic}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{"clientId" => client_id},
+               context: %{pubsub: PubSub},
+               result_phase: ResultPase
+             )
+
+    Absinthe.Subscription.publish(PubSub, %{foo: "bar"}, thing: client_id)
+
+    assert_receive({:broadcast, msg})
+
+    assert %{
+             event: "subscription:data",
+             result: %{data: %{thing: %{foo: "bar"}}},
+             topic: topic
+           } == msg
   end
 
   @query """


### PR DESCRIPTION
This PR will respect the `result_phase` from the pipeline for subscription resolution. 

An example of using `Absinthe.Phoenix.Controller.Result` as the result phase will allow using atoms as keys and returning structs 
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
