### PR TITLE
Allow passthrough of opts to pipeline modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug Fix: [Validate type references for invalid wrapped types](https://github.com/absinthe-graphql/absinthe/pull/1195)
 - Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)
 - Bug Fix: Adds **optional fix** for non compliant built-in scalar Int type. `use Absinthe.Schema, use_spec_compliant_int_scalar: true` in your schema to use the fixed Int type. It is also advisable to upgrade for custom types if you are leveraging the use of integers outside the GraphQl standard. [#1131](https://github.com/absinthe-graphql/absinthe/pull/1131).
+- Feature: [Support custom opts in schema pipeline modifiers](https://github.com/absinthe-graphql/absinthe/pull/1214)
 - Feature: [Support error tuples when scalar parsing fails](https://github.com/absinthe-graphql/absinthe/pull/1187)
 - Feature: [Convert SDL Language.\* structs to SDL notation](https://github.com/absinthe-graphql/absinthe/pull/1160)
 - Feature: [Support passing the resolution struct to dataloader helper callbacks](https://github.com/absinthe-graphql/absinthe/pull/1211)

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -284,4 +284,36 @@ defmodule Absinthe.Schema.SdlRenderTest do
              }
              """
   end
+
+  defmodule TestModifier do
+    def pipeline(pipeline, opts) do
+      send(self(), type: :module, opts: opts)
+      pipeline
+    end
+  end
+
+  defmodule ModifiedTestSchema do
+    use Absinthe.Schema
+
+    def custom_pipeline(pipeline, opts) do
+      send(self(), type: :function, opts: opts)
+      pipeline
+    end
+
+    @pipeline_modifier TestModifier
+    @pipeline_modifier {__MODULE__, :custom_pipeline}
+
+    @sdl """
+    type Query {
+      echo: String
+    }
+    """
+    import_sdl @sdl
+  end
+
+  test "Render SDL takes opts" do
+    Absinthe.Schema.to_sdl(ModifiedTestSchema, sdl_render: true)
+    assert_received type: :function, opts: [sdl_render: true]
+    assert_received type: :module, opts: [sdl_render: true]
+  end
 end


### PR DESCRIPTION
This can be used to e.g. pass through options to custom schema
phases in SDL rendering, to change the schema just before rendering it.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
