### PR TITLE
Place extra errors in extensions field

### DIFF
--- a/test/absinthe/integration/execution/resolution/extra_error_fields_test.exs
+++ b/test/absinthe/integration/execution/resolution/extra_error_fields_test.exs
@@ -1,11 +1,13 @@
 defmodule Elixir.Absinthe.Integration.Execution.Resolution.ExtraErrorFieldsTest do
   use Absinthe.Case, async: true
+  alias Absinthe.Pipeline
+  alias Absinthe.Phase
 
   @query """
   mutation { failingThing(type: WITH_CODE) { name } }
   """
 
-  test "scenario #1" do
+  test "extra fields places in errors list" do
     assert {:ok,
             %{
               data: %{"failingThing" => nil},
@@ -18,5 +20,52 @@ defmodule Elixir.Absinthe.Integration.Execution.Resolution.ExtraErrorFieldsTest 
                 }
               ]
             }} == Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema, [])
+  end
+
+  test "extra fields placed in extensions" do
+    pipeline =
+      Pipeline.for_document(Absinthe.Fixtures.Things.MacroSchema)
+      |> Pipeline.replace(
+        Phase.Document.Result,
+        {Phase.Document.Result, spec_compliant_errors: true}
+      )
+
+    assert {:ok,
+            %{
+              result: %{
+                data: %{"failingThing" => nil},
+                errors: [
+                  %{
+                    message: "Custom Error",
+                    path: ["failingThing"],
+                    locations: [%{column: 12, line: 1}],
+                    extensions: %{code: 42}
+                  }
+                ]
+              }
+            }, _} = Pipeline.run(@query, pipeline)
+  end
+
+  @query """
+  mutation { failingThing(type: MULTIPLE) { name } }
+  """
+  test "when no extra fields, extensions field is omitted" do
+    pipeline =
+      Pipeline.for_document(Absinthe.Fixtures.Things.MacroSchema)
+      |> Pipeline.replace(
+        Phase.Document.Result,
+        {Phase.Document.Result, spec_compliant_errors: true}
+      )
+
+    assert {:ok,
+            %{
+              result: %{
+                data: %{"failingThing" => nil},
+                errors: [
+                  %{locations: [%{column: 12, line: 1}], message: "one", path: ["failingThing"]},
+                  %{locations: [%{column: 12, line: 1}], message: "two", path: ["failingThing"]}
+                ]
+              }
+            }, _} = Pipeline.run(@query, pipeline)
   end
 end


### PR DESCRIPTION
As per the spec (https://spec.graphql.org/October2021/#sec-Errors.Error-result-format) any extra errors are now placed in the `extensions` field. 

This only happens when the `spec_compliant_errors` opt is set to true. As this is a breaking change and some clients may relay on the current behaviour it is opt in. With Absinthe 2.0 we can switch this around and make the spec compliant behaviour opt-out and the legacy behaviour opt-in. 

Fixes https://github.com/absinthe-graphql/absinthe/issues/925