### PR TITLE
Allow configurable docset runner for subscription documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Feature: [Configurable docset runner for subscription documents](https://github.com/absinthe-graphql/absinthe/pull/1218)
 - Bug Fix: [Validate field identifier uniqueness](https://github.com/absinthe-graphql/absinthe/pull/1200)
 - Bug Fix: [Validate type references for invalid wrapped types](https://github.com/absinthe-graphql/absinthe/pull/1195)
 - Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)

--- a/lib/absinthe/subscription/docset_runner.ex
+++ b/lib/absinthe/subscription/docset_runner.ex
@@ -1,0 +1,12 @@
+defmodule Absinthe.Subscription.DocSetRunner do
+  @moduledoc """
+  Behaviour on how to run a set of documents
+  for a subscription.
+  """
+
+  @callback run(
+              pubsub :: Absinthe.Subscription.Pubsub.t(),
+              docs_and_topics :: [Absinthe.Subscription.Document.t()],
+              mutation_result :: term
+            ) :: term
+end

--- a/lib/absinthe/subscription/docset_runner/simple.ex
+++ b/lib/absinthe/subscription/docset_runner/simple.ex
@@ -1,0 +1,40 @@
+defmodule Absinthe.Subscription.DocSetRunner.Simple do
+  @moduledoc """
+  Default runner for subscription docs
+
+  This runner will iterate over the subscription docs and run them sequentially.
+  It is run in inside of a mutation, so it will block the mutation response
+  until all subscription docs have been run, giving a form of back pressure.
+
+  Furthermore, no batching takes place between the documents. If document A
+  queries the database for some data, and document B queries the database for
+  the same data, then the database will be queried twice.
+  """
+  @behaviour Absinthe.Subscription.DocSetRunner
+  require Logger
+
+  alias Absinthe.Pipeline.BatchResolver
+  alias Absinthe.Pipeline
+  alias Absinthe.Subscription
+
+  def run(pubsub, subscription_docs, mutation_result) do
+    for subscription_doc <- subscription_docs do
+      try do
+        pipeline = Subscription.Document.pipeline(subscription_doc, root_value: mutation_result)
+        {:ok, %{result: data}, _} = Pipeline.run(subscription_doc.source, pipeline)
+
+        Logger.debug("""
+        Absinthe Subscription Publication
+        Field Topic: #{inspect(subscription_doc.key_strategy)}
+        Subscription id: #{inspect(subscription_doc.topic)}
+        Data: #{inspect(data)}
+        """)
+
+        :ok = pubsub.publish_subscription(subscription_doc.topic, data)
+      rescue
+        e ->
+          BatchResolver.pipeline_error(e, __STACKTRACE__)
+      end
+    end
+  end
+end

--- a/lib/absinthe/subscription/document.ex
+++ b/lib/absinthe/subscription/document.ex
@@ -1,0 +1,39 @@
+defmodule Absinthe.Subscription.Document do
+  @moduledoc """
+  A subscription document that is ready to be executed.
+  """
+  alias Absinthe.Pipeline
+  alias Absinthe.Phase
+
+  defstruct [:topic, :key_strategy, :field, :initial_phases, :source, __private__: []]
+
+  @type t :: %__MODULE__{
+    topic: atom(),
+    field: atom(),
+    key_strategy: term | (term -> term),
+    initial_phases: [Phase.t()],
+    source: String.t(),
+    __private__: Keyword.t()
+  }
+
+  @doc false
+  def pipeline(document, options) do
+    pipeline =
+      document.initial_phases
+      |> Pipeline.replace(
+        Phase.Telemetry,
+        {Phase.Telemetry, event: [:subscription, :publish, :start]}
+      )
+      |> Pipeline.without(Phase.Subscription.SubscribeSelf)
+      |> Pipeline.insert_before(
+        Phase.Document.Execution.Resolution,
+        {Phase.Document.OverrideRoot, options}
+      )
+      |> Pipeline.upto(Phase.Document.Execution.Resolution)
+
+    [
+      pipeline,
+      [Phase.Document.Result, {Phase.Telemetry, event: [:subscription, :publish, :stop]}]
+    ]
+  end
+end

--- a/lib/absinthe/subscription/document.ex
+++ b/lib/absinthe/subscription/document.ex
@@ -8,13 +8,13 @@ defmodule Absinthe.Subscription.Document do
   defstruct [:topic, :key_strategy, :field, :initial_phases, :source, __private__: []]
 
   @type t :: %__MODULE__{
-    topic: atom(),
-    field: atom(),
-    key_strategy: term | (term -> term),
-    initial_phases: [Phase.t()],
-    source: String.t(),
-    __private__: Keyword.t()
-  }
+          topic: atom(),
+          field: atom(),
+          key_strategy: term | (term -> term),
+          initial_phases: [Phase.t()],
+          source: String.t(),
+          __private__: Keyword.t()
+        }
 
   @doc false
   def pipeline(document, options) do

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -3,13 +3,9 @@ defmodule Absinthe.Subscription.Local do
   This module handles broadcasting documents that are local to this node
   """
 
-  require Logger
-
-  alias Absinthe.Pipeline.BatchResolver
-
-  # This module handles running and broadcasting documents that are local to this
-  # node.
-
+  @default_opts [
+    docset_runner: Absinthe.Subscription.DocSetRunner.Simple
+  ]
   @doc """
   Publish a mutation to the local node only.
 
@@ -20,59 +16,27 @@ defmodule Absinthe.Subscription.Local do
           term,
           [Absinthe.Subscription.subscription_field_spec()]
         ) :: :ok
-  def publish_mutation(pubsub, mutation_result, subscribed_fields) do
-    docs_and_topics =
+  def publish_mutation(
+        pubsub,
+        mutation_result,
+        subscribed_fields,
+        opts \\ @default_opts
+      ) do
+    doc_topics =
       for {field, key_strategy} <- subscribed_fields,
           {topic, doc} <- get_docs(pubsub, field, mutation_result, key_strategy) do
-        {topic, key_strategy, doc}
+        %Absinthe.Subscription.Document{
+          topic: topic,
+          field: field,
+          key_strategy: key_strategy,
+          initial_phases: doc.initial_phases,
+          source: doc.source
+        }
       end
 
-    run_docset(pubsub, docs_and_topics, mutation_result)
+    opts[:docset_runner].run(pubsub, doc_topics, mutation_result)
 
     :ok
-  end
-
-  alias Absinthe.{Phase, Pipeline}
-
-  defp run_docset(pubsub, docs_and_topics, mutation_result) do
-    for {topic, key_strategy, doc} <- docs_and_topics do
-      try do
-        pipeline =
-          doc.initial_phases
-          |> Pipeline.replace(
-            Phase.Telemetry,
-            {Phase.Telemetry, event: [:subscription, :publish, :start]}
-          )
-          |> Pipeline.without(Phase.Subscription.SubscribeSelf)
-          |> Pipeline.insert_before(
-            Phase.Document.Execution.Resolution,
-            {Phase.Document.OverrideRoot, root_value: mutation_result}
-          )
-          |> Pipeline.upto(Phase.Document.Execution.Resolution)
-
-        pipeline = [
-          pipeline,
-          [
-            Absinthe.Phase.Document.Result,
-            {Absinthe.Phase.Telemetry, event: [:subscription, :publish, :stop]}
-          ]
-        ]
-
-        {:ok, %{result: data}, _} = Absinthe.Pipeline.run(doc.source, pipeline)
-
-        Logger.debug("""
-        Absinthe Subscription Publication
-        Field Topic: #{inspect(key_strategy)}
-        Subscription id: #{inspect(topic)}
-        Data: #{inspect(data)}
-        """)
-
-        :ok = pubsub.publish_subscription(topic, data)
-      rescue
-        e ->
-          BatchResolver.pipeline_error(e, __STACKTRACE__)
-      end
-    end
   end
 
   defp get_docs(pubsub, field, mutation_result, topic: topic_fun)


### PR DESCRIPTION
As the docs mention, currently when subscription documents are run
it provides a simple form of back pressure due to it blocking the mutation.
Furthermore there is no batching across subscriptions.

This PR gives the ability to configure a docset runner by implementing
the Absinthe.Subscription.DocSetRunner behaviour.

A custom runner could be implemented to provide batching,
or to provide a different form of back pressure. Both of these
are useful for scaling out subscriptions. They can also both be highly
specific to the project and so it makes sense to allow them to be configured.
Furthermore, it also gives the opportunity to adjust the pipeline
for subscription documents just before execution.

I've changed the docset runner to accept a struct instead of a tuple,
as it makes it easier to add new options in the future.

The default is the same as before, a simple runner that runs the docset
and blocks the mutation.