### PR TITLE
Propagate errors if a non-null list of non-null elements contains a null

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -283,6 +283,15 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> propagate_null_trimming
   end
 
+  defp maybe_add_non_null_error([], values, %Type.NonNull{of_type: %Type.List{}}) do
+    values
+    |> Enum.with_index()
+    |> Enum.filter(&is_nil(elem(&1, 0)))
+    |> Enum.map(fn {_value, index} ->
+      %{message: "Cannot return null for non-nullable field", path: [index]}
+    end)
+  end
+
   defp maybe_add_non_null_error([], nil, %Type.NonNull{}) do
     ["Cannot return null for non-nullable field"]
   end
@@ -312,11 +321,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
       nil
       |> to_result(bp_field, full_type, node.extensions)
-      |> Map.put(:errors, bad_child.errors)
-
-      # ^ We don't have to worry about clobbering the current node's errors because,
-      # if it had any errors, it wouldn't have any children and we wouldn't be
-      # here anyway.
+      |> Map.put(:errors, node.errors ++ bad_child.errors)
     else
       node
     end


### PR DESCRIPTION
If a non-null list of non-null elements contained a null element, the null value was correctly propagated to the parents but the error wasn't.
This is described in the issue https://github.com/absinthe-graphql/absinthe/issues/1071 and also in the WIP PR https://github.com/absinthe-graphql/absinthe/pull/1072

I am not sure it is the right way to fix this. According to the comment in `do_propagate_null_trimming/0`, the null element resolution should have failed earlier.
