### PR TITLE
Allow maps as arguments in macros

### DIFF
--- a/lib/absinthe/blueprint/input.ex
+++ b/lib/absinthe/blueprint/input.ex
@@ -69,6 +69,11 @@ defmodule Absinthe.Blueprint.Input do
     }
   end
 
+  # Handle maps in AST format if they are not unquoted in macros
+  def parse({:%{}, _, map_key_values}) when is_list(map_key_values) do
+    map_key_values |> Enum.into(%{}) |> parse()
+  end
+
   def parse(value) when is_map(value) do
     %Input.Object{
       fields:

--- a/lib/absinthe/blueprint/input.ex
+++ b/lib/absinthe/blueprint/input.ex
@@ -69,11 +69,6 @@ defmodule Absinthe.Blueprint.Input do
     }
   end
 
-  # Handle maps in AST format if they are not unquoted in macros
-  def parse({:%{}, _, map_key_values}) when is_list(map_key_values) do
-    map_key_values |> Enum.into(%{}) |> parse()
-  end
-
   def parse(value) when is_map(value) do
     %Input.Object{
       fields:

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -2404,7 +2404,8 @@ defmodule Absinthe.Schema.Notation do
   end
 
   defp expand_ast(ast, env) do
-    Macro.prewalk(ast, fn
+    ast
+    |> Macro.prewalk(fn
       # We don't want to expand `@bla` into `Module.get_attribute(module, @bla)` because this
       # function call will fail if the module is already compiled. Remember that the ast gets put
       # into a generated `__absinthe_blueprint__` function which is called at "__after_compile__"
@@ -2423,6 +2424,22 @@ defmodule Absinthe.Schema.Notation do
       node ->
         node
     end)
+    |> expand_ast_map()
+  end
+
+  # Handle maps in AST format if they are not escaped in macros
+  defp expand_ast_map({:%{}, _, map_key_values} = _node) when is_list(map_key_values) do
+    map_key_values
+    |> Enum.map(fn {key, val} -> {key, expand_ast_map(val)} end)
+    |> Enum.into(%{})
+  end
+
+  defp expand_ast_map(node) when is_list(node) do
+    Enum.map(node, &expand_ast_map/1)
+  end
+
+  defp expand_ast_map(node) do
+    node
   end
 
   @doc false

--- a/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/macro_extensions_test.exs
@@ -8,8 +8,13 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
   defmodule WithFeatureDirective do
     use Absinthe.Schema.Prototype
 
+    input_object :related_feature do
+      field :name, :string
+    end
+
     directive :feature do
       arg :name, :string
+      arg :related_features, list_of(:related_feature)
       on [:scalar, :schema]
 
       expand(fn _args, node ->
@@ -28,7 +33,7 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
     end
 
     extend schema do
-      directive :feature
+      directive :feature, related_features: [%{"name" => "another_feature"}]
     end
 
     object :person do
@@ -235,6 +240,12 @@ defmodule Absinthe.Schema.Notation.Experimental.MacroExtensionsTest do
            ] = Map.values(object.fields)
 
     assert [:valued_entity] = object.interfaces
+  end
+
+  test "can use map in arguments" do
+    sdl = Absinthe.Schema.to_sdl(ExtendedSchema)
+
+    assert sdl =~ "schema @feature(related_features: [{name: \"another_feature\"}])"
   end
 
   test "raises when definition types do not match" do


### PR DESCRIPTION
This is one approach to possibly solve the issue https://github.com/absinthe-graphql/absinthe/issues/1225

My main goal is to support passing a map in the arguments for a directive that is wrapped in an `extend` macro.