### PR TITLE
Type extensions objects can be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bug Fix: [Object type extensions may be empty](https://github.com/absinthe-graphql/absinthe/pull/1228)
+
 ## 1.7.1
 - Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)
 - Breaking Bugfix: [Add "Objects must define fields" schema validation](https://github.com/absinthe-graphql/absinthe/pull/1167)

--- a/lib/absinthe/phase/schema/validation/object_must_define_fields.ex
+++ b/lib/absinthe/phase/schema/validation/object_must_define_fields.ex
@@ -18,6 +18,10 @@ defmodule Absinthe.Phase.Schema.Validation.ObjectMustDefineFields do
     obj
   end
 
+  defp validate_objects(%Blueprint.Schema.TypeExtensionDefinition{} = node) do
+    {:halt, node}
+  end
+
   defp validate_objects(%struct{} = node)
        when struct in [
               Blueprint.Schema.ObjectTypeDefinition,

--- a/test/absinthe/schema/rule/object_must_define_fields_test.exs
+++ b/test/absinthe/schema/rule/object_must_define_fields_test.exs
@@ -121,4 +121,24 @@ defmodule Absinthe.Schema.Rule.ObjectMustDefineFieldsTest do
       Code.eval_string(@schema)
     end)
   end
+
+  @schema ~S(
+    defmodule ExtendObjectSchema do
+      use Absinthe.Schema
+
+      query do
+        field :foo, :string
+      end
+
+      object :bar do
+        field :baz, :string
+      end
+
+      extend object :bar do
+      end
+    end
+    )
+  test "does not error on empty object extension" do
+    assert Code.eval_string(@schema)
+  end
 end


### PR DESCRIPTION
See the spec https://spec.graphql.org/October2021/#sec-Object-Extensions

an object extending another object can be empty. This is useful for
adding directives to an object without adding any fields.

It came up in a slack conversation that this was an issue

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
