### PR TITLE
Validate input object not being an Enum

### DIFF
--- a/lib/absinthe/phase/document/arguments/parse.ex
+++ b/lib/absinthe/phase/document/arguments/parse.ex
@@ -97,7 +97,7 @@ defmodule Absinthe.Phase.Document.Arguments.Parse do
   end
 
   defp build_value(%{__struct__: struct}, %Type.InputObject{}, _)
-       when struct in [Input.Boolean, Input.Float, Input.Integer, Input.String] do
+       when struct in [Input.Boolean, Input.Float, Input.Integer, Input.String, Input.Enum] do
     {:error, :bad_parse}
   end
 

--- a/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
+++ b/test/absinthe/phase/document/validation/arguments_of_correct_type_test.exs
@@ -873,6 +873,48 @@ defmodule Absinthe.Phase.Document.Validation.ArgumentsOfCorrectTypeTest do
   end
 
   describe "Invalid input object value" do
+    test "Not an input object, an unquoted string" do
+      assert_fails_validation(
+        """
+        {
+          complicatedArgs {
+            complexArgField(complexArg: SIT)
+          }
+        }
+        """,
+        [],
+        [bad_argument("complexArg", "ComplexInput", "SIT", 3, [])]
+      )
+    end
+
+    test "Not an input object, a string" do
+      assert_fails_validation(
+        """
+        {
+          complicatedArgs {
+            complexArgField(complexArg: "SIT")
+          }
+        }
+        """,
+        [],
+        [bad_argument("complexArg", "ComplexInput", ~s("SIT"), 3, [])]
+      )
+    end
+
+    test "Not an input object, a number" do
+      assert_fails_validation(
+        """
+        {
+          complicatedArgs {
+            complexArgField(complexArg: 42)
+          }
+        }
+        """,
+        [],
+        [bad_argument("complexArg", "ComplexInput", "42", 3, [])]
+      )
+    end
+
     test "Partial object, missing required" do
       assert_fails_validation(
         """


### PR DESCRIPTION
We have found out that in a query like this, when the `complexArg` argument is an input object:

```graphql
{ someField(complexArg: SEEMS_AN_ENUM) }
```

the argument is discarded instead of being marked as an error like if it was a scalar.

This PR adds a parse check for `Input.Enum` for this case, and tests for this and other cases.