### PR TITLE
Fix endpoint and docket setup documentation for subscriptions

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -51,6 +51,12 @@ options.
 In your `MyAppWeb.Endpoint` module add:
 
 ```elixir
+use Absinthe.Phoenix.Endpoint
+```
+
+Now, you need to configure your socket. I.e. in your `MyAppWeb.UserSocket` module add:
+
+```elixir
 use Absinthe.Phoenix.Socket,
   schema: MyAppWeb.Schema
 ```


### PR DESCRIPTION
The current documentation on Subscriptions indicates we should `use Absinthe.Phoenix.Socket` module in our `Endpoint` which raises an undefined function error, instead of using `Absinthe.Phoenix.Endpoint` in our endpoint module and then using the `Absinthe.Phoenix.Socket` on our socket modules.
