### PR TITLE
Fix Absinthe.Subscription parameter in Subscriptions guides

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -36,7 +36,7 @@ line:
       {Phoenix.PubSub, name: :my_pubsub},
       # Start the endpoint when the application starts
       MyAppWeb.Endpoint,
-      {Absinthe.Subscription, pubsub: MyAppWeb.Endpoint}
+      {Absinthe.Subscription, MyAppWeb.Endpoint}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/guides/tutorial/subscriptions.md
+++ b/guides/tutorial/subscriptions.md
@@ -33,7 +33,7 @@ In `lib/blog/application.ex`:
   children = [
     # other children ...
     {BlogWeb.Endpoint, []}, # this line should already exist
-    {Absinthe.Subscription, pubsub: BlogWeb.Endpoint}, # add this line
+    {Absinthe.Subscription, BlogWeb.Endpoint}, # add this line
     # other children ...
   ]
 ```


### PR DESCRIPTION
Hello there,

There's a small inconsistency in the Subscriptions guide. It may have been valid for older `:absinthe_phoenix` versions but the latest version documentation states otherwise:
https://hexdocs.pm/absinthe_phoenix/2.0.2/readme.html

