### PR TITLE
Deduplicate directives when building schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug Fix: [Object type extensions may be empty](https://github.com/absinthe-graphql/absinthe/pull/1228)
 - Bug Fix: [Validate input object not being an Enum](https://github.com/absinthe-graphql/absinthe/pull/1231)
+- Bug Fix: [Deduplicate directives when building schema](https://github.com/absinthe-graphql/absinthe/pull/1242)
 
 ## 1.7.1
 - Breaking Bugfix: [Validate repeatable directives on schemas](https://github.com/absinthe-graphql/absinthe/pull/1179)

--- a/lib/absinthe/phase/schema/build.ex
+++ b/lib/absinthe/phase/schema/build.ex
@@ -5,12 +5,15 @@ defmodule Absinthe.Phase.Schema.Build do
     %{schema_definitions: [schema]} = blueprint
 
     types = build_types(blueprint)
-    directive_artifacts = build_directives(blueprint)
+
+    directive_artifacts =
+      (schema.directive_artifacts ++ build_directives(blueprint))
+      |> Enum.uniq_by(fn v -> v.identifier end)
 
     schema = %{
       schema
       | type_artifacts: types,
-        directive_artifacts: schema.directive_artifacts ++ directive_artifacts
+        directive_artifacts: directive_artifacts
     }
 
     blueprint = %{blueprint | schema_definitions: [schema]}

--- a/lib/absinthe/phase/schema/build.ex
+++ b/lib/absinthe/phase/schema/build.ex
@@ -5,15 +5,12 @@ defmodule Absinthe.Phase.Schema.Build do
     %{schema_definitions: [schema]} = blueprint
 
     types = build_types(blueprint)
-
-    directive_artifacts =
-      (schema.directive_artifacts ++ build_directives(blueprint))
-      |> Enum.uniq_by(fn v -> v.identifier end)
+    directive_artifacts = build_directives(blueprint)
 
     schema = %{
       schema
       | type_artifacts: types,
-        directive_artifacts: directive_artifacts
+        directive_artifacts: schema.directive_artifacts ++ directive_artifacts
     }
 
     blueprint = %{blueprint | schema_definitions: [schema]}

--- a/lib/absinthe/schema/prototype/notation.ex
+++ b/lib/absinthe/schema/prototype/notation.ex
@@ -38,6 +38,7 @@ defmodule Absinthe.Schema.Prototype.Notation do
         pipeline
         |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.Validation.QueryTypeMustBeObject)
         |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.ImportPrototypeDirectives)
+        |> Absinthe.Pipeline.without(Absinthe.Phase.Schema.DirectiveImports)
         |> Absinthe.Pipeline.replace(
           Absinthe.Phase.Schema.TypeExtensionImports,
           {Absinthe.Phase.Schema.TypeExtensionImports, []}


### PR DESCRIPTION
When importing directives from the prototype some of them were duplicated, which caused multiple functions with the same clause to be generated.
This should (partially?) fix https://github.com/absinthe-graphql/absinthe/issues/1233

Thanks @maartenvanvliet for looking into the original issue :blue_heart: 
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
