### PR TITLE
Do not unquote AST twice

### DIFF
--- a/lib/absinthe/phase/schema/compile.ex
+++ b/lib/absinthe/phase/schema/compile.ex
@@ -103,7 +103,7 @@ defmodule Absinthe.Phase.Schema.Compile do
         end
 
         def __absinthe_type__(unquote(type.name)) do
-          unquote(ast)
+          __absinthe_type__(unquote(type.identifier))
         end
       end
     end
@@ -126,7 +126,7 @@ defmodule Absinthe.Phase.Schema.Compile do
         end
 
         def __absinthe_directive__(unquote(type.name)) do
-          unquote(ast)
+          __absinthe_directive__(unquote(type.identifier))
         end
       end
     end


### PR DESCRIPTION
Instead of generating

    def __absinthe_type__(:foo_bar), do: unquote(ast)
    def __absinthe_type__("FooBar"), do: unquote(ast)

We generate:

    def __absinthe_type__(:foo_bar), do: unquote(ast)
    def __absinthe_type__("FooBar"), do: __absinthe_type__(:foo_bar)

This considerably reduces the size of the generated code.
Compilation times went from 1.8s to 1.2s in a sample schema.
