### PR TITLE
Bugfix: multiple pushes per client for subscriptions that have a `context_id`

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -173,9 +173,7 @@ defmodule Absinthe.Subscription do
     pubsub
     |> registry_name
     |> Registry.lookup(key)
-    |> Enum.uniq_by(fn {_, {doc_id, _doc}} -> doc_id end)
-    |> Enum.map(fn match ->
-      {_, {doc_id, doc}} = match
+    |> Map.new(fn {_, {doc_id, doc}} ->
       doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
 
       {doc_id, doc}

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -173,13 +173,13 @@ defmodule Absinthe.Subscription do
     pubsub
     |> registry_name
     |> Registry.lookup(key)
+    |> Enum.uniq_by(fn {_, {doc_id, _doc}} -> doc_id end)
     |> Enum.map(fn match ->
       {_, {doc_id, doc}} = match
       doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
 
       {doc_id, doc}
     end)
-    |> Map.new()
   end
 
   @doc false

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -179,6 +179,7 @@ defmodule Absinthe.Subscription do
 
       {doc_id, doc}
     end)
+    |> Map.new()
   end
 
   @doc false

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -691,8 +691,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
       end)
 
     # assert that all documents are the same
-    first = hd(documents)
-    assert Enum.all?(documents, &(&1 == first))
+    assert [document] = Enum.dedup(documents)
 
     Absinthe.Subscription.publish(
       PubSub,
@@ -700,7 +699,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
       other_user: "*"
     )
 
-    topic_id = first["subscribed"]
+    topic_id = document["subscribed"]
 
     for _i <- 1..5 do
       assert_receive(


### PR DESCRIPTION
This PR aims to close this issue: https://github.com/absinthe-graphql/absinthe/issues/1064

Originally this issue seems to be introduced by [this PR -- because of this specific change](https://github.com/absinthe-graphql/absinthe/pull/1006/files#diff-c889d345bee83f3e4e6ca1fb71519118225dddbab7b2340bc1fe50644a4719f4R144). It was introduced in the version `v1.6.0` 

On the `v1.5.5` the deduplication happened using `Map.new` when looking at the Registry. By checking the current version, using the same strategy seems to fix the problem since the documents should be identical. 