### PR TITLE
Add __private__ field to Type.Argument and Type.Enum.Value structs

### DIFF
--- a/lib/absinthe/blueprint/schema/enum_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/enum_type_definition.ex
@@ -50,6 +50,7 @@ defmodule Absinthe.Blueprint.Schema.EnumTypeDefinition do
             value: value_def.value,
             enum_identifier: type_def.identifier,
             __reference__: value_def.__reference__,
+            __private__: value_def.__private__,
             description: value_def.description,
             deprecation: value_def.deprecation
           }

--- a/lib/absinthe/blueprint/schema/object_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/object_type_definition.ex
@@ -84,7 +84,9 @@ defmodule Absinthe.Blueprint.Schema.ObjectTypeDefinition do
         description: arg_def.description,
         type: Blueprint.TypeReference.to_type(arg_def.type, schema),
         default_value: arg_def.default_value,
-        deprecation: arg_def.deprecation
+        deprecation: arg_def.deprecation,
+        __reference__: arg_def.__reference__,
+        __private__: arg_def.__private__
       }
 
       {arg_def.identifier, arg}

--- a/lib/absinthe/blueprint/schema/union_type_definition.ex
+++ b/lib/absinthe/blueprint/schema/union_type_definition.ex
@@ -80,7 +80,9 @@ defmodule Absinthe.Blueprint.Schema.UnionTypeDefinition do
         description: arg_def.description,
         type: Blueprint.TypeReference.to_type(arg_def.type, schema),
         default_value: arg_def.default_value,
-        deprecation: arg_def.deprecation
+        deprecation: arg_def.deprecation,
+        __reference__: arg_def.__reference__,
+        __private__: arg_def.__private__
       }
 
       {arg_def.identifier, arg}

--- a/lib/absinthe/type/argument.ex
+++ b/lib/absinthe/type/argument.ex
@@ -15,6 +15,8 @@ defmodule Absinthe.Type.Argument do
   * `:deprecation` - Deprecation information for an argument, usually
     set-up using `Absinthe.Schema.Notation.deprecate/1`.
   * `:description` - Description of an argument, useful for introspection.
+
+  The `__private__` and `__reference__` fields are for internal use.
   """
   @type t :: %__MODULE__{
           name: binary,
@@ -23,7 +25,8 @@ defmodule Absinthe.Type.Argument do
           deprecation: Type.Deprecation.t() | nil,
           description: binary | nil,
           definition: module,
-          __reference__: Type.Reference.t()
+          __reference__: Type.Reference.t(),
+          __private__: Keyword.t(),
         }
 
   defstruct identifier: nil,
@@ -33,5 +36,6 @@ defmodule Absinthe.Type.Argument do
             deprecation: nil,
             default_value: nil,
             definition: nil,
-            __reference__: nil
+            __reference__: nil,
+            __private__: []
 end

--- a/lib/absinthe/type/argument.ex
+++ b/lib/absinthe/type/argument.ex
@@ -26,7 +26,7 @@ defmodule Absinthe.Type.Argument do
           description: binary | nil,
           definition: module,
           __reference__: Type.Reference.t(),
-          __private__: Keyword.t(),
+          __private__: Keyword.t()
         }
 
   defstruct identifier: nil,

--- a/lib/absinthe/type/enum/value.ex
+++ b/lib/absinthe/type/enum/value.ex
@@ -21,6 +21,8 @@ defmodule Absinthe.Type.Enum.Value do
   * `:deprecation` - Deprecation information for a value, usually
     set-up using the `Absinthe.Schema.Notation.deprecate/1` convenience
     function.
+
+  The `__private__` and `__reference__` fields are for internal use.
   """
   @type t :: %{
           name: binary,
@@ -28,12 +30,14 @@ defmodule Absinthe.Type.Enum.Value do
           value: any,
           enum_identifier: atom,
           deprecation: Type.Deprecation.t() | nil,
-          __reference__: Type.Reference.t()
+          __reference__: Type.Reference.t(),
+          __private__: Keyword.t()
         }
   defstruct name: nil,
             description: nil,
             value: nil,
             deprecation: nil,
             enum_identifier: nil,
-            __reference__: nil
+            __reference__: nil,
+            __private__: []
 end


### PR DESCRIPTION
Most structs under Absinthe.Type have private fields, but `Argument` and `Enum.Value` don't.
