### PR TITLE
Register subscription doc under doc_id key rather than field_key

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -184,14 +184,13 @@ defmodule Absinthe.Subscription do
     pubsub
     |> registry_name
     |> Registry.lookup(key)
-    |> Enum.map(fn {_, doc_id} -> doc_id end)
     |> then(fn doc_ids ->
       pubsub
       |> registry_name
       |> Registry.select(
         # We compose a list of match specs that basically mean "lookup all keys
         # in the doc_ids list"
-        for k <- doc_ids, do: {{:"$1", :_, :"$2"}, [{:==, :"$1", k}], [{{:"$1", :"$2"}}]}
+        for {_, doc_id} <- doc_ids, do: {{:"$1", :_, :"$2"}, [{:==, :"$1", doc_id}], [{{:"$1", :"$2"}}]}
       )
     end)
     |> Map.new(fn {doc_id, doc} ->

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -143,16 +143,14 @@ defmodule Absinthe.Subscription do
   def subscribe(pubsub, field_key, doc_id, doc) do
     registry = pubsub |> registry_name
 
-    doc_value = {
-      doc_id,
-      %{
-        initial_phases: PipelineSerializer.pack(doc.initial_phases),
-        source: doc.source
-      }
+    doc_value = %{
+      initial_phases: PipelineSerializer.pack(doc.initial_phases),
+      source: doc.source
     }
 
     pdict_add_field(doc_id, field_key)
-    {:ok, _} = Registry.register(registry, field_key, doc_value)
+    {:ok, _} = Registry.register(registry, field_key, doc_id)
+    {:ok, _} = Registry.register(registry, doc_id, doc_value)
   end
 
   defp pdict_fields(doc_id) do
@@ -172,8 +170,10 @@ defmodule Absinthe.Subscription do
     registry = pubsub |> registry_name
 
     for field_key <- pdict_fields(doc_id) do
-      Registry.unregister_match(registry, field_key, {doc_id, :_})
+      Registry.unregister(registry, field_key)
     end
+
+    Registry.unregister(registry, doc_id)
 
     pdict_delete_fields(doc_id)
     :ok
@@ -184,7 +184,17 @@ defmodule Absinthe.Subscription do
     pubsub
     |> registry_name
     |> Registry.lookup(key)
-    |> Map.new(fn {_, {doc_id, doc}} ->
+    |> Enum.map(fn {_, doc_id} -> doc_id end)
+    |> then(fn doc_ids ->
+      pubsub
+      |> registry_name
+      |> Registry.select(
+        # We compose a list of match specs that basically mean "lookup all keys
+        # in the doc_ids list"
+        for k <- doc_ids, do: {{:"$1", :_, :"$2"}, [{:==, :"$1", k}], [{{:"$1", :"$2"}}]}
+      )
+    end)
+    |> Map.new(fn {doc_id, doc} ->
       doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
 
       {doc_id, doc}

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -190,7 +190,8 @@ defmodule Absinthe.Subscription do
       |> Registry.select(
         # We compose a list of match specs that basically mean "lookup all keys
         # in the doc_ids list"
-        for {_, doc_id} <- doc_ids, do: {{:"$1", :_, :"$2"}, [{:==, :"$1", doc_id}], [{{:"$1", :"$2"}}]}
+        for {_, doc_id} <- doc_ids,
+            do: {{:"$1", :_, :"$2"}, [{:==, :"$1", doc_id}], [{{:"$1", :"$2"}}]}
       )
     end)
     |> Map.new(fn {doc_id, doc} ->


### PR DESCRIPTION
We've been running some performance tests against Absinthe subscriptions and discovered a curious scenario: if large number of clients were disconnecting at the same time, the app would become unresponsive and remain in this state until ETS memory consumption caused by the test did not drop to normal levels. And that was taking a lot of time.

After further investigation we were able to narrow down the following scenario:
1. Have a lot of clients subscribed to the same topic. (In our case, 1000 clients x 5 subscriptions each = 5000 subscriptions to the same topic)
2. Put some noticeable data into subscription context. (In our case it was two fairly big ecto structs)
3. Make sure to set `compress_registry?` settings to `true`.
4. Finally, make all those clients disconnect at the same time.

What happens next is that Registry begins to cleanup data associated with Absinthe channel processes [using ets `match_delete` call](https://github.com/elixir-lang/elixir/blob/52158d7de34a26576a8ec5b606d30587e916036f/lib/elixir/lib/registry.ex#L1453). And since the table is compressed, it has to uncompress values to run match against them, which turned out to be a slow enough operation to occupy all cpu cores and starve other processes. Registry is smart enough to scope this operation by key, but the problem is that Absinthe stores subscription data under `field_key` which is shared between subscriptions, so the scoping doesn't help.

The solution I came up in this PR is to split data which Absinthe puts in Registry from `{field_key, {doc_id, doc}}` into 2 records: `{field_key, doc_id}` and `{doc_id, doc}`. This way total amount of data stored under shared `field_key` should be much smaller and thus quicker to traverse.
