### PR TITLE
Initial phases mfa

### DIFF
--- a/lib/absinthe/blueprint.ex
+++ b/lib/absinthe/blueprint.ex
@@ -43,7 +43,7 @@ defmodule Absinthe.Blueprint do
           source: nil | String.t() | Absinthe.Language.Source.t(),
           execution: Blueprint.Execution.t(),
           result: result_t,
-          initial_phases: [Absinthe.Phase.t()]
+          initial_phases: [Absinthe.Phase.t()] | {module(), atom, list()}
         }
 
   @type result_t :: %{

--- a/lib/absinthe/subscription/pipeline_serializer.ex
+++ b/lib/absinthe/subscription/pipeline_serializer.ex
@@ -18,7 +18,12 @@ defmodule Absinthe.Subscription.PipelineSerializer do
 
   @type packed_pipeline :: {:packed, [packed_phase_config()], options_map()}
 
-  @spec pack(Pipeline.t()) :: packed_pipeline()
+  @spec pack(Pipeline.t() | {module(), atom, list()}) :: packed_pipeline()
+  def pack({module, function, args})
+      when is_atom(module) and is_atom(function) and is_list(args) do
+    {module, function, args}
+  end
+
   def pack(pipeline) do
     {packed_pipeline, reverse_map} =
       pipeline
@@ -39,6 +44,10 @@ defmodule Absinthe.Subscription.PipelineSerializer do
       phase ->
         phase
     end)
+  end
+
+  def unpack({module, function, args}) do
+    apply(module, function, args)
   end
 
   def unpack([_ | _] = pipeline) do


### PR DESCRIPTION
Add support for an MFA in the `blueprint.initial_phases` field. Part of ongoing work with @josevalim to optimize Absinthe subscription memory usage.