### PR TITLE
Update incorrect GraphQL website URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Last Updated](https://img.shields.io/github/last-commit/absinthe-graphql/absinthe.svg)](https://github.com/absinthe-graphql/absinthe/commits/master)
 
-[GraphQL](https://github.com/graphql-elixir/graphql) implementation for Elixir.
+[GraphQL](https://graphql.org) implementation for Elixir.
 
 Goals:
 

--- a/guides/introduction/overview.md
+++ b/guides/introduction/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Absinthe is the GraphQL toolkit for Elixir, an implementation of the [GraphQL specification](https://github.com/graphql-elixir/graphql) built to suit the language's capabilities and idiomatic style.
+Absinthe is the GraphQL toolkit for Elixir, an implementation of the [GraphQL specification](https://spec.graphql.org) built to suit the language's capabilities and idiomatic style.
 
 The Absinthe project consists of several complementary packages. You can find the full listing on the [absinthe-graphql](https://github.com/absinthe-graphql) GitHub organization page.
 


### PR DESCRIPTION
Not sure why these links would go to another (unmaintained) Elixir implementation of GraphQL