### PR TITLE
Improve typechecks on nested args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- POTENTIALLY BREAKING Bug Fix: [Validate variable usage in nested input arguments](https://github.com/absinthe-graphql/absinthe/pull/1290).This could break incoming documents previously considered valid. Skip the Absinthe.Phase.Document.Arguments.VariableTypesMatch phase to avoid this check. See Absinthe.Pipeline on adjusting the document pipeline.
+
 ## 1.7.6
 
 - Bugfix: [Handle non_null(list_of(:thing)) with null list elements properly](https://github.com/absinthe-graphql/absinthe/pull/1259)

--- a/lib/absinthe/phase/document/arguments/variable_types_match.ex
+++ b/lib/absinthe/phase/document/arguments/variable_types_match.ex
@@ -60,6 +60,18 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
   end
 
   defp check_variable_type(
+         %Absinthe.Blueprint.Input.Field{
+           input_value: %Blueprint.Input.Value{
+             raw: %{content: %Blueprint.Input.Variable{} = variable}
+           }
+         } = node,
+         operation_name,
+         variable_defs
+       ) do
+    compare_variable_with_definition(variable, node, operation_name, variable_defs)
+  end
+
+  defp check_variable_type(
          %Absinthe.Blueprint.Input.Argument{
            input_value: %Blueprint.Input.Value{
              raw: %{content: %Blueprint.Input.Variable{} = variable}
@@ -68,6 +80,14 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
          operation_name,
          variable_defs
        ) do
+    compare_variable_with_definition(variable, node, operation_name, variable_defs)
+  end
+
+  defp check_variable_type(node, _, _) do
+    node
+  end
+
+  defp compare_variable_with_definition(variable, node, operation_name, variable_defs) do
     location_type = node.input_value.schema_node
     location_definition = node.schema_node
 
@@ -93,10 +113,6 @@ defmodule Absinthe.Phase.Document.Arguments.VariableTypesMatch do
       _ ->
         node
     end
-  end
-
-  defp check_variable_type(node, _, _) do
-    node
   end
 
   def types_compatible?(type, type, _, _) do

--- a/test/absinthe/execution/arguments/input_object_test.exs
+++ b/test/absinthe/execution/arguments/input_object_test.exs
@@ -32,7 +32,7 @@ defmodule Absinthe.Execution.Arguments.InputObjectTest do
   end
 
   @graphql """
-  query ($email: String) {
+  query ($email: String!) {
     contacts(contacts: [{email: $email}, {email: $email}])
   }
   """
@@ -67,7 +67,7 @@ defmodule Absinthe.Execution.Arguments.InputObjectTest do
   end
 
   @graphql """
-  query ($email: String, $defaultWithString: String) {
+  query ($email: String!, $defaultWithString: String) {
     user(contact: {email: $email, defaultWithString: $defaultWithString})
   }
   """

--- a/test/absinthe/integration/execution/input_object_test.exs
+++ b/test/absinthe/integration/execution/input_object_test.exs
@@ -43,4 +43,29 @@ defmodule Elixir.Absinthe.Integration.Execution.InputObjectTest do
                variables: %{"input" => true}
              )
   end
+
+  @query """
+  mutation ($input: String) {
+    updateThing(id: "foo", thing: {value: $input}) {
+      name
+      value
+    }
+  }
+  """
+
+  test "errors if an invalid type is passed to nested arg" do
+    assert {:ok,
+            %{
+              errors: [
+                %{
+                  locations: [%{column: 41, line: 2}],
+                  message:
+                    "Variable `$input` of type `String` found as input to argument of type `Int`."
+                }
+              ]
+            }} ==
+             Absinthe.run(@query, Absinthe.Fixtures.Things.MacroSchema,
+               variables: %{"input" => 1}
+             )
+  end
 end


### PR DESCRIPTION
This PR adds check to see if the variable type matches the argument type for nested arguments. Currently this check works only for "top level" arguments, but misses the ones used inside input objects (see the test case in PR).

Specifically, documents of the form:

```
  mutation ($value: String) {
    updateThing(id: "foo", thing: {value: $value}) {
      name
      value
    }
  }
```

where the variable `$value` is used inside of an input object literal were not checked properly prior to this PR.

This is a bugfix, but will have the effect that some previously valid documents are now marked as invalid.