### PR TITLE
Support deprecated input object fields in introspection query (fixes #1241)

### DIFF
--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -80,7 +80,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
           source.args
           |> Map.values()
           |> Enum.filter(fn %{deprecation: is_deprecated} ->
-            !is_deprecated || (is_deprecated && show_deprecated)
+            !is_deprecated || show_deprecated
           end)
           |> Enum.sort_by(& &1.identifier)
 
@@ -122,7 +122,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
                 Absinthe.Type.introspection?(field) ->
                   []
 
-                !is_deprecated || (is_deprecated && show_deprecated) ->
+                !is_deprecated || show_deprecated ->
                   [field]
 
                 true ->
@@ -185,7 +185,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
             values
             |> Map.values()
             |> Enum.filter(fn %{deprecation: is_deprecated} ->
-              !is_deprecated || (is_deprecated && show_deprecated)
+              !is_deprecated || show_deprecated
             end)
             |> Enum.sort_by(& &1.value)
 
@@ -210,7 +210,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
             fields
             |> Map.values()
             |> Enum.filter(fn %{deprecation: is_deprecated} ->
-              !is_deprecated || (is_deprecated && show_deprecated)
+              !is_deprecated || show_deprecated
             end)
             |> Enum.sort_by(& &1.identifier)
 
@@ -253,7 +253,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
           args
           |> Map.values()
           |> Enum.filter(fn %{deprecation: is_deprecated} ->
-            !is_deprecated || (is_deprecated && show_deprecated)
+            !is_deprecated || show_deprecated
           end)
           |> Enum.sort_by(& &1.identifier)
 

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -78,12 +78,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       resolve: fn %{include_deprecated: show_deprecated}, %{source: source} ->
         args =
           source.args
-          |> Enum.flat_map(fn {_, %{deprecation: is_deprecated} = value} ->
-            if !is_deprecated || (is_deprecated && show_deprecated) do
-              [value]
-            else
-              []
-            end
+          |> Map.values()
+          |> Enum.filter(fn %{deprecation: is_deprecated} ->
+            !is_deprecated || (is_deprecated && show_deprecated)
           end)
           |> Enum.sort_by(& &1.identifier)
 
@@ -186,12 +183,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
         %{include_deprecated: show_deprecated}, %{source: %Absinthe.Type.Enum{values: values}} ->
           result =
             values
-            |> Enum.flat_map(fn {_, %{deprecation: is_deprecated} = value} ->
-              if !is_deprecated || (is_deprecated && show_deprecated) do
-                [value]
-              else
-                []
-              end
+            |> Map.values()
+            |> Enum.filter(fn %{deprecation: is_deprecated} ->
+              !is_deprecated || (is_deprecated && show_deprecated)
             end)
             |> Enum.sort_by(& &1.value)
 
@@ -214,12 +208,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
         %{source: %Absinthe.Type.InputObject{fields: fields}} ->
           input_fields =
             fields
-            |> Enum.flat_map(fn {_, %{deprecation: is_deprecated} = value} ->
-              if !is_deprecated || (is_deprecated && show_deprecated) do
-                [value]
-              else
-                []
-              end
+            |> Map.values()
+            |> Enum.filter(fn %{deprecation: is_deprecated} ->
+              !is_deprecated || (is_deprecated && show_deprecated)
             end)
             |> Enum.sort_by(& &1.identifier)
 
@@ -260,12 +251,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       resolve: fn %{include_deprecated: show_deprecated}, %{source: %{args: args}} ->
         args =
           args
-          |> Enum.flat_map(fn {_, %{deprecation: is_deprecated} = value} ->
-            if !is_deprecated || (is_deprecated && show_deprecated) do
-              [value]
-            else
-              []
-            end
+          |> Map.values()
+          |> Enum.filter(fn %{deprecation: is_deprecated} ->
+            !is_deprecated || (is_deprecated && show_deprecated)
           end)
           |> Enum.sort_by(& &1.identifier)
 

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -278,6 +278,93 @@ defmodule Absinthe.IntrospectionTest do
       assert !match?({:ok, %{data: %{"__type" => %{"fields" => _}}}}, result)
     end
 
+    test "can include deprecated fields based on an arg" do
+      result =
+        """
+        {
+          __type(name: "ProfileInput") {
+            kind
+            name
+            description
+            inputFields(includeDeprecated: true) {
+              name
+              description
+              type {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+              defaultValue
+              isDeprecated
+              deprecationReason
+            }
+          }
+        }
+        """
+        |> run(Absinthe.Fixtures.ContactSchema)
+
+      assert_result(
+        {:ok,
+         %{
+           data: %{
+             "__type" => %{
+               "description" => "The basic details for a person",
+               "inputFields" => [
+                 %{
+                   "defaultValue" => nil,
+                   "description" => nil,
+                   "name" => "address",
+                   "type" => %{
+                     "kind" => "SCALAR",
+                     "name" => "String",
+                     "ofType" => nil
+                   },
+                   "deprecationReason" => "change of privacy policy",
+                   "isDeprecated" => true
+                 },
+                 %{
+                   "defaultValue" => "43",
+                   "description" => "The person's age",
+                   "name" => "age",
+                   "type" => %{"kind" => "SCALAR", "name" => "Int", "ofType" => nil},
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 },
+                 %{
+                   "defaultValue" => nil,
+                   "description" => nil,
+                   "name" => "code",
+                   "type" => %{
+                     "kind" => "NON_NULL",
+                     "name" => nil,
+                     "ofType" => %{"kind" => "SCALAR", "name" => "String"}
+                   },
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 },
+                 %{
+                   "defaultValue" => "\"Janet\"",
+                   "description" => "The person's name",
+                   "name" => "name",
+                   "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil},
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 }
+               ],
+               "kind" => "INPUT_OBJECT",
+               "name" => "ProfileInput"
+             }
+           }
+         }},
+        result
+      )
+
+      assert !match?({:ok, %{data: %{"__type" => %{"fields" => _}}}}, result)
+    end
+
     defmodule ComplexDefaultSchema do
       use Absinthe.Schema
 

--- a/test/support/fixtures/contact_schema.ex
+++ b/test/support/fixtures/contact_schema.ex
@@ -75,6 +75,7 @@ defmodule Absinthe.Fixtures.ContactSchema do
     field :code, type: non_null(:string)
     field :name, type: :string, description: "The person's name", default_value: "Janet"
     field :age, type: :integer, description: "The person's age", default_value: 43
+    field :address, type: :string, deprecate: "change of privacy policy"
   end
 
   interface :named_entity do


### PR DESCRIPTION
I was setting up Apollo iOS in a new mobile app project, hoping to have it talk to my absinthe API. Apollo introspects the schema to generate types, however the [introspection query](https://gist.github.com/jgautsch/d95309a809e9ef8afd3ed49606071558) wasn't processable by absinthe.

The issue was the `(includeDeprecated: true)` param passed to various fields including `inputFields`. 

The `includeDeprecated` arg for input fields was [merged](https://github.com/dchang-dchang/graphql/commit/9ef8c9b845f2329dfa64f88e02f854c0354c1d41) into the graphql spec back in Aug 2022.

This PR brings absinthe up to support that arg, and makes Apollo's introspection query work.

Feedback welcome!