### PR TITLE
Add `docset_runner` option to Subscriptions to use a custom docset runner

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -240,9 +240,9 @@ defmodule Absinthe.Subscription do
 
   ## Middleware callback
   @doc false
-  def call(%{state: :resolved, errors: [], value: value} = res, _) do
+  def call(%{state: :resolved, errors: [], value: value} = res, opts) do
     with {:ok, pubsub} <- extract_pubsub(res.context) do
-      __MODULE__.publish(pubsub, value, res)
+      __MODULE__.publish(pubsub, value, res, opts)
     end
 
     res

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -99,22 +99,34 @@ defmodule Absinthe.Subscription do
     other_user_subscription_field: user.id,
   ])
   ```
+
+  ## Options
+  * `:docset_runner` - A custom function used iterate over the subscription docs and
+  publishes them using the pubsub module. The default docset_runner iterates over the subscription docs and runs them sequentially.`
   """
   @spec publish(
           Absinthe.Subscription.Pubsub.t(),
           term,
-          Absinthe.Resolution.t() | [subscription_field_spec]
+          Absinthe.Resolution.t() | [subscription_field_spec],
+          Keyword.t()
         ) :: :ok
-  def publish(_pubsub, _mutation_result, []), do: :ok
+  def publish(
+        _pubsub,
+        _mutation_result,
+        _subscribed_fields,
+        opts \\ []
+      )
 
-  def publish(pubsub, mutation_result, %Absinthe.Resolution{} = info) do
+  def publish(_pubsub, _mutation_result, [], _), do: :ok
+
+  def publish(pubsub, mutation_result, %Absinthe.Resolution{} = info, opts) do
     subscribed_fields = get_subscription_fields(info)
-    publish(pubsub, mutation_result, subscribed_fields)
+    publish(pubsub, mutation_result, subscribed_fields, opts)
   end
 
-  def publish(pubsub, mutation_result, subscribed_fields) do
+  def publish(pubsub, mutation_result, subscribed_fields, opts) do
     _ = publish_remote(pubsub, mutation_result, subscribed_fields)
-    _ = Subscription.Local.publish_mutation(pubsub, mutation_result, subscribed_fields)
+    _ = Subscription.Local.publish_mutation(pubsub, mutation_result, subscribed_fields, opts)
     :ok
   end
 

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -18,16 +18,21 @@ defmodule Absinthe.Subscription.Local do
   @spec publish_mutation(
           Absinthe.Subscription.Pubsub.t(),
           term,
-          [Absinthe.Subscription.subscription_field_spec()]
+          [Absinthe.Subscription.subscription_field_spec()],
+          Keyword.t()
         ) :: :ok
-  def publish_mutation(pubsub, mutation_result, subscribed_fields) do
+  def publish_mutation(_pubsub, _mutation_result, _subscribed_fields, opts \\ [])
+
+  def publish_mutation(pubsub, mutation_result, subscribed_fields, opts) do
     docs_and_topics =
       for {field, key_strategy} <- subscribed_fields,
           {topic, doc} <- get_docs(pubsub, field, mutation_result, key_strategy) do
         {topic, key_strategy, doc}
       end
 
-    run_docset(pubsub, docs_and_topics, mutation_result)
+    docset_runner = Keyword.get(opts, :docset_runner, &run_docset/3)
+
+    docset_runner.(pubsub, docs_and_topics, mutation_result)
 
     :ok
   end


### PR DESCRIPTION
Adds an optional `opts` parameter to both `Absinthe.Subscription.publish` and `Absinthe.Subscription.Local.publish_mutation`. The `opts` can include a `docset_runner` that allows for developers to use a custom docset runner to process subscriptions. 

It also updates the `Absinthe.Subscription` middleware to pass along the opts in the second parameter to the call to publish. This should allow developers to update the middleware to include the `docset_runner` option for triggered subscriptions.