### PR TITLE
sort_maps: true added to mix absinthe.schema.sdl, to reduce churn

### DIFF
--- a/lib/mix/tasks/absinthe.schema.sdl.ex
+++ b/lib/mix/tasks/absinthe.schema.sdl.ex
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Absinthe.Schema.Sdl do
              schema.__absinthe_blueprint__(),
              pipeline
            ) do
-      {:ok, inspect(blueprint, pretty: true)}
+      {:ok, inspect(blueprint, pretty: true, custom_options: [sort_maps: true])}
     else
       _ -> {:error, "Failed to render schema"}
     end


### PR DESCRIPTION
### Summary

We save the output of `mix absinthe.schema.sdl` in our repo so our JS front end can consume/use it.  Minor changes to the Absinthe schema often result in a huge amount of churn in the outputted file; our last PR had an extra +7000 -7000 lines from this.   This PR adds an option from Inspect.Opts to make the output of the sdl file deterministic.

The :sort_maps option was added in Elixir 1.14.4+, but the :custom_options field that it is passed to has been around since 1.9, so Absinthe (which is compatible starting at 1.11) will ignore the option, but not get confused by it if your Elixir version is not high enough.

### Notable Changes
* added `sort_maps: true` to the inspect call that outputs SDL