### PR TITLE
Mc/camelize directives

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1991,6 +1991,7 @@ defmodule Absinthe.Schema.Notation do
   defp default_name(Schema.DirectiveDefinition, identifier) do
     identifier
     |> Atom.to_string()
+    |> Absinthe.Utils.camelize(lower: true)
   end
 
   defp default_name(_, identifier) do

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -257,6 +257,11 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   end
 
   defp directives(directives, type_definitions) do
+    directives =
+      Enum.map(directives, fn directive ->
+        %{directive | name: Absinthe.Utils.camelize(directive.name, lower: true)}
+      end)
+
     concat(Enum.map(directives, &render(&1, type_definitions)))
   end
 

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -208,6 +208,10 @@ defmodule Absinthe.Schema.SdlRenderTest do
       on :field
     end
 
+    directive :foo_foo do
+      on :field
+    end
+
     enum :order_status do
       value :delivered
       value :processing
@@ -244,6 +248,8 @@ defmodule Absinthe.Schema.SdlRenderTest do
                query: RootQueryType
              }
 
+             directive @fooFoo on FIELD
+             
              directive @foo(baz: String) on FIELD
 
              \"Escaped\\t\\\"descrição\\/description\\\"\"


### PR DESCRIPTION
We're using custom schema directives in an Apollo federated schema. I noticed that multi-word directives were showing up as snake_case in the schema rather than camelCase. The change to `notation.ex` took care of camelCasing directives as defined in the `sdl_render_test.exs`, but the additional change in `sdl_render.ex` seemed to be necessary to camelCase custom schema directives defined in a federated subgraph. I'm not sure how to test that here since defining them relies on Apollo's `composeDirective` directive:

```
  extend schema do
    directive(:link, url: "https://specs.apollo.dev/federation/v2.5", import: ["@composeDirective"])
    directive(:link, url: "https://some-url.com", import: ["@disallowedForSubscriptions"])
    directive(:composeDirective, name: "@disallowedForSubscriptions")
  end
```

Any feedback would be appreciated cc: @benwilson512 