### PR TITLE
Fix #1302, camelize type system directives in sdl output

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1991,7 +1991,6 @@ defmodule Absinthe.Schema.Notation do
   defp default_name(Schema.DirectiveDefinition, identifier) do
     identifier
     |> Atom.to_string()
-    |> Absinthe.Utils.camelize(lower: true)
   end
 
   defp default_name(_, identifier) do

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -208,10 +208,6 @@ defmodule Absinthe.Schema.SdlRenderTest do
       on :field
     end
 
-    directive :foo_foo do
-      on :field
-    end
-
     enum :order_status do
       value :delivered
       value :processing
@@ -248,8 +244,6 @@ defmodule Absinthe.Schema.SdlRenderTest do
                query: RootQueryType
              }
 
-             directive @fooFoo on FIELD
-             
              directive @foo(baz: String) on FIELD
 
              \"Escaped\\t\\\"descrição\\/description\\\"\"

--- a/test/absinthe/schema/type_system_directive_test.exs
+++ b/test/absinthe/schema/type_system_directive_test.exs
@@ -33,6 +33,10 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
         :input_field_definition
       ]
     end
+
+    directive :camel_case_me do
+      on [:field_definition]
+    end
   end
 
   defmodule TypeSystemDirectivesSdlSchema do
@@ -110,7 +114,7 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
         directive :feature, name: ":field_definition"
       end
 
-      field :sweet, :sweet_scalar
+      field :sweet, :sweet_scalar, directives: [:camel_case_me]
       field :which, :category
       field :pet, :dog
 
@@ -190,7 +194,7 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
 
   type RootQueryType {
     post: Post @feature(name: \":field_definition\")
-    sweet: SweetScalar
+    sweet: SweetScalar @camelCaseMe
     which: Category
     pet: Dog
     search(filter: SearchFilter @feature(name: \":argument_definition\")): SearchResult @feature(name: \":argument_definition\")


### PR DESCRIPTION
This is a follow-up to #1302. I camelized in one too many places and wasn't testing type system directives in the way I intended, e.g. defined in a prototype schema. This PR removes the extra call to `Absinthe.Utils.camelize` and corrects the test to use a prototype schema.

cc: @benwilson512 