### PR TITLE
Fix typo in changelog.md (version 1.7.4 was used twice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Bugfix: [Handle non_null(list_of(:thing)) with null list elements properly](https://github.com/absinthe-graphql/absinthe/pull/1259)
 - Bugfix: [More non null result handling improvements](https://github.com/absinthe-graphql/absinthe/pull/1275)
 
-## 1.7.4
+## 1.7.5
 
 - Feature: Support Dataloader 2.0
 


### PR DESCRIPTION
version 1.7.4 was used twice 
 - once for the real 1.7.4 version
 - once again for version 1.7.5

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
