### PR TITLE
Use versioned main page link

### DIFF
--- a/guides/schemas.md
+++ b/guides/schemas.md
@@ -30,7 +30,7 @@ end
 ```
 
 
-You may want to refer to the [Absinthe API documentation](https://hexdocs.pm/absinthe/) for more detailed information as you look this over.
+You may want to refer to the [Absinthe API documentation](introduction/overview.md) for more detailed information as you look this over.
 
 
 Some macros and functions used here that are worth mentioning, pulled in automatically from


### PR DESCRIPTION
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
Currently, the link takes to the latest version of the main page.
I was working with an older version and expected the link to navigate me to the docs of the absinthe version that I had selected.

This fix will keep take the user to the main page of selected version of docs.