### PR TITLE
Bail from subscription if resolver has an error

### DIFF
--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -58,16 +58,20 @@ defmodule Absinthe.Subscription.Local do
           ]
         ]
 
-        {:ok, %{result: data}, _} = Absinthe.Pipeline.run(doc.source, pipeline)
+        case Absinthe.Pipeline.run(doc.source, pipeline) do
+          {:ok, %Absinthe.Blueprint{result: %{errors: errors}}, _} when not is_nil(errors) ->
+            :ok
 
-        Logger.debug("""
-        Absinthe Subscription Publication
-        Field Topic: #{inspect(key_strategy)}
-        Subscription id: #{inspect(topic)}
-        Data: #{inspect(data)}
-        """)
+          {:ok, %{result: data}, _} ->
+            Logger.debug("""
+            Absinthe Subscription Publication
+            Field Topic: #{inspect(key_strategy)}
+            Subscription id: #{inspect(topic)}
+            Data: #{inspect(data)}
+            """)
 
-        :ok = pubsub.publish_subscription(topic, data)
+            :ok = pubsub.publish_subscription(topic, data)
+        end
       rescue
         e ->
           BatchResolver.pipeline_error(e, __STACKTRACE__)


### PR DESCRIPTION
Would it be possible to do something like this? Right now, null is sent down to the subscriber if the resolver produces an error. 

It might depend on the use case, but I was thinking about something where you have a table where users can only see some of the entries and you have a subscription to updates, for example and use the user_id as the context id. Now, in the resolver, you check if the user is authorized to see the updated value and if not, put an error into the resolution. With the current implementation, the user would still get a push from the subscription with the null value. But not notifying the user in this case might be the better thing to do.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
