### PR TITLE
Ensure :yecc in included in the mix project's compilers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Absinthe.Mixfile do
         extras: extras(),
         groups_for_extras: groups_for_extras()
       ],
+      compilers: [:yecc] ++ Mix.compilers(),
       deps: deps(),
       dialyzer: [
         plt_add_deps: :apps_direct,


### PR DESCRIPTION
Starting in Elixir 1.16.0 ([commit](https://github.com/elixir-lang/elixir/commit/b02808dd21130bdb4c3ade2ef78e90b5658d6f49)), `:yecc` should be listed in the mix project's `:compilers` when compiling `.yrl` files.

Fixes #1297