### PR TITLE
Add parentheses to all function calls to fix Elixir 1.17 warnings

### DIFF
--- a/lib/absinthe/blueprint/schema.ex
+++ b/lib/absinthe/blueprint/schema.ex
@@ -59,7 +59,7 @@ defmodule Absinthe.Blueprint.Schema do
 
   def functions(module) do
     if function_exported?(module, :functions, 0) do
-      module.functions
+      module.functions()
     else
       []
     end

--- a/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
+++ b/lib/absinthe/phase/document/validation/fields_on_correct_type.ex
@@ -121,7 +121,7 @@ defmodule Absinthe.Phase.Document.Validation.FieldsOnCorrectType do
         [identifier]
 
       %Type.Interface{identifier: identifier} ->
-        schema.__absinthe_interface_implementors__
+        schema.__absinthe_interface_implementors__()
         |> Map.fetch!(identifier)
 
       %Type.Union{types: types} ->

--- a/lib/absinthe/phase/schema/directive_imports.ex
+++ b/lib/absinthe/phase/schema/directive_imports.ex
@@ -33,7 +33,7 @@ defmodule Absinthe.Phase.Schema.DirectiveImports do
   defp do_imports([{module, opts} | rest], acc, schema) do
     case ensure_compiled(module) do
       {:module, module} ->
-        [other_def] = module.__absinthe_blueprint__.schema_definitions
+        [other_def] = module.__absinthe_blueprint__().schema_definitions
 
         rejections = MapSet.new(Keyword.get(opts, :except, []))
 

--- a/lib/absinthe/phase/schema/spec_compliant_int.ex
+++ b/lib/absinthe/phase/schema/spec_compliant_int.ex
@@ -21,7 +21,7 @@ defmodule Absinthe.Phase.Schema.SpecCompliantInt do
   defp handle_node(%Blueprint.Schema.ScalarTypeDefinition{identifier: :integer}) do
     case ensure_compiled(Absinthe.Type.BuiltIns.SpecCompliantInt) do
       {:module, module} ->
-        [types] = module.__absinthe_blueprint__.schema_definitions
+        [types] = module.__absinthe_blueprint__().schema_definitions
 
         Enum.find(
           types.type_definitions,

--- a/lib/absinthe/phase/schema/type_extension_imports.ex
+++ b/lib/absinthe/phase/schema/type_extension_imports.ex
@@ -35,7 +35,7 @@ defmodule Absinthe.Phase.Schema.TypeExtensionImports do
   defp do_imports([{module, opts} | rest], type_extensions_acc, schema) do
     case ensure_compiled(module) do
       {:module, module} ->
-        [other_def] = module.__absinthe_blueprint__.schema_definitions
+        [other_def] = module.__absinthe_blueprint__().schema_definitions
 
         rejections = Keyword.get(opts, :except, []) |> MapSet.new()
 

--- a/lib/absinthe/phase/schema/type_imports.ex
+++ b/lib/absinthe/phase/schema/type_imports.ex
@@ -35,7 +35,7 @@ defmodule Absinthe.Phase.Schema.TypeImports do
   defp do_imports([{module, opts} | rest], types_acc, schema) do
     case ensure_compiled(module) do
       {:module, module} ->
-        [other_def] = module.__absinthe_blueprint__.schema_definitions
+        [other_def] = module.__absinthe_blueprint__().schema_definitions
 
         rejections =
           MapSet.new([:query, :mutation, :subscription] ++ Keyword.get(opts, :except, []))

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -27,7 +27,7 @@ defmodule Absinthe.Schema do
   ```
 
   You can see what your schema's blueprint looks like by calling
-  `__absinthe_blueprint__` on any schema or type definition module.
+  `__absinthe_blueprint__()` on any schema or type definition module.
 
   ```
   defmodule MyAppWeb.Schema do
@@ -38,7 +38,7 @@ defmodule Absinthe.Schema do
     end
   end
 
-  > MyAppWeb.Schema.__absinthe_blueprint__
+  > MyAppWeb.Schema.__absinthe_blueprint__()
   #=> %Absinthe.Blueprint{...}
   ```
 
@@ -88,7 +88,7 @@ defmodule Absinthe.Schema do
     end
   end
 
-  Foo.__absinthe_blueprint__ #=> ...
+  Foo.__absinthe_blueprint__() #=> ...
   ```
   """
 
@@ -363,7 +363,7 @@ defmodule Absinthe.Schema do
 
   @spec apply_modifiers(Absinthe.Pipeline.t(), t) :: Absinthe.Pipeline.t()
   def apply_modifiers(pipeline, schema, opts \\ []) do
-    Enum.reduce(schema.__absinthe_pipeline_modifiers__, pipeline, fn
+    Enum.reduce(schema.__absinthe_pipeline_modifiers__(), pipeline, fn
       {module, function}, pipeline ->
         cond do
           function_exported?(module, function, 1) ->
@@ -400,7 +400,7 @@ defmodule Absinthe.Schema do
       |> Absinthe.Pipeline.for_schema(prototype_schema: prototype_schema)
       |> apply_modifiers(env.module)
 
-    env.module.__absinthe_blueprint__
+    env.module.__absinthe_blueprint__()
     |> Absinthe.Pipeline.run(pipeline)
     |> case do
       {:ok, _, _} ->
@@ -639,7 +639,7 @@ defmodule Absinthe.Schema do
   """
   @spec directives(t) :: [Type.Directive.t()]
   def directives(schema) do
-    schema.__absinthe_directives__
+    schema.__absinthe_directives__()
     |> Map.keys()
     |> Enum.map(&lookup_directive(schema, &1))
   end
@@ -661,13 +661,13 @@ defmodule Absinthe.Schema do
   def to_sdl(schema, opts \\ []) do
     pipeline =
       schema
-      |> Absinthe.Pipeline.for_schema(prototype_schema: schema.__absinthe_prototype_schema__)
+      |> Absinthe.Pipeline.for_schema(prototype_schema: schema.__absinthe_prototype_schema__())
       |> Absinthe.Pipeline.upto({Absinthe.Phase.Schema.Validation.Result, pass: :final})
       |> apply_modifiers(schema, opts)
 
     # we can be assertive here, since this same pipeline was already used to
     # successfully compile the schema.
-    {:ok, bp, _} = Absinthe.Pipeline.run(schema.__absinthe_blueprint__, pipeline)
+    {:ok, bp, _} = Absinthe.Pipeline.run(schema.__absinthe_blueprint__(), pipeline)
 
     inspect(bp, pretty: true)
   end
@@ -677,7 +677,7 @@ defmodule Absinthe.Schema do
   """
   @spec implementors(t, Type.identifier_t() | Type.Interface.t()) :: [Type.Object.t()]
   def implementors(schema, ident) when is_atom(ident) do
-    schema.__absinthe_interface_implementors__
+    schema.__absinthe_interface_implementors__()
     |> Map.get(ident, [])
     |> Enum.map(&lookup_type(schema, &1))
   end
@@ -691,7 +691,7 @@ defmodule Absinthe.Schema do
   """
   @spec types(t) :: [Type.t()]
   def types(schema) do
-    schema.__absinthe_types__
+    schema.__absinthe_types__()
     |> Map.keys()
     |> Enum.map(&lookup_type(schema, &1))
   end

--- a/lib/absinthe/schema/compiled.ex
+++ b/lib/absinthe/schema/compiled.ex
@@ -16,7 +16,7 @@ defmodule Absinthe.Schema.Compiled do
   end
 
   def __absinthe_types__(schema_mod) do
-    Module.concat([schema_mod, Compiled]).__absinthe_types__
+    Module.concat([schema_mod, Compiled]).__absinthe_types__()
   end
 
   def __absinthe_types__(schema_mod, group) do
@@ -24,14 +24,14 @@ defmodule Absinthe.Schema.Compiled do
   end
 
   def __absinthe_directives__(schema_mod) do
-    Module.concat([schema_mod, Compiled]).__absinthe_directives__
+    Module.concat([schema_mod, Compiled]).__absinthe_directives__()
   end
 
   def __absinthe_interface_implementors__(schema_mod) do
-    Module.concat([schema_mod, Compiled]).__absinthe_interface_implementors__
+    Module.concat([schema_mod, Compiled]).__absinthe_interface_implementors__()
   end
 
   def __absinthe_schema_declaration__(schema_mod) do
-    Module.concat([schema_mod, Compiled]).__absinthe_schema_declaration__
+    Module.concat([schema_mod, Compiled]).__absinthe_schema_declaration__()
   end
 end

--- a/lib/absinthe/schema/manager.ex
+++ b/lib/absinthe/schema/manager.ex
@@ -6,14 +6,14 @@ defmodule Absinthe.Schema.Manager do
   end
 
   def init(schema_module) do
-    prototype_schema = schema_module.__absinthe_prototype_schema__
+    prototype_schema = schema_module.__absinthe_prototype_schema__()
 
     pipeline =
       schema_module
       |> Absinthe.Pipeline.for_schema(prototype_schema: prototype_schema)
       |> Absinthe.Schema.apply_modifiers(schema_module)
 
-    schema_module.__absinthe_blueprint__
+    schema_module.__absinthe_blueprint__()
     |> Absinthe.Pipeline.run(pipeline)
     |> case do
       {:ok, _, _} ->

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -100,7 +100,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     field :kind,
       type: non_null(:__type_kind),
       resolve: fn _, %{source: %{__struct__: type}} ->
-        {:ok, type.kind}
+        {:ok, type.kind()}
       end
 
     field :name, :string

--- a/lib/absinthe/utils.ex
+++ b/lib/absinthe/utils.ex
@@ -116,7 +116,7 @@ defmodule Absinthe.Utils do
       |> List.last()
 
     types =
-      module.__absinthe_types__
+      module.__absinthe_types__()
       |> Map.keys()
       |> Enum.sort_by(& &1)
       |> Enum.map(fn identifier ->
@@ -131,7 +131,7 @@ defmodule Absinthe.Utils do
       end)
 
     directives =
-      module.__absinthe_directives__
+      module.__absinthe_directives__()
       |> Map.keys()
       |> Enum.sort_by(& &1)
       |> Enum.map(fn identifier ->

--- a/test/absinthe/phase/document/validation/known_directives_test.exs
+++ b/test/absinthe/phase/document/validation/known_directives_test.exs
@@ -137,8 +137,8 @@ defmodule Absinthe.Phase.Document.Validation.KnownDirectivesTest do
     )
   end
 
-  @tag :pending
   describe "within schema language" do
+    @tag :pending
     test "with well placed directives" do
       assert_passes_validation(
         """

--- a/test/absinthe/schema/notation/experimental/import_type_extensions_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_type_extensions_test.exs
@@ -106,7 +106,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportTypeExtensionsTest do
   end
 
   defp imports(module) do
-    %{schema_definitions: [schema]} = module.__absinthe_blueprint__
+    %{schema_definitions: [schema]} = module.__absinthe_blueprint__()
     schema.type_extension_imports
   end
 

--- a/test/absinthe/schema/notation/experimental/import_types_test.exs
+++ b/test/absinthe/schema/notation/experimental/import_types_test.exs
@@ -76,7 +76,7 @@ defmodule Absinthe.Schema.Notation.Experimental.ImportTypesTest do
   end
 
   defp imports(module) do
-    %{schema_definitions: [schema]} = module.__absinthe_blueprint__
+    %{schema_definitions: [schema]} = module.__absinthe_blueprint__()
     schema.imports
   end
 end

--- a/test/absinthe/schema/notation/import_test.exs
+++ b/test/absinthe/schema/notation/import_test.exs
@@ -270,7 +270,7 @@ defmodule Absinthe.Schema.Notation.ImportTest do
       |> Absinthe.Pipeline.upto(Phase.Schema.FieldImports)
       |> Kernel.++([Phase.Schema.Validation.Result])
 
-    case Absinthe.Pipeline.run(schema.__absinthe_blueprint__, pipeline) do
+    case Absinthe.Pipeline.run(schema.__absinthe_blueprint__(), pipeline) do
       {ok_or_error, val, _} ->
         {ok_or_error, val}
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,6 +18,6 @@ fixtures_schemas = [
 ]
 
 for schema <- fixtures_schemas,
-    schema.__absinthe_schema_provider__ == Absinthe.Schema.PersistentTerm do
+    schema.__absinthe_schema_provider__() == Absinthe.Schema.PersistentTerm do
   Absinthe.Schema.Manager.start_link(schema)
 end


### PR DESCRIPTION
I took a stab at updating all the implicit function calls that cause warnings in Elixir 1.17. I couldn't get the tests to pass 100% on Elixir main + OTP 27, but I don't think the rest of the failures have anything to do with this particularly deprecation. Hopefully this helps at least a little bit in getting ready for Elixir 1.17.
