### PR TITLE
add telemetry phase when subscription config errors

### DIFF
--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -27,17 +27,19 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
       Absinthe.Subscription.subscribe(pubsub, field_keys, subscription_id, blueprint)
 
-      {:replace, blueprint,
-       [
-         {Phase.Subscription.Result, topic: subscription_id},
-         {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
-       ]}
+      pipeline = [
+        {Phase.Subscription.Result, topic: subscription_id},
+        {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
+      ]
+
+      {:replace, blueprint, pipeline}
     else
       {:error, error} ->
         blueprint = update_in(blueprint.execution.validation_errors, &[error | &1])
 
         error_pipeline = [
-          {Phase.Document.Result, options}
+          {Phase.Document.Result, options},
+          {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
         ]
 
         {:replace, blueprint, error_pipeline}


### PR DESCRIPTION
### What

Ensuring that telemetry events are fired when subscription config returns an error

### Why

We would like to be able to hook into these events even when subscription config returns an error.

### Testing

Wrote a new test to check that this functionality works. I'd also note that there are three failing tests on `main` that are unrelated to this change.