### PR TITLE
Fix 1325

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -365,6 +365,8 @@ defmodule Absinthe.Schema do
   def apply_modifiers(pipeline, schema, opts \\ []) do
     Enum.reduce(schema.__absinthe_pipeline_modifiers__(), pipeline, fn
       {module, function}, pipeline ->
+        Code.ensure_loaded!(module)
+
         cond do
           function_exported?(module, function, 1) ->
             apply(module, function, [pipeline])
@@ -377,6 +379,8 @@ defmodule Absinthe.Schema do
         end
 
       module, pipeline ->
+        Code.ensure_loaded!(module)
+
         cond do
           function_exported?(module, :pipeline, 1) ->
             module.pipeline(pipeline)


### PR DESCRIPTION
`function_exported/3` has a gotcha where, if the module is not loaded, it will just return false. We need to make sure pipeline modifier modules are loaded.