### PR TITLE
Fix unbounded concurrency

### DIFF
--- a/lib/absinthe/subscription/proxy.ex
+++ b/lib/absinthe/subscription/proxy.ex
@@ -44,11 +44,11 @@ defmodule Absinthe.Subscription.Proxy do
     # bottleneck execution inside each proxy process
 
     unless payload.node == state.pubsub.node_name() do
-      Task.Supervisor.start_child(state.task_super, Subscription.Local, :publish_mutation, [
+      Subscription.Local.publish_mutation(
         state.pubsub,
         payload.mutation_result,
         payload.subscribed_fields
-      ])
+      )
     end
 
     {:noreply, state}


### PR DESCRIPTION
We have an app that is a heavy user of subscriptions. We noticed that one of our servers were failing health checks, causing it to restart. Eventually we found that we were running into an issue of unbounded concurrency that led us to the proxy here in absinthe. We resolved it by simply removing the task supervisor. This creates a bottleneck here that limits concurrency. It doesn't completely limit concurrency though as the user can still control the level of concurrency via the pool option.
