### PR TITLE
Avoid table scans on registry

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -192,17 +192,17 @@ defmodule Absinthe.Subscription do
     name
     |> Registry.lookup(key)
     |> MapSet.new(fn {_pid, doc_id} -> doc_id end)
-    |> Enum.reduce(%{}, fn doc_id, acc ->
+    |> Enum.reduce([], fn doc_id, acc ->
       case Registry.lookup(name, doc_id) do
         [] ->
           acc
 
         [{_pid, doc} | _rest] ->
-          Map.put_new_lazy(acc, doc_id, fn ->
-            Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
-          end)
+          doc = Map.update!(doc, :initial_phases, &PipelineSerializer.unpack/1)
+          [{doc_id, doc} | acc]
       end
     end)
+    |> Map.new()
   end
 
   @doc false


### PR DESCRIPTION
Related to #1329, we noticed that looking in the registry would take a long time, making the unbounded concurrency issue worse as processes would wait for the lookups here to finish. This removes the table scan and replaces it with a MapSet instead.