### PR TITLE
Set include_deprecated default value to true for backwards compatibility

### DIFF
--- a/guides/introspection.md
+++ b/guides/introspection.md
@@ -91,6 +91,43 @@ Getting the name of the fields for a named type:
 Note that you may have to nest several depths of `type`/`ofType`, as
 type information includes any wrapping layers of [List](https://spec.graphql.org/October2021/#sec-List) and/or [NonNull](https://spec.graphql.org/October2021/#sec-Non-Null).
 
+## Configuration
+
+The introspection system can be configured through your application config:
+
+```elixir
+config :absinthe,
+  include_deprecated: false  # Defaults to false, set to true for backward compatibility
+```
+
+This configuration affects the default behavior of the `includeDeprecated` argument in introspection queries. When set to `false` (the default), deprecated fields and values will not be included in introspection results unless explicitly requested via the `includeDeprecated` argument. When set to `true`, deprecated fields and values will be included by default, matching the behavior of previous versions of Absinthe.
+
+For example, with the default configuration (`include_deprecated: false`), this query will not include deprecated fields:
+
+```graphql
+{
+  __type(name: "User") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+To include deprecated fields, you must explicitly set the `includeDeprecated` argument:
+
+```graphql
+{
+  __type(name: "User") {
+    fields(includeDeprecated: true) {
+      name
+    }
+  }
+}
+```
+
+If you set `include_deprecated: true` in your configuration, the first query would include deprecated fields by default, matching the behavior of previous versions of Absinthe.
+
 ## Using GraphiQL
 
 The [GraphiQL project](https://github.com/graphql/graphiql) is

--- a/guides/introspection.md
+++ b/guides/introspection.md
@@ -102,6 +102,8 @@ config :absinthe,
 
 This configuration affects the default behavior of the `includeDeprecated` argument in introspection queries. When set to `false` (the default), deprecated fields and values will not be included in introspection results unless explicitly requested via the `includeDeprecated` argument. When set to `true`, deprecated fields and values will be included by default, matching the behavior of previous versions of Absinthe.
 
+Note: Setting `include_deprecated` to true will break compatibility with the GraphQL specification, which recommends not including deprecated fields by default. Only use this option if you need to maintain compatibility with existing code that expects deprecated fields to be included.
+
 For example, with the default configuration (`include_deprecated: false`), this query will not include deprecated fields:
 
 ```graphql

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -72,7 +72,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: false
+          default_value: true
         ]
       ],
       resolve: fn %{include_deprecated: show_deprecated}, %{source: source} ->
@@ -187,7 +187,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: false
+          default_value: true
         ]
       ],
       resolve: fn
@@ -230,7 +230,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: false
+          default_value: true
         ]
       ],
       resolve: fn %{include_deprecated: show_deprecated}, %{source: %{args: args}} ->

--- a/lib/absinthe/type/built_ins/introspection.ex
+++ b/lib/absinthe/type/built_ins/introspection.ex
@@ -72,7 +72,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: true
+          default_value: default_include_deprecated()
         ]
       ],
       resolve: fn %{include_deprecated: show_deprecated}, %{source: source} ->
@@ -165,7 +165,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: false
+          default_value: default_include_deprecated()
         ]
       ],
       resolve: fn
@@ -187,7 +187,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: true
+          default_value: default_include_deprecated()
         ]
       ],
       resolve: fn
@@ -230,7 +230,7 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
       args: [
         include_deprecated: [
           type: :boolean,
-          default_value: true
+          default_value: default_include_deprecated()
         ]
       ],
       resolve: fn %{include_deprecated: show_deprecated}, %{source: %{args: args}} ->
@@ -397,5 +397,9 @@ defmodule Absinthe.Type.BuiltIns.Introspection do
     Enum.filter(values, fn %{deprecation: is_deprecated} ->
       !is_deprecated || show_deprecated
     end)
+  end
+
+  defp default_include_deprecated do
+    Application.get_env(:absinthe, :include_deprecated, false)
   end
 end

--- a/test/absinthe/integration/execution/fragments/introspection_test.exs
+++ b/test/absinthe/integration/execution/fragments/introspection_test.exs
@@ -33,7 +33,13 @@ defmodule Elixir.Absinthe.Integration.Execution.Fragments.IntrospectionTest do
               }
             }} = result
 
-    correct = [%{"name" => "code"}, %{"name" => "name"}, %{"name" => "age"}]
+    correct = [
+      %{"name" => "address"},
+      %{"name" => "code"},
+      %{"name" => "name"},
+      %{"name" => "age"}
+    ]
+
     sort = & &1["name"]
     assert Enum.sort_by(input_fields, sort) == Enum.sort_by(correct, sort)
   end

--- a/test/absinthe/integration/execution/fragments/introspection_test.exs
+++ b/test/absinthe/integration/execution/fragments/introspection_test.exs
@@ -34,7 +34,6 @@ defmodule Elixir.Absinthe.Integration.Execution.Fragments.IntrospectionTest do
             }} = result
 
     correct = [%{"name" => "code"}, %{"name" => "name"}, %{"name" => "age"}]
-
     sort = & &1["name"]
     assert Enum.sort_by(input_fields, sort) == Enum.sort_by(correct, sort)
   end

--- a/test/absinthe/integration/execution/fragments/introspection_test.exs
+++ b/test/absinthe/integration/execution/fragments/introspection_test.exs
@@ -33,12 +33,7 @@ defmodule Elixir.Absinthe.Integration.Execution.Fragments.IntrospectionTest do
               }
             }} = result
 
-    correct = [
-      %{"name" => "address"},
-      %{"name" => "code"},
-      %{"name" => "name"},
-      %{"name" => "age"}
-    ]
+    correct = [%{"name" => "code"}, %{"name" => "name"}, %{"name" => "age"}]
 
     sort = & &1["name"]
     assert Enum.sort_by(input_fields, sort) == Enum.sort_by(correct, sort)

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -211,7 +211,7 @@ defmodule Absinthe.IntrospectionTest do
   end
 
   describe "introspection of an input object type" do
-    test "can use __type and ignore deprecated fields" do
+    test "can use __type and ignore deprecated fields based on an arg" do
       result =
         """
         {
@@ -219,7 +219,7 @@ defmodule Absinthe.IntrospectionTest do
             kind
             name
             description
-            inputFields {
+            inputFields(includeDeprecated: false) {
               name
               description
               type {
@@ -278,7 +278,7 @@ defmodule Absinthe.IntrospectionTest do
       assert !match?({:ok, %{data: %{"__type" => %{"fields" => _}}}}, result)
     end
 
-    test "can include deprecated fields based on an arg" do
+    test "includes deprecated fields by default" do
       result =
         """
         {
@@ -286,7 +286,7 @@ defmodule Absinthe.IntrospectionTest do
             kind
             name
             description
-            inputFields(includeDeprecated: true) {
+            inputFields {
               name
               description
               type {
@@ -325,6 +325,81 @@ defmodule Absinthe.IntrospectionTest do
                    "deprecationReason" => "change of privacy policy",
                    "isDeprecated" => true
                  },
+                 %{
+                   "defaultValue" => "43",
+                   "description" => "The person's age",
+                   "name" => "age",
+                   "type" => %{"kind" => "SCALAR", "name" => "Int", "ofType" => nil},
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 },
+                 %{
+                   "defaultValue" => nil,
+                   "description" => nil,
+                   "name" => "code",
+                   "type" => %{
+                     "kind" => "NON_NULL",
+                     "name" => nil,
+                     "ofType" => %{"kind" => "SCALAR", "name" => "String"}
+                   },
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 },
+                 %{
+                   "defaultValue" => "\"Janet\"",
+                   "description" => "The person's name",
+                   "name" => "name",
+                   "type" => %{"kind" => "SCALAR", "name" => "String", "ofType" => nil},
+                   "deprecationReason" => nil,
+                   "isDeprecated" => false
+                 }
+               ],
+               "kind" => "INPUT_OBJECT",
+               "name" => "ProfileInput"
+             }
+           }
+         }},
+        result
+      )
+
+      assert !match?({:ok, %{data: %{"__type" => %{"fields" => _}}}}, result)
+    end
+
+    test "can remove deprecated fields based on an arg" do
+      result =
+        """
+        {
+          __type(name: "ProfileInput") {
+            kind
+            name
+            description
+            inputFields(includeDeprecated: false) {
+              name
+              description
+              type {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+              defaultValue
+              isDeprecated
+              deprecationReason
+            }
+          }
+        }
+        """
+        |> run(Absinthe.Fixtures.ContactSchema)
+
+      assert_result(
+        {:ok,
+         %{
+           data: %{
+             "__type" => %{
+               "description" => "The basic details for a person",
+               "inputFields" => [
                  %{
                    "defaultValue" => "43",
                    "description" => "The person's age",

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -211,7 +211,7 @@ defmodule Absinthe.IntrospectionTest do
   end
 
   describe "introspection of an input object type" do
-    test "can use __type and ignore deprecated fields based on an arg" do
+    test "can use __type and ignore deprecated fields" do
       result =
         """
         {
@@ -219,7 +219,7 @@ defmodule Absinthe.IntrospectionTest do
             kind
             name
             description
-            inputFields(includeDeprecated: false) {
+            inputFields {
               name
               description
               type {
@@ -278,7 +278,7 @@ defmodule Absinthe.IntrospectionTest do
       assert !match?({:ok, %{data: %{"__type" => %{"fields" => _}}}}, result)
     end
 
-    test "includes deprecated fields by default" do
+    test "includes deprecated fields based on an arg" do
       result =
         """
         {
@@ -286,7 +286,7 @@ defmodule Absinthe.IntrospectionTest do
             kind
             name
             description
-            inputFields {
+            inputFields(includeDeprecated: true) {
               name
               description
               type {


### PR DESCRIPTION
## Context

Absinthe introspection has always included deprecated fields, but there were a few misleading tests.

For example, [this test](https://github.com/absinthe-graphql/absinthe/blob/main/test/absinthe/introspection_test.exs#L214-L238) was targeting the ProfileInput object, which had no deprecated fields until #1291 added one.

The test mentioned above continued working successfully because the include_deprecated argument default was set to false.

## Purpose

Since Absinthe has always included deprecated fields for args, input_fields, and field, I recommend setting the default value of include_deprecated to true for these categories to maintain backwards compatibility (changed by #1291).

## Considerations

* `enum_values` and `__type` already had include_deprecated default set to false before adding include_deprecated to other fields. I understand the inconsistency this PR introduces, with some defaults set to true and others to false. However, the trade-off seems worth it to maintain backwards compatibility. If we decide to set include_deprecated to false by default, we could highlight this breaking change more explicitly in the CHANGELOG.

Fixes #1327 

