### PR TITLE
Fix type resolution by recursing prototypes

### DIFF
--- a/lib/absinthe/phase/schema/compile.ex
+++ b/lib/absinthe/phase/schema/compile.ex
@@ -19,11 +19,29 @@ defmodule Absinthe.Phase.Schema.Compile do
         {type_def.identifier, type_def.name}
       end)
 
+    type_list =
+      case prototype_schema do
+        Absinthe.Schema.Prototype ->
+          type_list
+
+        prototype_schema ->
+          Map.merge(type_list, prototype_schema.__absinthe_types__())
+      end
+
     referenced_types =
       for type_def <- schema.type_definitions,
           type_def.__private__[:__absinthe_referenced__],
           into: %{},
           do: {type_def.identifier, type_def.name}
+
+    referenced_types =
+      case prototype_schema do
+        Absinthe.Schema.Prototype ->
+          referenced_types
+
+        prototype_schema ->
+          Map.merge(referenced_types, prototype_schema.__absinthe_types__(:referenced))
+      end
 
     directive_list =
       Map.new(schema.directive_artifacts, fn type_def ->

--- a/lib/absinthe/schema/persistent_term.ex
+++ b/lib/absinthe/schema/persistent_term.ex
@@ -81,6 +81,7 @@ if Code.ensure_loaded?(:persistent_term) do
       |> get()
       |> Map.fetch!(:__absinthe_types__)
       |> Map.fetch!(:referenced)
+      |> __maybe_merge_types_from_prototype(schema_mod, :referenced)
     end
 
     def __absinthe_types__(schema_mod, group) do
@@ -88,6 +89,17 @@ if Code.ensure_loaded?(:persistent_term) do
       |> get()
       |> Map.fetch!(:__absinthe_types__)
       |> Map.fetch!(group)
+      |> __maybe_merge_types_from_prototype(schema_mod, group)
+    end
+
+    defp __maybe_merge_types_from_prototype(types, schema_mod, group) do
+      prototype_schema_mod = schema_mod.__absinthe_prototype_schema__()
+
+      if prototype_schema_mod == Absinthe.Schema.Prototype do
+        types
+      else
+        Map.merge(types, prototype_schema_mod.__absinthe_types__(group))
+      end
     end
 
     def __absinthe_directives__(schema_mod) do

--- a/lib/absinthe/schema/persistent_term.ex
+++ b/lib/absinthe/schema/persistent_term.ex
@@ -54,7 +54,20 @@ if Code.ensure_loaded?(:persistent_term) do
       |> get()
       |> Map.fetch!(:__absinthe_type__)
       |> Map.get(name)
+      |> __maybe_absinthe_type_from_prototype(name, schema_mod)
     end
+
+    defp __maybe_absinthe_type_from_prototype(nil, name, schema_mod) do
+      prototype_schema_mod = schema_mod.__absinthe_prototype_schema__()
+
+      if prototype_schema_mod == Absinthe.Schema.Prototype do
+        nil
+      else
+        prototype_schema_mod.__absinthe_type__(name)
+      end
+    end
+
+    defp __maybe_absinthe_type_from_prototype(value, _, _), do: value
 
     def __absinthe_directive__(schema_mod, name) do
       schema_mod

--- a/test/absinthe/introspection_test.exs
+++ b/test/absinthe/introspection_test.exs
@@ -111,6 +111,11 @@ defmodule Absinthe.IntrospectionTest do
           serialize &Utils.serialize/1
         end
 
+        scalar :_underscore_normal_string, name: "_UnderscoreNormalString" do
+          parse &Utils.parse/1
+          serialize &Utils.serialize/1
+        end
+
         enum :color_channel do
           description "The selected color channel"
           value :red, as: :r, description: "Color Red"
@@ -122,6 +127,7 @@ defmodule Absinthe.IntrospectionTest do
           arg :complex, :complex
           arg :normal_string, :normal_string
           arg :color_channel, :color_channel
+          arg :_underscore_normal_string, :_underscore_normal_string
 
           on [:field]
         end
@@ -142,6 +148,9 @@ defmodule Absinthe.IntrospectionTest do
         """
         query IntrospectionQuery {
           __schema {
+            types {
+              name
+            }
             directives {
               name
               args {
@@ -166,7 +175,8 @@ defmodule Absinthe.IntrospectionTest do
                     "directives" => [
                       %{"name" => "complexDirective", "args" => complex_directive_args}
                       | _
-                    ]
+                    ],
+                    "types" => types
                   }
                 }
               }} = result
@@ -184,6 +194,8 @@ defmodule Absinthe.IntrospectionTest do
                }
              )
 
+      assert Enum.member?(types, %{"name" => "Complex"})
+
       assert Enum.member?(
                complex_directive_args,
                %{
@@ -197,6 +209,8 @@ defmodule Absinthe.IntrospectionTest do
                }
              )
 
+      assert Enum.member?(types, %{"name" => "NormalString"})
+
       assert Enum.member?(
                complex_directive_args,
                %{
@@ -209,6 +223,23 @@ defmodule Absinthe.IntrospectionTest do
                  "name" => "colorChannel"
                }
              )
+
+      assert Enum.member?(types, %{"name" => "ColorChannel"})
+
+      assert Enum.member?(
+               complex_directive_args,
+               %{
+                 "type" => %{
+                   "kind" => "SCALAR",
+                   "name" => "_UnderscoreNormalString"
+                 },
+                 "defaultValue" => nil,
+                 "description" => nil,
+                 "name" => "_underscoreNormalString"
+               }
+             )
+
+      assert Enum.member?(types, %{"name" => "_UnderscoreNormalString"})
     end
   end
 


### PR DESCRIPTION
This fixes an issue when you have types declared in a Prototype (such as input_object input types for a directive). Previously type resolution would look on the Schema, but not the Prototype for the type definitions.

You _could_ workaround this by duplicating your type definition into both the Schema and the Prototype. This makes me somewhat curious if there is a better way to fix this, in that the code that was trying to resolve the type here shouldn't be resolving it on the Schema, but rather on the Prototype 🤷. This seems to work though.

Fixes #1279

Also should fix the issue mentioned here: https://github.com/DivvyPayHQ/absinthe_federation/pull/81
