### PR TITLE
Unregsiter duplicate (listening to the same topic) subscriptions individually

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -176,7 +176,7 @@ defmodule Absinthe.Subscription do
     registry = pubsub |> registry_name
 
     for field_key <- pdict_fields(doc_id) do
-      Registry.unregister(registry, field_key)
+      Registry.unregister_match(registry, field_key, doc_id)
     end
 
     Registry.unregister(registry, doc_id)


### PR DESCRIPTION
This PR fixes #1335. Having two subscriptions listening to the same topic, unsubscribe on one subscription would remove both references from the registry disrupting messages heading for the second subscription. Thе fix is to use `unregister_match` with correspondent doc_id instead of plain `unregister` targening field_key only.
