### PR TITLE
Allow config/2 to send errors in spec compliant format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Feature: [Treat maps returned from config/2 as response](https://github.com/absinthe-graphql/absinthe/pull/1341)
 - Feature: [Add async option to Absinthe.Subscription](https://github.com/absinthe-graphql/absinthe/pull/1329)
 - Bug Fix: [Avoid table scans on registry](https://github.com/absinthe-graphql/absinthe/pull/1330)
 - Big Fix: [Unregsiter duplicate (listening to the same topic) subscriptions individually](https://github.com/absinthe-graphql/absinthe/pull/1336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Feature: [Treat maps returned from config/2 as response](https://github.com/absinthe-graphql/absinthe/pull/1341)
+- Feature: [Allow config/2 to send errors in spec compliant format](https://github.com/absinthe-graphql/absinthe/pull/1341)
 - Feature: [Add async option to Absinthe.Subscription](https://github.com/absinthe-graphql/absinthe/pull/1329)
 - Bug Fix: [Avoid table scans on registry](https://github.com/absinthe-graphql/absinthe/pull/1330)
 - Big Fix: [Unregsiter duplicate (listening to the same topic) subscriptions individually](https://github.com/absinthe-graphql/absinthe/pull/1336)

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -109,6 +109,15 @@ defmodule Absinthe.Phase.Document.Result do
   defp field_name(%{alias: name}), do: name
   defp field_name(%{name: name}), do: name
 
+  defp format_error(%Phase.Error{message: %{message: _message} = error_object} = error, _opts) do
+    if Enum.empty?(error.locations) do
+      error_object
+    else
+      locations = Enum.flat_map(error.locations, &format_location/1)
+      Map.put_new(error_object, :locations, locations)
+    end
+  end
+
   defp format_error(%Phase.Error{locations: []} = error, opts) do
     error_object = %{message: error.message}
 


### PR DESCRIPTION
Related to #1340

This PR makes it so that if `config/2` returns an error tuple where the second element is a map, then that map is treated as the error response.

Subscription config errors currently expect a tuple of `{:error, msg }`. If message is an map, when returned to the user, it looks like:

```json
"errors": [
    {"message": {"extensions": {"code": "BAD_REQUEST"}, "message": "Invalid argument"}}
]
```

This causes trouble for us as we return spec compliant errors and they get wrapped in the message.

This PR makes it so returning the following from `config/2`

```elixir
{:error, %{message: "Invalid argument", extensions: %{code: "BAD_REQUEST"}}
```

Will return 

```json
"errors": [
    {"extensions": {"code": "BAD_REQUEST"}, "message": "Invalid argument"}
]
```


