### PR TITLE
Proposal: Telemetry event instead of predefined log message on batch timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 - Feature: [Add async option to Absinthe.Subscription](https://github.com/absinthe-graphql/absinthe/pull/1329)
 - Bug Fix: [Avoid table scans on registry](https://github.com/absinthe-graphql/absinthe/pull/1330)
 - Big Fix: [Unregsiter duplicate (listening to the same topic) subscriptions individually](https://github.com/absinthe-graphql/absinthe/pull/1336)
+- POTENTIALLY BREAKING Feature: [Add telemetry event on batch timeout](https://github.com/absinthe-graphql/absinthe/pull/1347). If you want to keep the behavior from 1.7.8, define a telemetry handler and attach it. For example:
+
+```elixir
+defmodule MyApp.Telemetry do
+  require Logger
+
+  def log_absinthe([:absinthe, :middleware, :batch, :timeout], _, metadata, _) do
+    Logger.error("Failed to get batching result in #{metadata.timeout}ms for\nfn: #{inspect(metadata.fn)}")
+  end
+end
+
+# attach
+
+:telemetry.attach("absinthe-batch-timeout", [:absinthe, :middleware, :batch, :timeout], &MyApp.Telemetry.log_absinthe/4, nil)
+```
 
 ## 1.7.8
 

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -13,6 +13,7 @@ handler function to any of the following event names:
 - `[:absinthe, :resolve, :field, :stop]` when field resolution finishes
 - `[:absinthe, :middleware, :batch, :start]` when the batch processing starts
 - `[:absinthe, :middleware, :batch, :stop]` when the batch processing finishes
+- `[:absinthe, :middleware, :batch, :timeout]` whe the batch processing times out
 
 Telemetry handlers are called with `measurements` and `metadata`. For details on
 what is passed, checkout `Absinthe.Phase.Telemetry`, `Absinthe.Middleware.Telemetry`,

--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -162,16 +162,14 @@ defmodule Absinthe.Middleware.Batch do
         result
 
       _ ->
-        Logger.error(
-          "Failed to get batching result in #{timeout}ms for\nfn: #{inspect(batch_fun)}"
-        )
-
+        emit_timeout_event(batch_fun, timeout)
         Process.exit(self(), :timeout)
     end
   end
 
   @batch_start [:absinthe, :middleware, :batch, :start]
   @batch_stop [:absinthe, :middleware, :batch, :stop]
+  @batch_timeout [:absinthe, :middleware, :batch, :timeout]
   defp emit_start_event(system_time, batch_fun, batch_opts, batch_data) do
     id = :erlang.unique_integer()
 
@@ -198,6 +196,15 @@ defmodule Absinthe.Middleware.Batch do
       %{duration: duration, end_time_mono: end_time_mono},
       Map.put(metadata, :result, result)
     )
+  end
+
+  defp emit_timeout_event(batch_fun, timeout) do
+    metadata = %{
+      fn: inspect(batch_fun),
+      timeout: timeout
+    }
+
+    :telemetry.execute(@batch_timeout, %{}, metadata)
   end
 
   defp call_batch_fun({module, fun}, batch_data) do


### PR DESCRIPTION
I really love the work done about batch timeouts in #1298, with one exception I noted in a comment there. On a timeout, Absinthe produces a predefined log message on error level. This goes against my thinking that libraries generally should not produce logs on runtime (only on startup or maintenance actions, such as running mix tasks), especially when there's a better option available.

This PR suggests adding a new telemetry event `[:absinthe, :middleware, :batch, :timeout]` instead, so everyone can attach to it and do whatever they want (including logging the same message on the same level).

## More context

I was about to bump Absinthe at our company project, but the approach with the log and not telemetry caused at least three hold-backs:

1. The log message sometimes exceeds max size of the message our Datadog agent accepts, which leads to breaking it into two messages that cannot be parsed as valid JSON. As a results the logs are almost-useless for us. This is because we have some really big GraphQL queries, so output of `inspect(batch_fun)` is large.
2. We have instrumentation on every `error`-level log message, but I'm not sure we want to trigger it in case of the timeout. So `warning` level, at least for evaluation period, would work much better here.
3. We would, however, send the timeouts to Sentry with more detailed information. Telemetry event would allow it.

## Other considerations

This is technically a breaking change, in case someone already relies on these log messages. But I think the capability was not advertised in changelog or anywhere, so perhaps it's safe to change. If not, perhaps we can at least give a configuration option to choose between the log message and telemetry.