### PR TITLE
Use exit/1 instead of Process.exit/2 on batch timeout

### DIFF
--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -163,7 +163,7 @@ defmodule Absinthe.Middleware.Batch do
 
       _ ->
         emit_timeout_event(batch_fun, timeout)
-        Process.exit(self(), :timeout)
+        exit({:timeout, timeout, batch_fun})
     end
   end
 


### PR DESCRIPTION
Hi 👋 

https://github.com/absinthe-graphql/absinthe/pull/1298 replaced `Task.await` with a combination of `Task.shutdown` + `Process.exit/2` in the case of timeout. This was theoretically an equivalent, as with `Task.await`, if the timeout is exceeded the caller process exits. However, `Task.await` [uses](https://github.com/elixir-lang/elixir/blob/78f63d08313677a680868685701ae79a2459dcc1/lib/elixir/lib/task.ex#L884) `Kernel.exit/1` under the hood which AFAIK isn't equivalent to `Process.exit(self(), reason)`.

Here's a single file demo of errors: 
<details>
<summary>
Script
</summary>

```elixir
Mix.install([
  {:absinthe, "1.7.6"},
  {:absinthe_plug, "~> 1.5"},
  {:jason, "~> 1.4"},
  {:plug_cowboy, "~> 2.5"},
  {:bandit, "~> 1.1"}
])

defmodule TimeoutModule do
  def arbitrary_fn_name(_, _) do
    :timer.sleep(2000)
  end
end

defmodule Schema do
  use Absinthe.Schema

  query do
    field :timeout, :string do
      resolve(fn _, _, _ ->
        batch(
          {TimeoutModule, :arbitrary_fn_name, %{arbitrary: :data}},
          nil,
          fn batch -> {:ok, batch} end,
          timeout: 1
        )
      end)
    end
  end
end

defmodule Router do
  use Plug.Router
  plug(Plug.Logger)
  plug(:match)
  plug(:dispatch)

  plug(Plug.Parsers,
    parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
    pass: ["*/*"],
    json_decoder: Jason
  )

  forward("/api",
    to: Absinthe.Plug,
    init_opts: [schema: Schema]
  )
end

plug_cowboy = {Plug.Cowboy, plug: Router, scheme: :http, port: 4000}
bandit = {Bandit, plug: Router, scheme: :http, port: 4001}
require Logger
Logger.info("starting #{inspect(plug_cowboy)}")
{:ok, _} = Supervisor.start_link([plug_cowboy], strategy: :one_for_one)
{:ok, _} = Supervisor.start_link([bandit], strategy: :one_for_one)

# unless running from IEx, sleep idenfinitely so we can serve requests
unless IEx.started?() do
  Process.sleep(:infinity)
end

# Example request
# curl --request POST \
#   --url http://127.0.0.1:4000/api \
#   --data '{timeout}'


```

</details>

This is 1.7.6 error with cowboy (before https://github.com/absinthe-graphql/absinthe/pull/1298)

```
14:10:09.187 [error] #PID<0.3035.0> running Router (connection #PID<0.3034.0>, stream id 1) terminated
Server: 127.0.0.1:4000 (http)
Request: POST /api
** (exit) exited in: Task.await(%Task{mfa: {:erlang, :apply, 2}, owner: #PID<0.3035.0>, pid: #PID<0.3036.0>, ref: #Reference<0.0.388483.1747014105.723582980.237863>}, 1)
    ** (EXIT) time out
```

On current [main](https://github.com/absinthe-graphql/absinthe/tree/c5fc04c1b7b79724d20258709c8d8e796fb396a8) cowboy just hangs, but Bandit yields this error which demonstrates that execution continues after `Process.exit(self(), :timeout)` is called:

```
14:16:14.920 [error] ** (Plug.Conn.WrapperError) ** (ArgumentError) argument error
    (stdlib 6.1.2) :maps.from_list([true])
    (elixir 1.17.3) lib/map.ex:263: Map.new_from_enum/2
    (absinthe 1.7.8) lib/absinthe/middleware/batch.ex:130: Absinthe.Middleware.Batch.after_resolution/1
    (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (absinthe 1.7.8) lib/absinthe/phase/document/execution/resolution.ex:72: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3
    (absinthe 1.7.8) lib/absinthe/phase/document/execution/resolution.ex:24: Absinthe.Phase.Document.Execution.Resolution.resolve_current/3
    (absinthe 1.7.8) lib/absinthe/pipeline.ex:408: Absinthe.Pipeline.run_phase/3
    (absinthe_plug 1.5.8) lib/absinthe/plug.ex:536: Absinthe.Plug.run_query/4
```

Finally, with this PR the error as seen through Cowboy will be this:

```
14:19:26.918 [error] #PID<0.3966.0> running Router (connection #PID<0.3965.0>, stream id 1) terminated
Server: 127.0.0.1:4000 (http)
Request: POST /api
** (exit) {:timeout, 1, {TimeoutModule, :arbitrary_fn_name, %{arbitrary: :data}}}
```

Bandit does not handle process exit very well, but that's not new and a conversation for another ticket I think.