### PR TITLE
Make task implementation for async configurable

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -89,3 +89,11 @@ Instead, you can add the `:opentelemetry_process_propagator` package to your
 dependencies, which has a `Task.async/1` wrapper that will attach the context
 automatically. If the package is installed, the middleware will use it in place
 of the default `Task.async/1`.
+
+Alternatively, you can configure the `Task` implementation to use:
+
+```elixir
+config :absinthe, task_module: MyTaskModule
+```
+
+The provided module must support the `async/1` function.

--- a/lib/absinthe/middleware/async.ex
+++ b/lib/absinthe/middleware/async.ex
@@ -38,6 +38,8 @@ defmodule Absinthe.Middleware.Async do
   @behaviour Absinthe.Middleware
   @behaviour Absinthe.Plugin
 
+  import Absinthe.Utils, only: [async: 1]
+
   # A function has handed resolution off to this middleware. The first argument
   # is the current resolution struct. The second argument is the function to
   # execute asynchronously, and opts we'll want to use when it is time to await
@@ -109,14 +111,5 @@ defmodule Absinthe.Middleware.Async do
       _ ->
         pipeline
     end
-  end
-
-  # Optionally use `async/1` function from `opentelemetry_process_propagator` if available
-  if Code.ensure_loaded?(OpentelemetryProcessPropagator.Task) do
-    @spec async((-> any)) :: Task.t()
-    defdelegate async(fun), to: OpentelemetryProcessPropagator.Task
-  else
-    @spec async((-> any)) :: Task.t()
-    defdelegate async(fun), to: Task
   end
 end

--- a/lib/absinthe/middleware/batch.ex
+++ b/lib/absinthe/middleware/batch.ex
@@ -62,6 +62,8 @@ defmodule Absinthe.Middleware.Batch do
 
   require Logger
 
+  import Absinthe.Utils, only: [async: 1]
+
   @typedoc """
   The function to be called with the aggregate batch information.
 
@@ -225,14 +227,5 @@ defmodule Absinthe.Middleware.Batch do
       _ ->
         pipeline
     end
-  end
-
-  # Optionally use `async/1` function from `opentelemetry_process_propagator` if available
-  if Code.ensure_loaded?(OpentelemetryProcessPropagator.Task) do
-    @spec async((-> any)) :: Task.t()
-    defdelegate async(fun), to: OpentelemetryProcessPropagator.Task
-  else
-    @spec async((-> any)) :: Task.t()
-    defdelegate async(fun), to: Task
   end
 end


### PR DESCRIPTION
Projects that don't use open-telemetry or with more complex process propagation requirements can now implement it themselves by configuring the `Task` module to use.