### PR TITLE
Replace regex with pattern as string to support OTP 28

### DIFF
--- a/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
+++ b/lib/absinthe/phase/schema/validation/names_must_be_valid.ex
@@ -4,7 +4,6 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
   use Absinthe.Phase
   alias Absinthe.Blueprint
 
-  @valid_name_regex ~r/^[_A-Za-z][_0-9A-Za-z]*$/
 
   def run(bp, _) do
     bp = Blueprint.prewalk(bp, &validate_names/1)
@@ -30,7 +29,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
   end
 
   defp valid_name?(name) do
-    Regex.match?(@valid_name_regex, name)
+    Regex.match?(valid_name_regex(), name)
   end
 
   defp error(object, data) do
@@ -42,15 +41,7 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
     }
   end
 
-  @description """
-  Name does not match possible #{inspect(@valid_name_regex)} regex.
-
-  > Names in GraphQL are limited to this ASCII subset of possible characters to
-  > support interoperation with as many other systems as possible.
-
-  Reference: https://graphql.github.io/graphql-spec/June2018/#sec-Names
-
-  """
+  defp valid_name_regex(), do: ~r/^[_A-Za-z][_0-9A-Za-z]*$/
 
   def explanation(%{artifact: artifact, value: value}) do
     artifact_name = String.capitalize(artifact)
@@ -58,7 +49,12 @@ defmodule Absinthe.Phase.Schema.Validation.NamesMustBeValid do
     """
     #{artifact_name} #{inspect(value)} has invalid characters.
 
-    #{@description}
+    Name does not match possible #{inspect(valid_name_regex())} regex.
+
+    > Names in GraphQL are limited to this ASCII subset of possible characters to
+    > support interoperation with as many other systems as possible.
+
+    Reference: https://graphql.github.io/graphql-spec/June2018/#sec-Names
     """
   end
 end


### PR DESCRIPTION
OTP 28 changes the implementation of the regex module, and as a result you can no longer use regexes as module attributes.

By changing the regex to a pattern as a string it can still be used in the error message, and just needs to be compiled before usage.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
