### PR TITLE
fix: use `Code.ensure_compiled!` at compile time

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -365,7 +365,7 @@ defmodule Absinthe.Schema do
   def apply_modifiers(pipeline, schema, opts \\ []) do
     Enum.reduce(schema.__absinthe_pipeline_modifiers__(), pipeline, fn
       {module, function}, pipeline ->
-        Code.ensure_loaded!(module)
+        Code.ensure_compiled!(module)
 
         cond do
           function_exported?(module, function, 1) ->
@@ -379,7 +379,7 @@ defmodule Absinthe.Schema do
         end
 
       module, pipeline ->
-        Code.ensure_loaded!(module)
+        Code.ensure_compiled!(module)
 
         cond do
           function_exported?(module, :pipeline, 1) ->


### PR DESCRIPTION
While investigating the changes in this PR:
https://github.com/elixir-lang/elixir/pull/14451

I encountered an error about not being able to load a module at this line, implying this is called at compile time.

@josevalim pointed out that `Code.ensure_loaded!/1` will have no effect at compile time, and so this was really just relying on compile order and would be non-deterministic. `Code.ensure_compiled!/1` is a superset of `Code.ensure_loaded!/1` and will work at compile time to ensure the depended on module is compiled.

This would appear to solve #1351.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
