### PR TITLE
Rename to TokenLimitEnforcementTest to fix warning

### DIFF
--- a/test/absinthe/integration/execution/token_limit_enforcement_test.exs
+++ b/test/absinthe/integration/execution/token_limit_enforcement_test.exs
@@ -1,4 +1,4 @@
-defmodule Elixir.Absinthe.Integration.Execution.TokenLimitEnforcement do
+defmodule Elixir.Absinthe.Integration.Execution.TokenLimitEnforcementTest do
   use Absinthe.Case, async: true
 
   test "Token limit lexer enforcement is precise" do


### PR DESCRIPTION
It yielded a warning in elixir 1.19 
```
Generated absinthe app
warning: the following files do not match any of the configured `:test_load_filters` / `:test_ignore_filters`:

test/absinthe/integration/execution/token_limit_enforcement.exs

This might indicate a typo in a test file name (for example, using "foo_tests.exs" instead of "foo_test.exs").

You can adjust which files trigger this warning by configuring the `:test_ignore_filters` option in your
Mix project's configuration. To disable the warning entirely, set that option to false.
```