### PR TITLE
Fix typo on union and interface docs

### DIFF
--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -54,7 +54,7 @@ defmodule Absinthe.Type.Interface do
   * `:args` - A map of `Absinthe.Type.Argument` structs. See `Absinthe.Schema.Notation.arg/2`.
   * `:resolve_type` - A function used to determine the implementing type of a resolved object. See also `Absinthe.Type.Object`'s `:is_type_of`.
 
-  The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Execution` struct providing the full execution context.
+  The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Resolution` struct providing the full resolution context.
 
   The `__private__` and `:__reference__` keys are for internal use.
   """

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -33,7 +33,7 @@ defmodule Absinthe.Type.Union do
   * `:types` - The list of possible types.
   * `:resolve_type` - A function used to determine the concrete type of a resolved object. See also `Absinthe.Type.Object`'s `:is_type_of`. Either `resolve_type` is specified in the union type, or every object type in the union must specify `is_type_of`
 
-  The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Execution` struct providing the full execution context.
+  The `:resolve_type` function will be passed two arguments; the object whose type needs to be identified, and the `Absinthe.Resolution` struct providing the full resolution context.
 
   The `__private__` and `:__reference__` keys are for internal use.
 


### PR DESCRIPTION
While reviewing the documentation for unions/interfaces, I noticed that the type indicated for the second argument was incorrect. Just a small correction.