### PR TITLE
Fix a typo in a module name

### DIFF
--- a/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
+++ b/lib/absinthe/phase/schema/validation/no_interface_cycles.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Phase.Schema.Validation.NoInterfaceCyles do
+defmodule Absinthe.Phase.Schema.Validation.NoInterfaceCycles do
   @moduledoc false
 
   use Absinthe.Phase

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -183,7 +183,7 @@ defmodule Absinthe.Pipeline do
       Phase.Schema.Validation.InterfacesMustResolveTypes,
       Phase.Schema.Validation.ObjectInterfacesMustBeValid,
       Phase.Schema.Validation.ObjectMustImplementInterfaces,
-      Phase.Schema.Validation.NoInterfaceCyles,
+      Phase.Schema.Validation.NoInterfaceCycles,
       Phase.Schema.Validation.QueryTypeMustBeObject,
       Phase.Schema.Validation.NamesMustBeValid,
       Phase.Schema.Validation.UniqueFieldNames,

--- a/test/absinthe/schema/rule/no_interface_cycles_test.exs
+++ b/test/absinthe/schema/rule/no_interface_cycles_test.exs
@@ -15,7 +15,7 @@ defmodule Absinthe.Schema.Rule.NoInterfacecyclesTest do
           message:
             "Interface Cycle Error\n\nInterface `named' forms a cycle via: ([:named, :node, :named])",
           path: [],
-          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCyles
+          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCycles
         },
         %{
           extra: :node,
@@ -28,7 +28,7 @@ defmodule Absinthe.Schema.Rule.NoInterfacecyclesTest do
           message:
             "Interface Cycle Error\n\nInterface `node' forms a cycle via: ([:node, :named, :node])",
           path: [],
-          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCyles
+          phase: Absinthe.Phase.Schema.Validation.NoInterfaceCycles
         }
       ])
     end


### PR DESCRIPTION
Came across a typo in the module name - this PR fixes the typo (Cyles -> Cycles). This PR contains no functionality changes.