### PR TITLE
Fix documentation for setting pool_size

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -50,7 +50,7 @@ line:
 > happen often on cloud deployment platforms.
 
 ```elixir
-{Absinthe.Subscription, name: MyAppWeb.Endpoint, pool_size: 8}
+{Absinthe.Subscription, pubsub: MyAppWeb.Endpoint, pool_size: 8}
 ```
 
 See `Absinthe.Subscription.child_spec/1` for more information on the supported


### PR DESCRIPTION
Name is not a valid option and the application startup will crash. It seems that the key the code is looking for is :pubsub