### PR TITLE
fix(compilation): mark `middleware`, `resolve`, `resolve_type` macro ast as runtime

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -684,10 +684,13 @@ defmodule Absinthe.Schema.Notation do
   end
 
   defp mark_aliases_as_runtime(ast, env) do
-    Macro.prewalk ast, fn
-      {:__aliases__, _, _} = alias -> Macro.expand(alias, %{env | function: {:__absinthe_resolver__, 1}})
-      other -> other
-    end
+    Macro.prewalk(ast, fn
+      {:__aliases__, _, _} = alias ->
+        Macro.expand(alias, %{env | function: {:__absinthe_resolver__, 1}})
+
+      other ->
+        other
+    end)
   end
 
   @placement {:complexity, [under: [:field]]}

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -460,7 +460,7 @@ defmodule Absinthe.Schema.Notation do
   defmacro resolve_type(func_ast) do
     __CALLER__
     |> recordable!(:resolve_type, @placement[:resolve_type])
-    |> record_resolve_type!(func_ast)
+    |> record_resolve_type!(mark_aliases_as_runtime(func_ast, __CALLER__))
   end
 
   defp handle_field_attrs(attrs, caller) do
@@ -676,8 +676,17 @@ defmodule Absinthe.Schema.Notation do
     __CALLER__
     |> recordable!(:resolve, @placement[:resolve])
 
+    func_ast = mark_aliases_as_runtime(func_ast, __CALLER__)
+
     quote do
       middleware Absinthe.Resolution, unquote(func_ast)
+    end
+  end
+
+  defp mark_aliases_as_runtime(ast, env) do
+    Macro.prewalk ast, fn
+      {:__aliases__, _, _} = alias -> Macro.expand(alias, %{env | function: {:__absinthe_resolver__, 1}})
+      other -> other
     end
   end
 
@@ -720,7 +729,7 @@ defmodule Absinthe.Schema.Notation do
   defmacro middleware(new_middleware, opts \\ []) do
     __CALLER__
     |> recordable!(:middleware, @placement[:middleware])
-    |> record_middleware!(new_middleware, opts)
+    |> record_middleware!(mark_aliases_as_runtime(new_middleware, __CALLER__), opts)
   end
 
   @placement {:is_type_of, [under: [:object]]}


### PR DESCRIPTION
Greetings! It's me again, taking another stab at making some parts of the absinthe notation DSL mark aliases as runtime references to prevent adding compile-time dependencies to the graph when possible.

## Context

The last attempt at this was #1430, which applied this technique to the schema's shape itself. That proved untenable without major absinthe redesigns, but I'm hoping that _these macros_ at least really do only apply their code during runtime and so can be marked as the same.

## Benefit

As for the level of benefit here, it'll obviously depend on how users write their modules. But for a rough metric, the large codebase I work with saw a 3% decrease in the number of transitive dependencies as totaled by the [`mix recompile_buster`](https://github.com/MrYawe/recompile_buster) tool. 3% doesn't sound large, but keeping in mind that our graphql api is only a small portion of our files, i assure you it's pretty big!

## Other work

I'm confident many other macros in the notation world could have this change applied to them as well. I'd love feedback on what else qualifies as a runtime macro, but just wanted to get eyes to see if it's tenable before doing more work