### PR TITLE
fix: wrap long input objects and lists onto multiple lines

### DIFF
--- a/lib/absinthe/language/render.ex
+++ b/lib/absinthe/language/render.ex
@@ -108,9 +108,19 @@ defmodule Absinthe.Language.Render do
   end
 
   defp render(%Absinthe.Language.ObjectValue{fields: fields}) do
-    fields = fields |> Enum.map(&render(&1)) |> join(", ")
+    fields = fields |> Enum.map(&render(&1)) |> join(break(", "))
 
-    concat(["{ ", fields, " }"])
+    group(
+      glue(
+        nest(
+          glue("{", " ", fields),
+          2,
+          :break
+        ),
+        " ",
+        "}"
+      )
+    )
   end
 
   defp render(%Absinthe.Language.NullValue{}) do
@@ -122,9 +132,19 @@ defmodule Absinthe.Language.Render do
   end
 
   defp render(%Absinthe.Language.ListValue{values: values}) do
-    values = values |> Enum.map(&render(&1)) |> join(", ")
+    values = values |> Enum.map(&render(&1)) |> join(break(", "))
 
-    concat(["[", values, "]"])
+    group(
+      glue(
+        nest(
+          glue("[", "", values),
+          2,
+          :break
+        ),
+        "",
+        "]"
+      )
+    )
   end
 
   defp render(%Absinthe.Language.Fragment{} = fragment) do

--- a/test/absinthe/language/render_test.exs
+++ b/test/absinthe/language/render_test.exs
@@ -101,6 +101,37 @@ defmodule Absinthe.Language.RenderTest do
       """)
     end
 
+    test "for input objects that exceed the line width" do
+      assert_rendered("""
+      mutation {
+        createThing(
+          input: {
+            name: "Thing"
+            nested: { enabled: false, startingStorage: "100" }
+            ratings: [{ ratedEnergy: "5000", ratedPower: "50000" }, { ratedEnergy: "6000", ratedPower: "60000" }]
+            remoteId: "a fairly long remote identifier"
+          }
+        ) {
+          id
+        }
+      }
+      """)
+    end
+
+    test "for lists that exceed the line width" do
+      assert_rendered("""
+      query {
+        search(
+          filters: [
+            { field: "status", value: "active" }
+            { field: "category", value: "books" }
+            { field: "region", value: "europe" }
+          ]
+        )
+      }
+      """)
+    end
+
     test "for variables" do
       assert_rendered("""
       query ($id: ID, $mult: Int = 6, $list: [Int!]! = [1, 2], $customScalar: CustomScalar!) {


### PR DESCRIPTION
Fixes #1307. The GraphQL formatter renders object and list values on a single line no matter how long they get, so a mutation with a large input argument collapses into one unreadable line. This makes those two node types use the same group/nest/break document algebra the argument renderer already uses, so they stay inline when they fit and break one field or element per line when they exceed the line width. Short nested objects and lists are left inline. Added round trip tests for both cases.