### PR TITLE
fix: ex_doc configuration, image path

### DIFF
--- a/guides/tutorial/our-first-query.md
+++ b/guides/tutorial/our-first-query.md
@@ -156,7 +156,7 @@ Once it's up-and-running, take a look at [http://localhost:4000/api/graphiql](ht
 
 Make sure that the `URL` is pointing to the correct place and press the play button. If everything goes according to plan, you should see something like this:
 
-<img style="box-shadow: 0 0 6px #ccc;" src="/guides/assets/tutorial/graphiql.png" alt=""/>
+<img style="box-shadow: 0 0 6px #ccc;" src="assets/tutorial/graphiql.png" alt=""/>
 
 ## Next Step
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Absinthe.Mixfile do
         main: "overview",
         logo: "logo.png",
         extra_section: "GUIDES",
-        assets: "guides/assets",
+        assets: %{"guides/assets" => "assets"},
         formatters: ["html", "epub"],
         groups_for_modules: groups_for_modules(),
         extras: extras(),

--- a/mix.exs
+++ b/mix.exs
@@ -105,6 +105,8 @@ defmodule Absinthe.Mixfile do
       "guides/tutorial/query-arguments.md",
       "guides/tutorial/mutations.md",
       "guides/tutorial/complex-arguments.md",
+      {"guides/tutorial/dataloader.md", filename: "tutorial-dataloader"},
+      {"guides/tutorial/subscriptions.md", filename: "tutorial-subscriptions"},
       "guides/tutorial/conclusion.md",
       "guides/schemas.md",
       "guides/plug-phoenix.md",


### PR DESCRIPTION
- Fix `ArgumentError` when running `mix docs` with newer `ex_doc` versions.
- Fix image path in tutorial.
- Add the dataloader and subscriptions guides to the docs. They weren't published before. `filename` option set to prevent name collision.