### PR TITLE
fix: reject integers with no finite float representation

### DIFF
--- a/lib/absinthe/type/built_ins/scalars.ex
+++ b/lib/absinthe/type/built_ins/scalars.ex
@@ -6,6 +6,11 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   @max_int 9_007_199_254_740_991
   @min_int -9_007_199_254_740_991
 
+  # Integers larger than this have no finite IEEE 754 double representation,
+  # so converting them raises ArithmeticError instead of failing as invalid.
+  @max_float 1.7976931348623157e308
+  @min_float -1.7976931348623157e308
+
   scalar :integer, name: "Int" do
     description """
     The `Int` scalar type represents non-fractional signed whole numeric
@@ -46,7 +51,7 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
   end
 
   def serialize_float(n) when is_float(n), do: n
-  def serialize_float(n) when is_integer(n), do: n * 1.0
+  def serialize_float(n) when is_integer(n) and n >= @min_float and n <= @max_float, do: n * 1.0
 
   def serialize_float(n) do
     raise Absinthe.SerializationError, """
@@ -114,7 +119,8 @@ defmodule Absinthe.Type.BuiltIns.Scalars do
     {:ok, value}
   end
 
-  defp parse_float(value) when is_integer(value) do
+  defp parse_float(value)
+       when is_integer(value) and value >= @min_float and value <= @max_float do
     {:ok, value * 1.0}
   end
 

--- a/test/absinthe/type/built_ins/scalars_test.exs
+++ b/test/absinthe/type/built_ins/scalars_test.exs
@@ -14,6 +14,9 @@ defmodule Absinthe.Type.BuiltIns.ScalarsTest do
   @max_ieee_int 9_007_199_254_740_991
   @min_ieee_int -9_007_199_254_740_991
 
+  # The largest integer that still has a finite IEEE 754 double representation.
+  @max_finite_float_int trunc(1.7976931348623157e308)
+
   defp serialize(type, value) do
     TestSchema.__absinthe_type__(type)
     |> Type.Scalar.serialize(value)
@@ -77,6 +80,21 @@ defmodule Absinthe.Type.BuiltIns.ScalarsTest do
     test "cannot be parsed from a binary" do
       assert :error == parse(:float, "")
       assert :error == parse(:float, "0.0")
+    end
+
+    test "cannot be parsed from an integer with no finite float representation" do
+      assert :error == parse(:float, @max_finite_float_int + 1)
+      assert :error == parse(:float, -@max_finite_float_int - 1)
+    end
+
+    test "cannot serialize an integer with no finite float representation" do
+      assert_raise Absinthe.SerializationError, fn ->
+        serialize(:float, @max_finite_float_int + 1)
+      end
+
+      assert_raise Absinthe.SerializationError, fn ->
+        serialize(:float, -@max_finite_float_int - 1)
+      end
     end
   end
 


### PR DESCRIPTION
The `Float` scalar converts integer input with `value * 1.0` and no bound. An
integer above the largest finite double raises `ArithmeticError`, which is
neither a parse failure nor an `Absinthe.SerializationError`, so the rescue in
`Phase.Document.Result` does not catch it and the request crashes.

Reproduced on 1.12.0 with a 309-digit integer (308 digits is fine), both from a
document literal and from a JSON variable:

```
{ f(v: 999...999) }  ->  ** (ArithmeticError) bad argument in arithmetic expression
```

The `Int` scalar bounds both directions against `@max_int`/`@min_int` and
returns an ordinary `Argument "v" has invalid value` error for the equivalent
input. `Float` is the one sibling without the bound.

Spec §3.5.2 says an input value "not representable by finite IEEE 754" must
raise a *request* error, so an error response rather than a crash.

The fix bounds both integer clauses, which lets them fall through to the
catch-alls already below them: `:error` on parse, `SerializationError` on
serialize. No new error paths.

`mix test`: 1503 passed before, 1505 after. Both new tests fail without the
change.

Assisted by Claude (`claude-opus-5`); I reviewed and verified the change.
